### PR TITLE
update: add singleton decorator function for markers in `junifer.markers.utils`

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -91,6 +91,8 @@ Enhancements
 
 - Allow :class:`junifer.markers.ParcelAggregation` to apply multiple parcellations at once (:gh:`131` by `Fede Raimondo`_).
 
+- Introduce a singleton decorator for marker computations (:gh:`151` by `Synchon Mandal`_).
+
 Bugs
 ~~~~
 

--- a/junifer/markers/utils.py
+++ b/junifer/markers/utils.py
@@ -4,15 +4,55 @@
 #          Nicolás Nieto <n.nieto@fz-juelich.de>
 #          Sami Hamdan <s.hamdan@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>
+#          Federico Raimondo <f.raimondo@fz-juelich.de>
 # License: AGPL
 
-from typing import Callable, Union
+from typing import Any, Callable, Dict, Type, Union
 
 import numpy as np
 import pandas as pd
 from scipy.stats import zscore
 
 from ..utils import raise_error
+
+
+def singleton(cls: Type) -> Type:
+    """Make a class singleton.
+
+    Parameters
+    ----------
+    cls : class
+        The class to designate as singleton.
+
+    Returns
+    -------
+    class
+        The only instance of the class.
+
+    """ ""
+    instances: Dict = {}
+
+    def get_instance(*args: Any, **kwargs: Any) -> Type:
+        """Get the only instance for a class.
+
+        Parameters
+        ----------
+        *args : tuple
+            The positional arguments to pass to the class.
+        **kwargs : dict
+            The keyword arguments to pass to the class.
+
+        Returns
+        -------
+        class
+            The only instance of the class.
+
+        """ ""
+        if cls not in instances:
+            instances[cls] = cls(*args, **kwargs)
+        return instances[cls]
+
+    return get_instance
 
 
 def _ets(bold_ts: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
* [ ] fix #(issue number)
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [latest changes](../docs/changes/latest.inc)

This PR introduces a singleton decorator in `junifer.markers.utils`, useful for markers using external toolboxes like `afni` to cache computations and other stuff.