### PR TITLE
[ENH]: Allow ParcelAggregation to apply multiple parcellations at once

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -89,6 +89,8 @@ Enhancements
 
 - Add support for "masks" (:gh:`79` by `Fede Raimondo`_).
 
+- Allow :class:`junifer.markers.ParcelAggregation` to apply multiple parcellations at once (:gh:`131` by `Fede Raimondo`_).
+
 Bugs
 ~~~~
 

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -216,15 +216,13 @@ def load_parcellation(
         parcel_values = np.unique(parcellation_img.get_fdata())
         if len(parcel_values) - 1 != len(parcellation_labels):
             raise_error(
-                f"Parcellation {name} has {len(parcel_values) - 1} parcels"
+                f"Parcellation {name} has {len(parcel_values) - 1} parcels "
                 f"but {len(parcellation_labels)} labels."
             )
-        if (
-            parcel_values.min() != 0
-            and parcel_values.max() != len(parcel_values) - 1
-        ):
+        parcel_values.sort()
+        if np.any(np.diff(parcel_values) != 1):
             raise_error(
-                f"Parcellation {name} has parcel values outside the range "
+                f"Parcellation {name} must have all the values in the range  "
                 f"[0, {len(parcel_values)}]."
             )
 

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -216,12 +216,13 @@ def load_parcellation(
         parcel_values = np.unique(parcellation_img.get_fdata())
         if len(parcel_values) - 1 != len(parcellation_labels):
             raise_error(
-                f"Parcellation {name} has {len(parcel_values) - 1} parcels but "
-                f"{len(parcellation_labels)} labels."
+                f"Parcellation {name} has {len(parcel_values) - 1} parcels"
+                f"but {len(parcellation_labels)} labels."
             )
-        if parcel_values.min() != 0 and parcel_values.max() != len(
-            parcel_values
-        ) - 1:
+        if (
+            parcel_values.min() != 0
+            and parcel_values.max() != len(parcel_values) - 1
+        ):
             raise_error(
                 f"Parcellation {name} has parcel values outside the range "
                 f"[0, {len(parcel_values)}]."

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -213,6 +213,19 @@ def load_parcellation(
     parcellation_img = None
     if path_only is False:
         parcellation_img = nib.load(parcellation_fname)
+        parcel_values = np.unique(parcellation_img.get_fdata())
+        if len(parcel_values) - 1 != len(parcellation_labels):
+            raise_error(
+                f"Parcellation {name} has {len(parcel_values) - 1} parcels but "
+                f"{len(parcellation_labels)} labels."
+            )
+        if parcel_values.min() != 0 and parcel_values.max() != len(
+            parcel_values
+        ) - 1:
+            raise_error(
+                f"Parcellation {name} has parcel values outside the range "
+                f"[0, {len(parcel_values)}]."
+            )
 
     return parcellation_img, parcellation_labels, parcellation_fname
 

--- a/junifer/data/tests/test_parcellations.py
+++ b/junifer/data/tests/test_parcellations.py
@@ -72,6 +72,9 @@ def test_register_parcellation_already_registered() -> None:
     )
 
 
+# TODO: Add tests to verify wrong number of labels and wrong values
+
+
 @pytest.mark.parametrize(
     "name, parcellation_path, parcels_labels, overwrite",
     [

--- a/junifer/data/tests/test_parcellations.py
+++ b/junifer/data/tests/test_parcellations.py
@@ -119,7 +119,6 @@ def test_parcellation_wrong_labels_values(tmp_path: Path) -> None:
         load_parcellation("WrongValues2")
 
 
-
 @pytest.mark.parametrize(
     "name, parcellation_path, parcels_labels, overwrite",
     [

--- a/junifer/markers/ets_rss.py
+++ b/junifer/markers/ets_rss.py
@@ -6,7 +6,7 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import numpy as np
 
@@ -26,8 +26,8 @@ class RSSETSMarker(BaseMarker):
 
     Parameters
     ----------
-    parcellation : str
-        The name of the parcellation. Check valid options by calling
+    parcellation : str or list of str
+        The name(s) of the parcellation(s). Check valid options by calling
         :func:`junifer.data.parcellations.list_parcellations`.
     agg_method : str, optional
         The method to perform aggregation using. Check valid options in
@@ -47,7 +47,7 @@ class RSSETSMarker(BaseMarker):
 
     def __init__(
         self,
-        parcellation: str,
+        parcellation: Union[str, List[str]],
         agg_method: str = "mean",
         agg_method_params: Optional[Dict] = None,
         mask: Optional[str] = None,

--- a/junifer/markers/functional_connectivity_parcels.py
+++ b/junifer/markers/functional_connectivity_parcels.py
@@ -4,7 +4,7 @@
 #          Kaustubh R. Patil <k.patil@fz-juelich.de>
 # License: AGPL
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from nilearn.connectome import ConnectivityMeasure
 from sklearn.covariance import EmpiricalCovariance
@@ -24,8 +24,8 @@ class FunctionalConnectivityParcels(BaseMarker):
 
     Parameters
     ----------
-    parcellation : str
-        The name of the parcellation. Check valid options by calling
+    parcellation : str or list of str
+        The name(s) of the parcellation(s). Check valid options by calling
         :func:`junifer.data.parcellations.list_parcellations`.
     agg_method : str, optional
         The method to perform aggregation using. Check valid options in
@@ -51,7 +51,7 @@ class FunctionalConnectivityParcels(BaseMarker):
 
     def __init__(
         self,
-        parcellation: str,
+        parcellation: Union[str, List[str]],
         agg_method: str = "mean",
         agg_method_params: Optional[Dict] = None,
         cor_method: str = "covariance",

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -26,8 +26,8 @@ class ParcelAggregation(BaseMarker):
 
     Parameters
     ----------
-    parcellation : str
-        The name of the parcellation. Check valid options by calling
+    parcellation : str or list of str
+        The name(s) of the parcellation(s). Check valid options by calling
         :func:`junifer.data.parcellations.list_parcellations`.
     method : str
         The method to perform aggregation using. Check valid options in
@@ -191,7 +191,7 @@ class ParcelAggregation(BaseMarker):
             labels = all_labels[0]
             for t_parc, t_labels in zip(all_parcelations[1:], all_labels[1:]):
                 # Get the data from this parcellation
-                t_parc_data = t_parc.get_fdata()
+                t_parc_data = t_parc.get_fdata().copy()  # must be copied
                 # Increase the values of each ROI to match the labels
                 t_parc_data[t_parc_data != 0] += len(labels)
 

--- a/junifer/markers/tests/test_parcel_aggregation.py
+++ b/junifer/markers/tests/test_parcel_aggregation.py
@@ -6,13 +6,14 @@
 import nibabel as nib
 import numpy as np
 import pytest
+from pathlib import Path
 from nilearn import datasets
-from nilearn.image import concat_imgs, math_img, resample_to_img
+from nilearn.image import concat_imgs, math_img, resample_to_img, new_img_like
 from nilearn.maskers import NiftiLabelsMasker, NiftiMasker
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy.stats import trim_mean
 
-from junifer.data import load_mask
+from junifer.data import load_mask, load_parcellation, register_parcellation
 from junifer.markers.parcel_aggregation import ParcelAggregation
 
 
@@ -202,8 +203,8 @@ def test_ParcelAggregation_3D_mask() -> None:
 
     # Create NiftiLabelsMasker
     nifti_masker = NiftiLabelsMasker(
-        labels_img=parcellation.maps,
-        mask_img=mask_img)
+        labels_img=parcellation.maps, mask_img=mask_img
+    )
     auto = nifti_masker.fit_transform(img)
 
     # Use the ParcelAggregation object
@@ -231,45 +232,201 @@ def test_ParcelAggregation_3D_mask() -> None:
     assert meta["method_params"] == {}
 
 
-def test_ParcelAggregation_3D_multiple() -> None:
-    """Test ParcelAggregation object on 3D images, multiple parcellations."""
+def test_ParcelAggregation_3D_multiple_non_overlapping(tmp_path: Path) -> None:
+    """Test ParcelAggregation with multiple non-overlapping parcellations.
 
-    # Get the testing parcellation (for nilearn)
-    # parcellation = datasets.fetch_atlas_schaefer_2018(n_rois=100)
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+
+    # Get the testing parcellation
+    parcellation, labels, _ = load_parcellation("Schaefer100x7")
+
+    assert parcellation is not None
 
     # Get the oasis VBM data
     oasis_dataset = datasets.fetch_oasis_vbm(n_subjects=1)
     vbm = oasis_dataset.gray_matter_maps[0]
     img = nib.load(vbm)
 
-    # # Create NiftiLabelsMasker for schaefer 100
-    # nifti_masker = NiftiLabelsMasker(labels_img=parcellation.maps)
-    # auto_schaefer = nifti_masker.fit_transform(img)
+    # Create two parcellations from it
+    parcellation_data = parcellation.get_fdata()
+    parcellation1_data = parcellation_data.copy()
+    parcellation1_data[parcellation1_data > 50] = 0
+    parcellation2_data = parcellation_data.copy()
+    parcellation2_data[parcellation2_data <= 50] = 0
+    parcellation2_data[parcellation2_data > 0] -= 50
+    labels1 = labels[:50]
+    labels2 = labels[50:]
 
-    # # Create NiftiLabelsMasker for Tian 2012
-    # nifti_masker = NiftiLabelsMasker(labels_img=parcellation.maps)
-    # auto_tian = nifti_masker.fit_transform(img)
+    parcellation1_img = new_img_like(parcellation, parcellation1_data)
+    parcellation2_img = new_img_like(parcellation, parcellation2_data)
 
-    # Use the ParcelAggregation object
-    marker = ParcelAggregation(
-        parcellation=["Schaefer100x7", "SUITxMNI"],
+    parcellation1_path = tmp_path / "parcellation1.nii.gz"
+    parcellation2_path = tmp_path / "parcellation2.nii.gz"
+
+    nib.save(parcellation1_img, parcellation1_path)
+    nib.save(parcellation2_img, parcellation2_path)
+
+    register_parcellation("Schaefer100x7_low", parcellation1_path, labels1)
+    register_parcellation("Schaefer100x7_high", parcellation2_path, labels2)
+
+    # Use the ParcelAggregation object on the original parcellation
+    marker_original = ParcelAggregation(
+        parcellation="Schaefer100x7",
         method="mean",
-        mask="GM_prob0.2",
         name="gmd_schaefer100x7_mean",
         on="VBM_GM",
     )  # Test passing "on" as a keyword argument
     input = dict(VBM_GM=dict(data=img))
-    jun_values3d_mean = marker.fit_transform(input)["VBM_GM"]["data"]
+    orig_mean = marker_original.fit_transform(input)["VBM_GM"]
 
-    assert jun_values3d_mean.ndim == 2
-    assert jun_values3d_mean.shape[0] == 1
+    orig_mean_data = orig_mean["data"]
+    assert orig_mean_data.ndim == 2
+    assert orig_mean_data.shape[0] == 1
+    assert orig_mean_data.shape[1] == 100
     # assert_array_almost_equal(auto, jun_values3d_mean)
 
-    meta = marker.get_meta("VBM_GM")["marker"]
+    meta = marker_original.get_meta("VBM_GM")["marker"]
     assert meta["method"] == "mean"
-    assert meta["parcellation"] == ["Schaefer100x7", "SUITxMNI"]
-    assert meta["mask"] == "GM_prob0.2"
+    assert meta["parcellation"] == ["Schaefer100x7"]
+    assert meta["mask"] == None
     assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
     assert meta["class"] == "ParcelAggregation"
     assert meta["kind"] == "VBM_GM"
     assert meta["method_params"] == {}
+
+    # Use the ParcelAggregation object on the two parcellations
+    marker_split = ParcelAggregation(
+        parcellation=["Schaefer100x7_low", "Schaefer100x7_high"],
+        method="mean",
+        name="gmd_schaefer100x7_mean",
+        on="VBM_GM",
+    )  # Test passing "on" as a keyword argument
+    input = dict(VBM_GM=dict(data=img))
+    split_mean = marker_split.fit_transform(input)["VBM_GM"]
+    split_mean_data = split_mean["data"]
+
+    assert split_mean_data.ndim == 2
+    assert split_mean_data.shape[0] == 1
+    assert split_mean_data.shape[1] == 100
+
+    meta = marker_split.get_meta("VBM_GM")["marker"]
+    assert meta["method"] == "mean"
+    assert meta["parcellation"] == ["Schaefer100x7_low", "Schaefer100x7_high"]
+    assert meta["mask"] == None
+    assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
+    assert meta["class"] == "ParcelAggregation"
+    assert meta["kind"] == "VBM_GM"
+    assert meta["method_params"] == {}
+
+    # Data and labels should be the same
+    assert_array_equal(orig_mean_data, split_mean_data)
+    assert orig_mean["columns"] == split_mean["columns"]
+
+
+def test_ParcelAggregation_3D_multiple_overlapping(tmp_path: Path) -> None:
+    """Test ParcelAggregation with multiple overlapping parcellations.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+
+    # Get the testing parcellation
+    parcellation, labels, _ = load_parcellation("Schaefer100x7")
+
+    assert parcellation is not None
+
+    # Get the oasis VBM data
+    oasis_dataset = datasets.fetch_oasis_vbm(n_subjects=1)
+    vbm = oasis_dataset.gray_matter_maps[0]
+    img = nib.load(vbm)
+
+    # Create two parcellations from it
+    parcellation_data = parcellation.get_fdata()
+    parcellation1_data = parcellation_data.copy()
+    parcellation1_data[parcellation1_data > 50] = 0
+    parcellation2_data = parcellation_data.copy()
+
+    # Make the second parcellation overlap with the first
+    parcellation2_data[parcellation2_data <= 45] = 0
+    parcellation2_data[parcellation2_data > 0] -= 45
+    labels1 = [f"low_{x}" for x in labels[:50]]  # Change the labels
+    labels2 = [f"high_{x}" for x in labels[45:]]  # Change the labels
+
+    parcellation1_img = new_img_like(parcellation, parcellation1_data)
+    parcellation2_img = new_img_like(parcellation, parcellation2_data)
+
+    parcellation1_path = tmp_path / "parcellation1.nii.gz"
+    parcellation2_path = tmp_path / "parcellation2.nii.gz"
+
+    nib.save(parcellation1_img, parcellation1_path)
+    nib.save(parcellation2_img, parcellation2_path)
+
+    register_parcellation("Schaefer100x7_low2", parcellation1_path, labels1)
+    register_parcellation("Schaefer100x7_high2", parcellation2_path, labels2)
+
+    # Use the ParcelAggregation object on the original parcellation
+    marker_original = ParcelAggregation(
+        parcellation="Schaefer100x7",
+        method="mean",
+        name="gmd_schaefer100x7_mean",
+        on="VBM_GM",
+    )  # Test passing "on" as a keyword argument
+    input = dict(VBM_GM=dict(data=img))
+    orig_mean = marker_original.fit_transform(input)["VBM_GM"]
+
+    orig_mean_data = orig_mean["data"]
+    assert orig_mean_data.ndim == 2
+    assert orig_mean_data.shape[0] == 1
+    assert orig_mean_data.shape[1] == 100
+    # assert_array_almost_equal(auto, jun_values3d_mean)
+
+    meta = marker_original.get_meta("VBM_GM")["marker"]
+    assert meta["method"] == "mean"
+    assert meta["parcellation"] == ["Schaefer100x7"]
+    assert meta["mask"] == None
+    assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
+    assert meta["class"] == "ParcelAggregation"
+    assert meta["kind"] == "VBM_GM"
+    assert meta["method_params"] == {}
+
+    # Use the ParcelAggregation object on the two parcellations
+    marker_split = ParcelAggregation(
+        parcellation=["Schaefer100x7_low2", "Schaefer100x7_high2"],
+        method="mean",
+        name="gmd_schaefer100x7_mean",
+        on="VBM_GM",
+    )  # Test passing "on" as a keyword argument
+    input = dict(VBM_GM=dict(data=img))
+    split_mean = marker_split.fit_transform(input)["VBM_GM"]
+    split_mean_data = split_mean["data"]
+
+    assert split_mean_data.ndim == 2
+    assert split_mean_data.shape[0] == 1
+    assert split_mean_data.shape[1] == 100
+
+    meta = marker_split.get_meta("VBM_GM")["marker"]
+    assert meta["method"] == "mean"
+    assert meta["parcellation"] == [
+        "Schaefer100x7_low2",
+        "Schaefer100x7_high2",
+    ]
+    assert meta["mask"] == None
+    assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
+    assert meta["class"] == "ParcelAggregation"
+    assert meta["kind"] == "VBM_GM"
+    assert meta["method_params"] == {}
+
+    # Data should be the same
+    assert_array_equal(orig_mean_data, split_mean_data)
+
+    # Labels should be "low" for the first 50 and "high" for the second 50
+    assert all(x.startswith("low") for x in split_mean["columns"][:50])
+    assert all(x.startswith("high") for x in split_mean["columns"][50:])

--- a/junifer/markers/tests/test_parcel_aggregation.py
+++ b/junifer/markers/tests/test_parcel_aggregation.py
@@ -293,7 +293,7 @@ def test_ParcelAggregation_3D_multiple_non_overlapping(tmp_path: Path) -> None:
     meta = marker_original.get_meta("VBM_GM")["marker"]
     assert meta["method"] == "mean"
     assert meta["parcellation"] == ["Schaefer100x7"]
-    assert meta["mask"] == None
+    assert meta["mask"] is None
     assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
     assert meta["class"] == "ParcelAggregation"
     assert meta["kind"] == "VBM_GM"
@@ -317,7 +317,7 @@ def test_ParcelAggregation_3D_multiple_non_overlapping(tmp_path: Path) -> None:
     meta = marker_split.get_meta("VBM_GM")["marker"]
     assert meta["method"] == "mean"
     assert meta["parcellation"] == ["Schaefer100x7_low", "Schaefer100x7_high"]
-    assert meta["mask"] == None
+    assert meta["mask"] is None
     assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
     assert meta["class"] == "ParcelAggregation"
     assert meta["kind"] == "VBM_GM"
@@ -391,7 +391,7 @@ def test_ParcelAggregation_3D_multiple_overlapping(tmp_path: Path) -> None:
     meta = marker_original.get_meta("VBM_GM")["marker"]
     assert meta["method"] == "mean"
     assert meta["parcellation"] == ["Schaefer100x7"]
-    assert meta["mask"] == None
+    assert meta["mask"] is None
     assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
     assert meta["class"] == "ParcelAggregation"
     assert meta["kind"] == "VBM_GM"
@@ -418,7 +418,7 @@ def test_ParcelAggregation_3D_multiple_overlapping(tmp_path: Path) -> None:
         "Schaefer100x7_low2",
         "Schaefer100x7_high2",
     ]
-    assert meta["mask"] == None
+    assert meta["mask"] is None
     assert meta["name"] == "VBM_GM_gmd_schaefer100x7_mean"
     assert meta["class"] == "ParcelAggregation"
     assert meta["kind"] == "VBM_GM"

--- a/junifer/markers/tests/test_parcel_aggregation.py
+++ b/junifer/markers/tests/test_parcel_aggregation.py
@@ -235,21 +235,20 @@ def test_ParcelAggregation_3D_multiple() -> None:
     """Test ParcelAggregation object on 3D images, multiple parcellations."""
 
     # Get the testing parcellation (for nilearn)
-    parcellation = datasets.fetch_atlas_schaefer_2018(n_rois=100)
+    # parcellation = datasets.fetch_atlas_schaefer_2018(n_rois=100)
 
     # Get the oasis VBM data
     oasis_dataset = datasets.fetch_oasis_vbm(n_subjects=1)
     vbm = oasis_dataset.gray_matter_maps[0]
     img = nib.load(vbm)
 
-    # Create NiftiLabelsMasker for schaefer 100
-    nifti_masker = NiftiLabelsMasker(labels_img=parcellation.maps)
-    auto_schaefer = nifti_masker.fit_transform(img)
+    # # Create NiftiLabelsMasker for schaefer 100
+    # nifti_masker = NiftiLabelsMasker(labels_img=parcellation.maps)
+    # auto_schaefer = nifti_masker.fit_transform(img)
 
-    # Create NiftiLabelsMasker for Tian 2012
-    nifti_masker = NiftiLabelsMasker(labels_img=parcellation.maps)
-    auto_schaefer = nifti_masker.fit_transform(img)
-
+    # # Create NiftiLabelsMasker for Tian 2012
+    # nifti_masker = NiftiLabelsMasker(labels_img=parcellation.maps)
+    # auto_tian = nifti_masker.fit_transform(img)
 
     # Use the ParcelAggregation object
     marker = ParcelAggregation(
@@ -274,4 +273,3 @@ def test_ParcelAggregation_3D_multiple() -> None:
     assert meta["class"] == "ParcelAggregation"
     assert meta["kind"] == "VBM_GM"
     assert meta["method_params"] == {}
-


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

It is common to compute markers on more than one parcel. However, some markers such as Functional Connectivity need to first extract signals from all the parcels and then compute the pairwise connectivity.

This could be done at the FC marker. However, it is also the case that there might be overlapping voxels (i.e. voxels that are present in both parcellations). 

Thus, the solution is to pass several parcellations to `ParcelAggregation`. This marker should first merge the parcells into one and then compute the aggregation.

However, in case of overlapping voxels, the order of the parcels should matter, as any voxel belonging to more than one parcellation should be placed in the parcellation that was first between the two.

Also, if the parcellations resolution do not match, it should be resamples to the one with the highest resolution.

Here's an example code:

https://github.com/LeSasse/parcmerge/blob/1aef22665ec8a4079e7cc24857ad901c20e5b43c/parcmerge/utils/parcutils.py#L30



### How do you imagine this integrated in junifer?

in `ParcelAggregation.compute`

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_