### PR TITLE
[ENH] Implement `junifer selftest` to allow the users to test the library themselves

### DIFF
--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -5,6 +5,9 @@
 # License: AGPL
 
 import pathlib
+import subprocess
+import sys
+from pathlib import Path
 from typing import Dict, List, Union
 
 import click
@@ -216,3 +219,16 @@ def wtf(long_: bool) -> None:
         "environment": _get_environment_information(long_=long_),
     }
     click.echo(yaml.dump(report, sort_keys=False))
+
+
+@cli.command()
+def selftest() -> None:
+    """Selftest command for CLI."""
+    subprocess.run(
+        ["pytest", "-vvv"],
+        stdin=subprocess.DEVNULL,
+        stdout=sys.stdout,
+        stderr=subprocess.STDOUT,
+        cwd=Path(__file__).parent.parent.parent.absolute(),
+        check=True,
+    )

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -222,13 +222,64 @@ def wtf(long_: bool) -> None:
 
 
 @cli.command()
-def selftest() -> None:
-    """Selftest command for CLI."""
-    subprocess.run(
-        ["pytest", "-vvv"],
-        stdin=subprocess.DEVNULL,
-        stdout=sys.stdout,
-        stderr=subprocess.STDOUT,
-        cwd=Path(__file__).parent.parent.parent.absolute(),
-        check=True,
-    )
+@click.argument("subpkg", type=str)
+def selftest(subpkg: str) -> None:
+    """Selftest command for CLI.
+
+    Parameters
+    ----------
+    subpkg : {"all", "api", "configs", "data", "datagrabber", "datareader",
+        "markers", "pipeline", "preprocess", "storage", "testing", "utils",
+        "stats"}
+        The sub-package to run tests for.
+
+    Raises
+    ------
+    click.BadArgumentUsage
+        If `subpkg` is invalid.
+
+    """
+    sub_packages = [
+        "all",
+        "api",
+        "configs",
+        "data",
+        "datagrabber",
+        "datareader",
+        "markers",
+        "pipeline",
+        "preprocess",
+        "storage",
+        "testing",
+        "tests",
+        "utils",
+    ]
+    if subpkg not in sub_packages:
+        raise click.BadArgumentUsage(
+            f"Invalid value for argument `subpkg`: {subpkg}. "
+            f"Should be one of {sub_packages}"
+        )
+
+    if subpkg == "all":
+        completed_process = subprocess.run(
+            ["pytest", "-vvv"],
+            stdin=subprocess.DEVNULL,
+            stdout=sys.stdout,
+            stderr=subprocess.STDOUT,
+            cwd=Path(__file__).parent.parent.parent.absolute(),
+            check=False,
+        )
+    else:
+        completed_process = subprocess.run(
+            ["pytest", f"junifer/{subpkg}", "-vvv"],
+            stdin=subprocess.DEVNULL,
+            stdout=sys.stdout,
+            stderr=subprocess.STDOUT,
+            cwd=Path(__file__).parent.parent.parent.absolute(),
+            check=False,
+        )
+
+    if completed_process.returncode == 0:
+        click.secho("Successful.", fg="green")
+    else:
+        click.secho("Failure.", fg="red")

--- a/junifer/api/tests/test_cli.py
+++ b/junifer/api/tests/test_cli.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from junifer.api.cli import collect, run, wtf
+from junifer.api.cli import collect, run, selftest, wtf
 
 
 # Create click test runner
@@ -84,3 +84,19 @@ def test_wtf_long() -> None:
     wtf_result = runner.invoke(wtf, "--long")
     # Check
     assert wtf_result.exit_code == 0
+
+
+def test_selftest_invalid_arg() -> None:
+    """Test selftest failure for invalid argument value."""
+    # Invoke selftest command
+    selftest_result = runner.invoke(selftest, "abyss")
+    # Check
+    assert selftest_result.exit_code == 2
+
+
+def test_selftest() -> None:
+    """Test selftest."""
+    # Invoke selftest command
+    selftest_result = runner.invoke(selftest, "tests")
+    # Check; will result in 1 due to I/O descriptor manipulation
+    assert selftest_result.exit_code == 1


### PR DESCRIPTION
It might be the case that some users have specific working environments that are not comprised within the tests from junifer (i.e. specific versions of the dependencies). For solving issues in a more efficient way, it might be good if we can have a `junifer selftest` command that run the test suite within the environment (so no `tox`, just `pytest`).