### PR TITLE
[ENH] Refactor markers

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -67,6 +67,8 @@ Enhancements
 
 - Add ``junifer selftest`` to report environment details (:gh:`9` by `Synchon Mandal`_).
 
+- Refactor markers ``on`` attribute and ``get_valid_inputs`` to verify that the marker can be computed on the input data types (by `Fede Raimondo`_)
+
 Bugs
 ~~~~
 

--- a/examples/run_compute_parcel_mean.py
+++ b/examples/run_compute_parcel_mean.py
@@ -12,7 +12,7 @@ License: BSD 3 clause
 
 import nilearn
 
-from junifer.markers.parcel import ParcelAggregation
+from junifer.markers.parcel_aggregation import ParcelAggregation
 from junifer.utils import configure_logging
 
 

--- a/junifer/markers/__init__.py
+++ b/junifer/markers/__init__.py
@@ -9,5 +9,5 @@ from .collection import MarkerCollection
 from .ets_rss import RSSETSMarker
 from .functional_connectivity_atlas import FunctionalConnectivityAtlas
 from .functional_connectivity_spheres import FunctionalConnectivitySpheres
-from .parcel import ParcelAggregation
+from .parcel_aggregation import ParcelAggregation
 from .sphere_aggregation import SphereAggregation

--- a/junifer/markers/ets_rss.py
+++ b/junifer/markers/ets_rss.py
@@ -13,7 +13,7 @@ import numpy as np
 from ..api.decorators import register_marker
 from ..utils import logger
 from .base import BaseMarker
-from .parcel import ParcelAggregation
+from .parcel_aggregation import ParcelAggregation
 from .utils import _ets
 
 
@@ -43,12 +43,23 @@ class RSSETSMarker(BaseMarker):
         self,
         atlas: str,
         aggregation_method: str = "mean",
-        name: str = None,
+        name: Optional[str] = None,
     ) -> None:
         """Initialize the class."""
         self.atlas = atlas
         self.aggregation_method = aggregation_method
-        super().__init__(on=["BOLD"], name=name)
+        super().__init__(name=name)
+
+    def get_valid_inputs(self) -> List[str]:
+        """Get valid data types for input.
+
+        Returns
+        -------
+        list of str
+            The list of data types that can be used as input for this marker
+
+        """
+        return ["BOLD"]
 
     def get_output_kind(self, input: List[str]) -> List[str]:
         """Get output kind.

--- a/junifer/markers/functional_connectivity_atlas.py
+++ b/junifer/markers/functional_connectivity_atlas.py
@@ -12,7 +12,7 @@ from sklearn.covariance import EmpiricalCovariance
 from ..api.decorators import register_marker
 from ..utils import logger
 from .base import BaseMarker
-from .parcel import ParcelAggregation
+from .parcel_aggregation import ParcelAggregation
 
 
 if TYPE_CHECKING:
@@ -65,13 +65,23 @@ class FunctionalConnectivityAtlas(BaseMarker):
         self.cor_method_params = (
             {} if cor_method_params is None else cor_method_params
         )
-        on = ["BOLD"]
         # default to nilearn behavior
         self.cor_method_params["empirical"] = self.cor_method_params.get(
             "empirical", False
         )
 
-        super().__init__(on=on, name=name)
+        super().__init__(name=name)
+
+    def get_valid_inputs(self) -> List[str]:
+        """Get valid data types for input.
+
+        Returns
+        -------
+        list of str
+            The list of data types that can be used as input for this marker
+
+        """
+        return ["BOLD"]
 
     def get_output_kind(self, input: List[str]) -> List[str]:
         """Get output kind.

--- a/junifer/markers/functional_connectivity_spheres.py
+++ b/junifer/markers/functional_connectivity_spheres.py
@@ -79,7 +79,18 @@ class FunctionalConnectivitySpheres(BaseMarker):
             "empirical", False
         )
 
-        super().__init__(on=["BOLD"], name=name)
+        super().__init__(name=name)
+
+    def get_valid_inputs(self) -> List[str]:
+        """Get valid data types for input.
+
+        Returns
+        -------
+        list of str
+            The list of data types that can be used as input for this marker
+
+        """
+        return ["BOLD"]
 
     def get_output_kind(self, input: List[str]) -> List[str]:
         """Get output kind.

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -38,7 +38,7 @@ class ParcelAggregation(BaseMarker):
         :func:`junifer.stats.get_aggfunc_by_name`.
     on : {"T1w", "BOLD", "VBM_GM", "VBM_WM", "fALFF", "GCOR", "LCOR"} or list
         of the options, optional
-        The kind of data to apply the marker to. If None, will work on all
+        The data types to apply the marker to. If None, will work on all
         available data (default None).
     name : str, optional
         The name of the marker. If None, will use the class name (default
@@ -58,9 +58,18 @@ class ParcelAggregation(BaseMarker):
         self.atlas = atlas
         self.method = method
         self.method_params = {} if method_params is None else method_params
-        if on is None:
-            on = ["T1w", "BOLD", "VBM_GM", "VBM_WM", "fALFF", "GCOR", "LCOR"]
         super().__init__(on=on, name=name)
+
+    def get_valid_inputs(self) -> List[str]:
+        """Get valid data types for input.
+
+        Returns
+        -------
+        list of str
+            The list of data types that can be used as input for this marker
+
+        """
+        return ["T1w", "BOLD", "VBM_GM", "VBM_WM", "fALFF", "GCOR", "LCOR"]
 
     def get_output_kind(self, input: List[str]) -> List[str]:
         """Get output kind.

