### PR TITLE
update: expose `PartlyCloudyTestingDataGrabber` to `testing.registry`

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -20,6 +20,9 @@ Current (0.0.2.dev)
 Enhancements
 ~~~~~~~~~~~~
 
+- Allow :class:`junifer.testing.datagrabbers.PartlyCloudyTestingDataGrabber` to be accessible
+  via ``import junifer.testing.registry`` (:gh:`160` by `Synchon Mandal`_).
+
 Bugs
 ~~~~
 

--- a/junifer/testing/registry.py
+++ b/junifer/testing/registry.py
@@ -7,6 +7,7 @@
 from ..pipeline.registry import register
 from .datagrabbers import (
     OasisVBMTestingDatagrabber,
+    PartlyCloudyTestingDataGrabber,
     SPMAuditoryTestingDatagrabber,
 )
 
@@ -22,4 +23,10 @@ register(
     step="datagrabber",
     name="SPMAuditoryTestingDatagrabber",
     klass=SPMAuditoryTestingDatagrabber,
+)
+
+register(
+    step="datagrabber",
+    name="PartlyCloudyTestingDataGrabber",
+    klass=PartlyCloudyTestingDataGrabber,
 )


### PR DESCRIPTION
* [ ] fix #(issue number)
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [latest changes](../docs/changes/latest.inc)

This PR exposes `PartlyCloudyTestingDataGrabber` to `junifer.testing.registry`.