### PR TITLE
docs: fix RSSETSMarker rendering

### DIFF
--- a/junifer/markers/ets_rss.py
+++ b/junifer/markers/ets_rss.py
@@ -131,9 +131,10 @@ class RSSETSMarker(BaseMarker):
         dict
             The computed result as dictionary. The dictionary has the following
             keys:
-            - data : the actual computed values as a numpy.ndarray
-            - columns : the column labels for the computed values as a list
-            - row_names (if more than one row is present in data): "scan"
+
+            * ``data`` : the actual computed values as a numpy.ndarray
+            * ``columns`` : the column labels for the computed values as a list
+            * ``row_names`` (if more than one row is present in data): "scan"
 
         References
         ----------


### PR DESCRIPTION
This PR fixes the rendering in API docs for `RSSETSMarker`.