### PR TITLE
[BUG]: `PatternDataGrabber` does not respect the `"format"` parameter required for `BOLD_confounds` data type

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -30,3 +30,6 @@ Bugs
 
 API changes
 ~~~~~~~~~~~
+
+- Add ``confounds_format`` parameter to :class:`junifer.datagrabber.PatternDataGrabber` constructor for
+  improved handling of confounds specified via ``BOLD_confounds`` data type (:gh:`158` by `Synchon Mandal`_).

--- a/junifer/configs/juseless/datagrabbers/ucla.py
+++ b/junifer/configs/juseless/datagrabbers/ucla.py
@@ -107,6 +107,7 @@ class JuselessUCLA(PatternDataGrabber):
             datadir=datadir,
             patterns=patterns,
             replacements=replacements,
+            confounds_format="fmriprep",
         )
 
     def get_elements(self) -> List:

--- a/junifer/datagrabber/aomic/id1000.py
+++ b/junifer/datagrabber/aomic/id1000.py
@@ -86,4 +86,5 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
             uri=uri,
             patterns=patterns,
             replacements=replacements,
+            confounds_format="fmriprep",
         )

--- a/junifer/datagrabber/aomic/piop1.py
+++ b/junifer/datagrabber/aomic/piop1.py
@@ -116,6 +116,7 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
             uri=uri,
             patterns=patterns,
             replacements=replacements,
+            confounds_format="fmriprep",
         )
 
     def get_item(self, subject: str, task: str) -> Dict:

--- a/junifer/datagrabber/aomic/piop2.py
+++ b/junifer/datagrabber/aomic/piop2.py
@@ -113,6 +113,7 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
             uri=uri,
             patterns=patterns,
             replacements=replacements,
+            confounds_format="fmriprep",
         )
 
     def get_elements(self) -> List:

--- a/junifer/datagrabber/pattern.py
+++ b/junifer/datagrabber/pattern.py
@@ -7,7 +7,7 @@
 
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -35,6 +35,9 @@ class PatternDataGrabber(BaseDataGrabber):
         Replacements in the patterns for each item in the "element" tuple.
     datadir : str or pathlib.Path
         The directory where the data is / will be stored.
+    confounds_format : {"fmriprep", "adhoc"}, optional
+        The format of the confounds for the dataset (default None).
+
     """
 
     def __init__(
@@ -43,6 +46,7 @@ class PatternDataGrabber(BaseDataGrabber):
         patterns: Dict[str, str],
         replacements: Union[List[str], str],
         datadir: Union[str, Path],
+        confounds_format: Optional[str] = None,
     ) -> None:
         # Validate patterns
         validate_patterns(types=types, patterns=patterns)
@@ -58,6 +62,7 @@ class PatternDataGrabber(BaseDataGrabber):
         logger.debug(f"\treplacements = {replacements}")
         self.patterns = patterns
         self.replacements = replacements
+        self.confounds_format = confounds_format
 
     @property
     def skip_file_check(self) -> bool:
@@ -184,7 +189,12 @@ class PatternDataGrabber(BaseDataGrabber):
                             f"Cannot access {t_type} for {element}: "
                             f"File {t_out} does not exist"
                         )
+            # Update path for the element
             out[t_type] = {"path": t_out}
+            # Update confounds format (if provided)
+            if self.confounds_format is not None:
+                out[t_type].update({"format": self.confounds_format})
+
         return out
 
     def get_elements(self) -> List:

--- a/junifer/datagrabber/tests/test_pattern.py
+++ b/junifer/datagrabber/tests/test_pattern.py
@@ -259,3 +259,48 @@ def test_PatternDataGrabber(tmp_path: Path) -> None:
     assert out1["func"]["path"] == out2["func"]["path"]
     assert out1["anat"]["path"] == out2["anat"]["path"]
     assert out1["vbm"]["path"] != out2["vbm"]["path"]
+
+
+def test_pattern_data_grabber_confounds_format_error_on_init() -> None:
+    """Test PatterDataGrabber confounds format error on initialisation."""
+    with pytest.raises(
+        ValueError, match="Invalid value for `confounds_format`"
+    ):
+        PatternDataGrabber(
+            types=["func"],
+            patterns={"func": "func/{subject}.nii"},
+            replacements=["subject"],
+            datadir="/tmp",
+            confounds_format="foobar",
+        )
+
+
+def test_pattern_data_grabber_confounds_format_error_on_fetch(
+    tmp_path: Path,
+) -> None:
+    """Test PatterDataGrabber confounds format error on fetching.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    # Create test directory path
+    tmpdir = tmp_path / "pattern_dg_test"
+    # Create final test directory
+    (tmpdir / "func" / "confounds").mkdir(exist_ok=True, parents=True)
+    # Create test confound file
+    (tmpdir / "func" / "confounds" / "sub-001.nii").touch()
+    # Initialise datagrabber
+    datagrabber = PatternDataGrabber(
+        types=["BOLD_confounds"],
+        patterns={"BOLD_confounds": "func/confounds/{subject}.nii"},
+        replacements=["subject"],
+        datadir=tmpdir,
+    )
+    # Check error on fetch
+    with pytest.raises(
+        ValueError, match="As the datagrabber used specifies 'BOLD_confounds'"
+    ):
+        datagrabber.get_item(subject="sub-001")


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

As of c6508a76, when loading the data for `BOLD_confounds` data type, the `PatternDataGrabber` (hence other dependent datagrabbers) does not add the `"format"` key to the `Junifer Data object`'s `BOLD_confounds` data type. This causes the `fMRIPrepConfoundRemover` to raise error later on when removing the confounds.

### Expected Behavior

The `"format"` key should be available to the `BOLD_confounds` data type so that `fMRIPrepConfoundRemover` can pre-process normally.

### Steps To Reproduce

As of c6508a76, `DataladAOMICPIOP1 > DefaultDataReader > fMRIPrepConfoundRemover > FunctionalConnectivityParcels`.

### Environment

```markdown
junifer:
  version: 0.0.1
python:
  version: 3.11.0
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.23.4
  datalad: 0.17.8
  pandas: 1.4.4
  nibabel: 4.0.2
  nilearn: 0.9.2
  sqlalchemy: 1.4.42
  yaml: '6.0'
system:
  platform: macOS-13.1-arm64-arm-64bit
environment:
  LC_CTYPE: UTF-8
  LC_TERMINAL: iTerm2
  LC_TERMINAL_VERSION: 3.4.18
  PATH: /Users/synchon/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/sbin:/opt/homebrew/bin:/Users/synchon/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/synchon/opt/miniconda3/envs/junifer-dev/bin:/Users/synchon/opt/miniconda3/condabin:/Users/synchon/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/sbin:/opt/homebrew/bin
```


### Relevant log output

_No response_

### Anything else?

_No response_