--- a/junifer/markers/sphere_aggregation.py
+++ b/junifer/markers/sphere_aggregation.py
@@ -69,9 +69,18 @@ class SphereAggregation(BaseMarker):
 
         self.method = method
         self.method_params = {} if method_params is None else method_params
-        if on is None:
-            on = ["T1w", "BOLD", "VBM_GM", "VBM_WM", "fALFF", "GCOR", "LCOR"]
         super().__init__(on=on, name=name)
+
+    def get_valid_inputs(self) -> List[str]:
+        """Get valid data types for input.
+
+        Returns
+        -------
+        list of str
+            The list of data types that can be used as input for this marker
+
+        """
+        return ["T1w", "BOLD", "VBM_GM", "VBM_WM", "fALFF", "GCOR", "LCOR"]
 
     def get_output_kind(self, input: List[str]) -> List[str]:
         """Get output kind.

--- a/junifer/markers/tests/test_functional_connectivity_atlas.py
+++ b/junifer/markers/tests/test_functional_connectivity_atlas.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from junifer.markers.functional_connectivity_atlas import (
     FunctionalConnectivityAtlas,
 )
-from junifer.markers.parcel import ParcelAggregation
+from junifer.markers.parcel_aggregation import ParcelAggregation
 from junifer.storage import SQLiteFeatureStorage
 
 

--- a/junifer/markers/tests/test_markers_base.py
+++ b/junifer/markers/tests/test_markers_base.py
@@ -47,6 +47,10 @@ def test_base_marker_subclassing() -> None:
         },
     }
     marker = MyBaseMarker(on=["BOLD"])
+
+    with pytest.raises(ValueError, match="not have the required data"):
+        marker.validate_input(["T1w"])
+
     output = marker.fit_transform(input=input_)  # process
     # Check output
     assert "BOLD" in output

--- a/junifer/markers/tests/test_markers_base.py
+++ b/junifer/markers/tests/test_markers_base.py
@@ -12,13 +12,16 @@ from junifer.markers.base import BaseMarker
 def test_base_marker_abstractness() -> None:
     """Test BaseMarker is abstract base class."""
     with pytest.raises(TypeError, match=r"abstract"):
-        BaseMarker(on=["BOLD"])
+        BaseMarker(on=["BOLD"])  # type: ignore
 
 
-def test_base_datagrabber_subclassing() -> None:
+def test_base_marker_subclassing() -> None:
     """Test proper subclassing of BaseMarker."""
     # Create concrete class
     class MyBaseMarker(BaseMarker):
+        def get_valid_inputs(self):
+            return ["BOLD", "T1w"]
+
         def get_output_kind(self, input):
             return ["timeseries"]
 
@@ -31,6 +34,9 @@ def test_base_datagrabber_subclassing() -> None:
 
         def store(self, kind, out, storage):
             return super().store(kind=kind, out=out, storage=storage)
+
+    with pytest.raises(ValueError, match=r"cannot be computed on \['T2w'\]"):
+        MyBaseMarker(on=["BOLD", "T2w"])
 
     # Create input for marker
     input_ = {
@@ -54,7 +60,7 @@ def test_base_datagrabber_subclassing() -> None:
 
     # Check no implementation check
     with pytest.raises(NotImplementedError):
-        marker.store(kind="kind", out="out", storage="storage")
+        marker.store(kind="kind", out="out", storage="storage")  # type: ignore
 
     # Check attributes
     assert marker.name == "MyBaseMarker"

--- a/junifer/markers/tests/test_parcel.py
+++ b/junifer/markers/tests/test_parcel.py
@@ -12,7 +12,7 @@ from nilearn.maskers import NiftiLabelsMasker, NiftiMasker
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy.stats import trim_mean
 
-from junifer.markers.parcel import ParcelAggregation
+from junifer.markers.parcel_aggregation import ParcelAggregation
 
 
 def test_ParcelAggregation_input_output() -> None:

--- a/scratch/test_niftimasker.py
+++ b/scratch/test_niftimasker.py
@@ -43,7 +43,7 @@ for t_v in sorted(np.unique(atlas_values)):
     manual.append(t_values)
 
 
-from junifer.markers.parcel import ParcelAggregation
+from junifer.markers.parcel_aggregation import ParcelAggregation
 
 marker = ParcelAggregation(atlas='Schaefer100x7', method='mean')
 input = dict(VBM_GM=dict(data=img))


### PR DESCRIPTION
* [x] no issue
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [latest changes](../docs/changes/latest.inc)


The idea is to have the `on` parameter of the markers to select the data types that the marker will be applied *on*, and use the `get_valid_inputs` function to verify that the marker is able to be computed on this kind of data.