### PR TITLE
[ENH]: Implement a command to print the running environment details

### DIFF
--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -211,7 +211,7 @@ def wtf(long_: bool) -> None:
     report = {
         "junifer": _get_junifer_version(),
         "python": _get_python_information(),
-        "dependencies": _get_dependency_information(),
+        "dependencies": _get_dependency_information(long_=long_),
         "system": _get_system_information(),
         "environment": _get_environment_information(),
     }

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -8,12 +8,20 @@ import pathlib
 from typing import Dict, List, Union
 
 import click
+import yaml
 
 from ..utils.logging import configure_logging, logger, warn_with_log
 from .functions import collect as api_collect
 from .functions import queue as api_queue
 from .functions import run as api_run
 from .parser import parse_yaml
+from .utils import (
+    _get_dependency_information,
+    _get_environment_information,
+    _get_junifer_version,
+    _get_python_information,
+    _get_system_information,
+)
 
 
 def _parse_elements(element: str, config: Dict) -> Union[List, None]:
@@ -190,6 +198,13 @@ def queue(
 
 
 @cli.command()
-def selftest() -> None:
-    """Selftest command for CLI."""
-    pass
+def wtf() -> None:
+    """Wtf command for CLI."""
+    report = {
+        "junifer": _get_junifer_version(),
+        "python": _get_python_information(),
+        "dependencies": _get_dependency_information(),
+        "system": _get_system_information(),
+        "environment": _get_environment_information(),
+    }
+    click.echo(yaml.dump(report, sort_keys=False))

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -198,8 +198,16 @@ def queue(
 
 
 @cli.command()
-def wtf() -> None:
-    """Wtf command for CLI."""
+@click.option("--long", "long_", is_flag=True)
+def wtf(long_: bool) -> None:
+    """Wtf command for CLI.
+
+    Parameters
+    ----------
+    long_ : bool
+        Whether to report long version or not.
+
+    """
     report = {
         "junifer": _get_junifer_version(),
         "python": _get_python_information(),

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -213,6 +213,6 @@ def wtf(long_: bool) -> None:
         "python": _get_python_information(),
         "dependencies": _get_dependency_information(long_=long_),
         "system": _get_system_information(),
-        "environment": _get_environment_information(),
+        "environment": _get_environment_information(long_=long_),
     }
     click.echo(yaml.dump(report, sort_keys=False))

--- a/junifer/api/tests/test_api_utils.py
+++ b/junifer/api/tests/test_api_utils.py
@@ -1,0 +1,89 @@
+"""Provide tests for utils."""
+
+# Authors: Synchon Mandal <s.mandal@fz-juelich.de>
+# License: AGPL
+
+import platform as pl
+
+from junifer._version import __version__
+from junifer.api.utils import (
+    _get_dependency_information,
+    _get_environment_information,
+    _get_junifer_version,
+    _get_python_information,
+    _get_system_information,
+)
+
+
+def test_get_junifer_version() -> None:
+    """Test _get_junifer_version()."""
+    assert _get_junifer_version()["version"] == __version__
+
+
+def test_get_python_information() -> None:
+    """Test _get_python_information()."""
+    python_information = _get_python_information()
+    assert python_information["version"] == pl.python_version()
+    assert python_information["implementation"] == pl.python_implementation()
+
+
+def test_get_dependency_information_short() -> None:
+    """Test short version of _get_dependency_information()."""
+    dependency_information = _get_dependency_information(long_=False)
+    assert [key for key in dependency_information.keys()] == [
+        "click",
+        "numpy",
+        "datalad",
+        "pandas",
+        "nibabel",
+        "nilearn",
+        "sqlalchemy",
+        "yaml",
+    ]
+
+
+def test_get_dependency_information_long() -> None:
+    """Test long version of _get_dependency_information()."""
+    dependency_information = _get_dependency_information(long_=True)
+    dependency_information_keys = [
+        key for key in dependency_information.keys()
+    ]
+    for key in [
+        "click",
+        "numpy",
+        "datalad",
+        "pandas",
+        "nibabel",
+        "nilearn",
+        "sqlalchemy",
+        "yaml",
+    ]:
+        assert key in dependency_information_keys
+
+
+def test_get_system_information() -> None:
+    """Test _get_system_information()."""
+    system_information = _get_system_information()
+    assert system_information["platform"] == pl.platform()
+
+
+def test_get_environment_information_short() -> None:
+    """Test short version of _get_environment_information()."""
+    environment_information = _get_environment_information(long_=False)
+    assert [key for key in environment_information.keys()] == [
+        "LC_CTYPE",
+        "PATH",
+    ]
+
+
+def test_get_environment_information_long() -> None:
+    """Test long version of _get_environment_information()."""
+    environment_information = _get_environment_information(long_=True)
+    environment_information_keys = [
+        key for key in environment_information.keys()
+    ]
+    for key in [
+        "LC_CTYPE",
+        "PATH",
+    ]:
+        assert key in environment_information_keys

--- a/junifer/api/tests/test_api_utils.py
+++ b/junifer/api/tests/test_api_utils.py
@@ -5,6 +5,8 @@
 
 import platform as pl
 
+import pytest
+
 from junifer._version import __version__
 from junifer.api.utils import (
     _get_dependency_information,
@@ -67,23 +69,21 @@ def test_get_system_information() -> None:
     assert system_information["platform"] == pl.platform()
 
 
-def test_get_environment_information_short() -> None:
-    """Test short version of _get_environment_information()."""
-    environment_information = _get_environment_information(long_=False)
-    assert [key for key in environment_information.keys()] == [
-        "LC_CTYPE",
-        "PATH",
-    ]
+@pytest.mark.parametrize(
+    "format_",
+    [
+        "short",
+        "long",
+    ],
+)
+def test_get_environment_information(format_: str) -> None:
+    """Test _get_environment_information().
 
+    Parameters
+    ----------
+    format_ : str
+        The parametrized report version.
 
-def test_get_environment_information_long() -> None:
-    """Test long version of _get_environment_information()."""
-    environment_information = _get_environment_information(long_=True)
-    environment_information_keys = [
-        key for key in environment_information.keys()
-    ]
-    for key in [
-        "LC_CTYPE",
-        "PATH",
-    ]:
-        assert key in environment_information_keys
+    """
+    environment_information = _get_environment_information(long_=format_)
+    assert "PATH" in environment_information.keys()

--- a/junifer/api/tests/test_cli.py
+++ b/junifer/api/tests/test_cli.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from junifer.api.cli import collect, run
+from junifer.api.cli import collect, run, wtf
 
 
 # Create click test runner
@@ -68,3 +68,19 @@ def test_run_and_collect_commands(
     collect_result = runner.invoke(collect, collect_args)
     # Check
     assert collect_result.exit_code == 0
+
+
+def test_wtf_short() -> None:
+    """Test short version of wtf command."""
+    # Invoke wtf command
+    wtf_result = runner.invoke(wtf)
+    # Check
+    assert wtf_result.exit_code == 0
+
+
+def test_wtf_long() -> None:
+    """Test long version of wtf command."""
+    # Invoke wtf command
+    wtf_result = runner.invoke(wtf, "--long")
+    # Check
+    assert wtf_result.exit_code == 0

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -74,7 +74,7 @@ def _get_dependency_information(long_: bool) -> Dict[str, str]:
             "nibabel",
             "nilearn",
             "sqlalchemy",
-            "pyyaml",
+            "yaml",
         ]:
             if key in dependency_versions.keys():
                 pruned_dependency_versions[key] = dependency_versions[key]

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -96,8 +96,13 @@ def _get_system_information() -> Dict[str, str]:
     }
 
 
-def _get_environment_information() -> Dict[str, str]:
+def _get_environment_information(long_: bool) -> Dict[str, str]:
     """Get system environment information.
+
+    Parameters
+    ----------
+    long_ : bool
+        Whether to report long version.
 
     Returns
     -------
@@ -106,7 +111,14 @@ def _get_environment_information() -> Dict[str, str]:
 
     """
     environment_values = {}
-    for key, value in os.environ.items():
-        environment_values[key] = value
+    # Report long version
+    if long_:
+        for key, value in os.environ.items():
+            environment_values[key] = value
+    # Report short version
+    else:
+        for key in ["LC_CTYPE", "LC_TERMINAL", "LC_TERMINAL_VERSION", "PATH"]:
+            if key in os.environ.keys():
+                environment_values[key] = os.environ[key]
 
     return environment_values

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -5,6 +5,8 @@
 
 import os
 import platform as pl
+import re
+from importlib.metadata import distribution
 from typing import Dict
 
 from .._version import __version__
@@ -66,18 +68,24 @@ def _get_dependency_information(long_: bool) -> Dict[str, str]:
 
     # Report short version
     else:
-        for key in [
-            "click",
-            "numpy",
-            "datalad",
-            "pandas",
-            "nibabel",
-            "nilearn",
-            "sqlalchemy",
-            "yaml",
-        ]:
+        # Get dependencies for junifer
+        dist = distribution("junifer")
+        # Compile regex pattern
+        re_pattern = re.compile("[a-z-]+")
+
+        for pkg_with_version in dist.requires:
+            # Perform regex search
+            matches = re.findall(pattern=re_pattern, string=pkg_with_version)
+            # Fix issue with PyYAML name registration
+            if matches[0] == "pyyaml":
+                key = "yaml"
+            else:
+                key = matches[0]
+
             if key in dependency_versions.keys():
-                pruned_dependency_versions[key] = dependency_versions[key]
+                # Check if pkg part of optional dependencies
+                if "extra" not in matches:
+                    pruned_dependency_versions[key] = dependency_versions[key]
 
     return pruned_dependency_versions
 

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -1,0 +1,90 @@
+"""Provide utility functions for the api sub-package."""
+
+# Authors: Synchon Mandal <s.mandal@fz-juelich.de>
+# License: AGPL
+
+import os
+import platform as pl
+from typing import Dict
+
+from .._version import __version__
+from ..utils.logging import get_versions
+
+
+def _get_junifer_version() -> Dict[str, str]:
+    """Get junifer version information.
+
+    Returns
+    -------
+    dict
+        A dictionary containing junifer version.
+
+    """
+    return {
+        "version": __version__,
+    }
+
+
+def _get_python_information() -> Dict[str, str]:
+    """Get installed Python information.
+
+    Parameters
+    ----------
+    dict
+        A dictionary containing Python information.
+
+    """
+    return {
+        "version": pl.python_version(),
+        "implementation": pl.python_implementation(),
+    }
+
+
+def _get_dependency_information() -> Dict[str, str]:
+    """Get Python environment dependency information.
+
+    Returns
+    -------
+    dict
+        A dictionary containing Python dependency information.
+
+    """
+    dependency_versions = get_versions()
+
+    pruned_dependency_versions = {}
+    for key in ["numpy", "scipy", "pandas", "nilearn", "nibabel", "nitime"]:
+        if key in dependency_versions.keys():
+            pruned_dependency_versions[key] = dependency_versions[key]
+
+    return pruned_dependency_versions
+
+
+def _get_system_information() -> Dict[str, str]:
+    """Get system information.
+
+    Returns
+    -------
+    dict
+        A dictionary containing system information.
+
+    """
+    return {
+        "platform": pl.platform(),
+    }
+
+
+def _get_environment_information() -> Dict[str, str]:
+    """Get system environment information.
+
+    Returns
+    -------
+    dict
+        A dictionary containing system environment information.
+
+    """
+    environment_values = {}
+    for key in ["LC_CTYPE", "LC_TERMINAL", "LC_TERMINAL_VERSION", "PATH"]:
+        if key in os.environ.keys():
+            environment_values[key] = os.environ[key]
+
+    return environment_values

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -52,9 +52,10 @@ def _get_dependency_information() -> Dict[str, str]:
     dependency_versions = get_versions()
 
     pruned_dependency_versions = {}
-    for key in ["numpy", "scipy", "pandas", "nilearn", "nibabel", "nitime"]:
-        if key in dependency_versions.keys():
-            pruned_dependency_versions[key] = dependency_versions[key]
+    for key, value in dependency_versions.items():
+        # Ignore built-in modules and self
+        if value != "None" and key != "junifer":
+            pruned_dependency_versions[key] = value
 
     return pruned_dependency_versions
 

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -40,8 +40,13 @@ def _get_python_information() -> Dict[str, str]:
     }
 
 
-def _get_dependency_information() -> Dict[str, str]:
+def _get_dependency_information(long_: bool) -> Dict[str, str]:
     """Get Python environment dependency information.
+
+    Parameters
+    ----------
+    long_ : bool
+        Whether to report long version.
 
     Returns
     -------
@@ -52,10 +57,27 @@ def _get_dependency_information() -> Dict[str, str]:
     dependency_versions = get_versions()
 
     pruned_dependency_versions = {}
-    for key, value in dependency_versions.items():
-        # Ignore built-in modules and self
-        if value != "None" and key != "junifer":
-            pruned_dependency_versions[key] = value
+    # Report long version
+    if long_:
+        for key, value in dependency_versions.items():
+            # Ignore built-in modules and self
+            if value != "None" and key != "junifer":
+                pruned_dependency_versions[key] = value
+
+    # Report short version
+    else:
+        for key in [
+            "click",
+            "numpy",
+            "datalad",
+            "pandas",
+            "nibabel",
+            "nilearn",
+            "sqlalchemy",
+            "pyyaml",
+        ]:
+            if key in dependency_versions.keys():
+                pruned_dependency_versions[key] = dependency_versions[key]
 
     return pruned_dependency_versions
 

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -84,8 +84,7 @@ def _get_environment_information() -> Dict[str, str]:
 
     """
     environment_values = {}
-    for key in ["LC_CTYPE", "LC_TERMINAL", "LC_TERMINAL_VERSION", "PATH"]:
-        if key in os.environ.keys():
-            environment_values[key] = os.environ[key]
+    for key, value in os.environ.items():
+        environment_values[key] = value
 
     return environment_values


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

I've seen this in datalad and it's a very cool feature. When you run `datalad wtf`, you get a verbose print of all the characteristics of the runtime environment. Thus, whenever you submit an issue, you can copy/paste the output to help the developers understand what's going on.

### How do you imagine this integrated in junifer?

As a new command in `junifer.api.cli` so we can run `junifer wtf`

### Do you have a sample code that implements this outside of junifer?

```shell
No
```


### Anything else to say?

We can check datalad, but beware of the license. Maybe we can also get an approval to copy/paste and release under AGPLv3.