### PR TITLE
[BUG]: CLI help has the wrong format

### DIFF
--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -84,7 +84,7 @@ def cli() -> None:  # pragma: no cover
 )
 def run(filepath: click.Path, element: str, verbose: click.Choice) -> None:
     """Run command for CLI.
-
+    \f
     Parameters
     ----------
     filepath : click.Path
@@ -128,7 +128,7 @@ def run(filepath: click.Path, element: str, verbose: click.Choice) -> None:
 )
 def collect(filepath: click.Path, verbose: click.Choice) -> None:
     """Collect command for CLI.
-
+    \f
     Parameters
     ----------
     filepath : click.Path
@@ -169,7 +169,7 @@ def queue(
     verbose: click.Choice,
 ) -> None:
     """Queue command for CLI.
-
+    \f
     Parameters
     ----------
     filepath : click.Path
@@ -204,7 +204,7 @@ def queue(
 @click.option("--long", "long_", is_flag=True)
 def wtf(long_: bool) -> None:
     """Wtf command for CLI.
-
+    \f
     Parameters
     ----------
     long_ : bool
@@ -225,7 +225,7 @@ def wtf(long_: bool) -> None:
 @click.argument("subpkg", type=str)
 def selftest(subpkg: str) -> None:
     """Selftest command for CLI.
-
+    \f
     Parameters
     ----------
     subpkg : {"all", "api", "configs", "data", "datagrabber", "datareader",

--- a/tox.ini
+++ b/tox.ini
@@ -96,6 +96,7 @@ extend-ignore =
     B024  # abstract class with no abstract methods
     D202
     D107  # missing docstring in __init__, incompatible with numpydoc
+    D301  # use r""" if any backslashes in a docstring
     E201  # whitespace after ‘(’
     E202  # whitespace before ‘)’
     E203  # whitespace before ‘,’, ‘;’, or ‘:’


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

```
(junifer)juseless ➜  junifer git:(feat/import) junifer run --help
Usage: junifer run [OPTIONS] FILEPATH

  Run command for CLI.

  Parameters ---------- filepath : click.Path     The filepath to the
  configuration file. element : str     The element to operate using. verbose
  : click.Choice     The verbosity level: warning, info or debug (default
  "info").

Options:
  --element TEXT
  -v, --verbose [warning|info|debug]
  --help                          Show this message and exit.

### Expected Behavior

```
(junifer)juseless ➜  junifer git:(feat/import) junifer run --help
Usage: junifer run [OPTIONS] FILEPATH

  Run junifer using the configuration from FILEPATH

Options:
  --element TEXT
  -v, --verbose [warning|info|debug]
  --help                          Show this message and exit.

### Steps To Reproduce

`junifer run --help`

### Environment

```markdown
junifer:
  version: 0.0.1.dev927
python:
  version: 3.9.12
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.21.2
  datalad: 0.15.5
  pandas: 1.4.1
  nibabel: 3.2.2
  nilearn: 0.9.0
  sqlalchemy: 1.4.32
  yaml: '6.0'
system:
  platform: Linux-4.19.0-21-amd64-x86_64-with-glibc2.28
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: /usr/lib/fsl/5.0:/home/fraimondo/anaconda3/envs/junifer/bin:/home/fraimondo/anaconda3/condabin:/home/fraimondo/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games
```


### Relevant log output

_No response_

### Anything else?

_No response_