### PR TITLE
[ENH] Include tests for the `queue` command

### DIFF
--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -186,7 +186,7 @@ def queue(
     jobdir = cwd / "junifer_jobs" / jobname
     logger.info(f"Creating job in {str(jobdir.absolute())}")
     if jobdir.exists():
-        if overwrite is not True:
+        if not overwrite:
             raise_error(
                 f"Job folder for {jobname} already exists. "
                 "This error is raised to prevent overwriting job files "

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -84,7 +84,7 @@ def run(
     # Convert str to Path
     if isinstance(workdir, str):
         workdir = Path(workdir)
-    if not isinstance(elements, List) and elements is not None:
+    if not isinstance(elements, list) and elements is not None:
         elements = [elements]
     # Get datagrabber to use
     datagrabber_object = _get_datagrabber(datagrabber)
@@ -234,7 +234,7 @@ def queue(
                 elements = dg.get_elements()
 
     # TODO: Fix typing of elements
-    if not isinstance(elements, List):
+    if not isinstance(elements, list):
         elements = [elements]  # type: ignore
 
     typing.cast(List[Union[str, Tuple]], elements)

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -258,7 +258,7 @@ def queue(
             **kwargs,
         )
     else:
-        raise ValueError(f"Unknown queue kind: {kind}")
+        raise_error(f"Unknown queue kind: {kind}")
 
     logger.info("Queue done")
 

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -501,6 +501,40 @@ def test_queue_condor_venv_python(
             # TODO: needs implementation for testing
 
 
+def test_queue_condor_submission_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test HTCondor job submission failure.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+    caplog : pytest.LogCaptureFixture
+        The logcapturefixture object.
+
+    """
+    with pytest.raises(
+        FileNotFoundError,
+        match="No such file or directory: 'condor_submit_dag'",
+    ):
+        with monkeypatch.context() as m:
+            m.chdir(tmp_path)
+            with caplog.at_level(logging.INFO):
+                queue(
+                    config={"elements": ["sub-001"]},
+                    kind="HTCondor",
+                    jobname="condor_job_submission_fail",
+                    submit=True,
+                )
+            # Check submit log
+            assert "Submitting HTCondor job" in caplog.text
+
+
 @pytest.mark.skip(reason="SLURM not installed on system.")
 def test_queue_slurm() -> None:
     """Test job queueing in SLURM."""

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 import junifer.testing.registry  # noqa: F401
-from junifer.api.functions import collect, run
+from junifer.api.functions import collect, queue, run
 from junifer.datagrabber.base import BaseDataGrabber
 from junifer.pipeline.registry import build
 
@@ -142,6 +142,29 @@ def test_run_and_collect(tmp_path: Path) -> None:
     collect(storage)
     # Now the file exists
     assert uri.exists()
+
+
+def test_queue_invalid_job_queue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test queue function for invalid job queue.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+
+    """
+    with pytest.raises(ValueError, match="Unknown queue kind"):
+        with monkeypatch.context() as m:
+            m.chdir(tmp_path)
+            queue(
+                config={"elements": ["sub-001"]},
+                kind="ABC",
+            )
 
 
 @pytest.mark.skip(reason="HTCondor not installed on system.")

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -318,6 +318,33 @@ def test_queue_with_elements(
             assert "Queue done" in caplog.text
 
 
+def test_queue_without_elements(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test queue without elements.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+    caplog : pytest.LogCaptureFixture
+        The logcapturefixture object.
+
+    """
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        with caplog.at_level(logging.INFO):
+            queue(
+                config={"datagrabber": datagrabber},
+                kind="SLURM",
+            )
+            assert "Queue done" in caplog.text
+
+
 @pytest.mark.skip(reason="HTCondor not installed on system.")
 def test_queue_condor() -> None:
     """Test job queueing in HTCondor."""

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -167,6 +167,37 @@ def test_queue_invalid_job_queue(
             )
 
 
+def test_queue_assets_disallow_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test overwrite prevention of queue files.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+
+    """
+    with pytest.raises(ValueError, match="Either delete the directory"):
+        with monkeypatch.context() as m:
+            m.chdir(tmp_path)
+            # First generate assets
+            queue(
+                config={"elements": ["sub-001"]},
+                kind="HTCondor",
+                jobname="prevent_overwrite",
+            )
+            # Re-run to trigger error
+            queue(
+                config={"elements": ["sub-001"]},
+                kind="HTCondor",
+                jobname="prevent_overwrite",
+            )
+
+
 @pytest.mark.skip(reason="HTCondor not installed on system.")
 def test_queue_condor() -> None:
     """Test job queueing in HTCondor."""

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -345,10 +345,30 @@ def test_queue_without_elements(
             assert "Queue done" in caplog.text
 
 
-@pytest.mark.skip(reason="HTCondor not installed on system.")
-def test_queue_condor() -> None:
-    """Test job queueing in HTCondor."""
-    pass
+def test_queue_condor_invalid_python_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test invalid Python environment check for HTCondor.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+
+    """
+    with pytest.raises(ValueError, match="Unknown env kind"):
+        with monkeypatch.context() as m:
+            m.chdir(tmp_path)
+            queue(
+                config={"elements": "sub-001"},
+                kind="HTCondor",
+                env={"kind": "galaxy"},
+            )
+
+
 
 
 @pytest.mark.skip(reason="SLURM not installed on system.")

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -7,7 +7,7 @@
 
 import logging
 from pathlib import Path
-from typing import List, Union
+from typing import List, Tuple, Union
 
 import pytest
 
@@ -291,13 +291,16 @@ def test_queue_with_imports(
         "sub-001",
         ["sub-001"],
         ["sub-001", "sub-002"],
+        ("sub-001", "ses-001"),
+        [("sub-001", "ses-001")],
+        [("sub-001", "ses-001"), ("sub-001", "ses-002")],
     ],
 )
 def test_queue_with_elements(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
-    elements: Union[str, List[str]],
+    elements: Union[str, List[Union[str, Tuple[str]]], Tuple[str]],
 ) -> None:
     """Test queue with elements.
 

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -628,6 +628,50 @@ def test_queue_condor_assets_generation(
             )
 
 
+def test_queue_condor_extra_preamble(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test HTCondor extra preamble addition.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+
+    """
+    jobname = "condor_extra_preamble_check"
+    extra_preamble = "FOO = BAR"
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        queue(
+            config={"elements": ["sub-001"]},
+            kind="HTCondor",
+            jobname=jobname,
+            extra_preamble=extra_preamble,
+        )
+
+        # Check extra preamble in run submit file
+        run_submit_file_path = Path(
+            tmp_path / "junifer_jobs" / jobname / f"run_{jobname}.submit"
+        )
+        with open(run_submit_file_path, "r") as f:
+            for line in f.read().splitlines():
+                if "FOO" in line:
+                    assert line.strip() == extra_preamble
+
+        # Check extra preamble in collect submit file
+        collect_submit_file_path = Path(
+            tmp_path / "junifer_jobs" / jobname / f"collect_{jobname}.submit"
+        )
+        with open(collect_submit_file_path, "r") as f:
+            for line in f.read().splitlines():
+                if "FOO" in line:
+                    assert line.strip() == extra_preamble
+
+
 def test_queue_condor_submission_fail(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -409,6 +409,32 @@ def test_queue_condor_conda_python(
             )
 
 
+def test_queue_condor_venv_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test venv Python environment check for HTCondor.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+    caplog : pytest.LogCaptureFixture
+        The logcapturefixture object.
+
+    """
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        with caplog.at_level(logging.INFO):
+            queue(
+                config={"elements": "sub-001"},
+                kind="HTCondor",
+                env={"kind": "venv", "name": "venv-env"},
+            )
+            # TODO: needs implementation for testing
 
 
 @pytest.mark.skip(reason="SLURM not installed on system.")

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -273,10 +273,16 @@ def test_queue_with_imports(
             queue(
                 config={"with": with_},
                 kind="HTCondor",
+                jobname="with_import_check",
                 elements="sub-001",
             )
             assert "Copying" in caplog.text
             assert "Queue done" in caplog.text
+
+        # Check that file is copied
+        assert Path(
+            tmp_path / "junifer_jobs" / "with_import_check" / "a.py"
+        ).is_file()
 
 
 @pytest.mark.parametrize(

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -369,6 +369,46 @@ def test_queue_condor_invalid_python_env(
             )
 
 
+def test_queue_condor_conda_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test conda Python environment check for HTCondor.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+    caplog : pytest.LogCaptureFixture
+        The logcapturefixture object.
+
+    """
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        with caplog.at_level(logging.INFO):
+            queue(
+                config={"elements": "sub-001"},
+                kind="HTCondor",
+                jobname="conda_env_check",
+                env={"kind": "conda", "name": "conda-env"},
+            )
+            assert "Copying" in caplog.text
+            assert (
+                Path(
+                    tmp_path
+                    / "junifer_jobs"
+                    / "conda_env_check"
+                    / "run_conda.sh"
+                )
+                .stat()
+                .st_mode
+                == 33261
+            )
+
+
 
 
 @pytest.mark.skip(reason="SLURM not installed on system.")

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -279,6 +279,45 @@ def test_queue_with_imports(
             assert "Queue done" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "elements",
+    [
+        "sub-001",
+        ["sub-001"],
+        ["sub-001", "sub-002"],
+    ],
+)
+def test_queue_with_elements(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    elements: Union[str, List[str]],
+) -> None:
+    """Test queue with elements.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    monkeypatch : pytest.MonkeyPatch
+        The monkeypatch object.
+    caplog : pytest.LogCaptureFixture
+        The logcapturefixture object.
+    elements : str of list of str
+        The parametrized elements for the queue.
+
+    """
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        with caplog.at_level(logging.INFO):
+            queue(
+                config={},
+                kind="HTCondor",
+                elements=elements,
+            )
+            assert "Queue done" in caplog.text
+
+
 @pytest.mark.skip(reason="HTCondor not installed on system.")
 def test_queue_condor() -> None:
     """Test job queueing in HTCondor."""


### PR DESCRIPTION
`julearn.api.functions.queue` and `julearn.api.functions._queue_condor` are currently not tested.

The functionality should be tested. At least that the YAML file is created, the submit file is somehow correct, the executable file is there, etc etc.

To consider:
- The logs directory should exist/be created. Otherwise the jobs will be on hold forever.

It will be ideal if we can check the validity of the submit file according to htcondor syntax.