### PR TITLE
[BUG]: Preprocess step is not respected by `junifer run`

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -26,5 +26,7 @@ Enhancements
 Bugs
 ~~~~
 
+- Fix ``junifer run`` to respect preprocess step specified in the pipeline (:gh:`159` by `Synchon Mandal`_).
+
 API changes
 ~~~~~~~~~~~

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -113,7 +113,7 @@ def run(filepath: click.Path, element: str, verbose: click.Choice) -> None:
     datagrabber = config["datagrabber"]
     markers = config["markers"]
     storage = config["storage"]
-    preprocessor = config.get("preprocessor")
+    preprocessor = config.get("preprocess")
     elements = _parse_elements(element, config)
     # Perform operation
     api_run(

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -113,6 +113,7 @@ def run(filepath: click.Path, element: str, verbose: click.Choice) -> None:
     datagrabber = config["datagrabber"]
     markers = config["markers"]
     storage = config["storage"]
+    preprocessor = config.get("preprocessor")
     elements = _parse_elements(element, config)
     # Perform operation
     api_run(
@@ -120,6 +121,7 @@ def run(filepath: click.Path, element: str, verbose: click.Choice) -> None:
         datagrabber=datagrabber,
         markers=markers,
         storage=storage,
+        preprocessor=preprocessor,
         elements=elements,
     )
 

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -76,6 +76,50 @@ def test_run_single_element(tmp_path: Path) -> None:
     assert len(files) == 1
 
 
+def test_run_single_element_with_preprocessing(tmp_path: Path) -> None:
+    """Test run function with single element and pre-processing.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    # Create working directory
+    workdir = tmp_path / "workdir_single_with_preprocess"
+    workdir.mkdir()
+    # Create output directory
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    # Create storage
+    uri = outdir / "test.sqlite"
+    storage["uri"] = uri  # type: ignore
+    # Run operations
+    run(
+        workdir=workdir,
+        datagrabber={
+            "kind": "PartlyCloudyTestingDataGrabber",
+            "reduce_confounds": False,
+        },
+        markers=[
+            {
+                "name": "Schaefer100x17_mean_FC",
+                "kind": "FunctionalConnectivityParcels",
+                "parcellation": "Schaefer100x17",
+                "agg_method": "mean",
+            }
+        ],
+        storage=storage,
+        preprocessor={
+            "kind": "fMRIPrepConfoundRemover",
+        },
+        elements=["sub-001"],
+    )
+    # Check files
+    files = list(outdir.glob("*.sqlite"))
+    assert len(files) == 1
+
+
 def test_run_multi_element(tmp_path: Path) -> None:
     """Test run function with multi element.
 

--- a/junifer/markers/collection.py
+++ b/junifer/markers/collection.py
@@ -116,6 +116,11 @@ class MarkerCollection:
         t_data = self._datareader.validate(t_data)
         logger.info(f"Data Reader output type: {t_data}")
 
+        if self._preprocessing is not None:
+            logger.info("Validating Preprocessor:")
+            t_data = self._preprocessing.validate(t_data)
+            logger.info(f"Preprocess output type: {t_data}")
+
         for marker in self._markers:
             logger.info(f"Validating Marker: {marker.name}")
             # Validate marker

--- a/junifer/markers/tests/test_collection.py
+++ b/junifer/markers/tests/test_collection.py
@@ -34,7 +34,7 @@ def test_marker_collection_incorrect_markers() -> None:
         MarkerCollection(wrong_markers)
 
 
-def test_marker_collection():
+def test_marker_collection() -> None:
     """Test MarkerCollection."""
     markers = [
         ParcelAggregation(

--- a/junifer/markers/tests/test_collection.py
+++ b/junifer/markers/tests/test_collection.py
@@ -10,10 +10,18 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from junifer.datareader.default import DefaultDataReader
-from junifer.markers import MarkerCollection, ParcelAggregation
+from junifer.markers import (
+    FunctionalConnectivityParcels,
+    MarkerCollection,
+    ParcelAggregation,
+)
 from junifer.pipeline import PipelineStepMixin
+from junifer.preprocess import fMRIPrepConfoundRemover
 from junifer.storage import SQLiteFeatureStorage
-from junifer.testing.datagrabbers import OasisVBMTestingDatagrabber
+from junifer.testing.datagrabbers import (
+    OasisVBMTestingDatagrabber,
+    PartlyCloudyTestingDataGrabber,
+)
 
 
 def test_marker_collection_incorrect_markers() -> None:
@@ -102,6 +110,34 @@ def test_marker_collection() -> None:
             assert_array_equal(
                 out[t_name]["VBM_GM"]["data"], out2[t_name]["VBM_GM"]["data"]
             )
+
+
+def test_marker_collection_with_preprocessing() -> None:
+    """Test MarkerCollection with preprocessing."""
+    markers = [
+        FunctionalConnectivityParcels(
+            parcellation="Schaefer100x17",
+            agg_method="mean",
+            name="Schaefer100x17_mean_FC",
+        ),
+        FunctionalConnectivityParcels(
+            parcellation="TianxS2x3TxMNInonlinear2009cAsym",
+            agg_method="mean",
+            name="TianxS2x3TxMNInonlinear2009cAsym_mean_FC",
+        ),
+    ]
+    mc = MarkerCollection(
+        markers=markers,
+        preprocessing=fMRIPrepConfoundRemover(),
+    )
+    assert mc._markers == markers
+    assert mc._preprocessing is not None
+    assert mc._storage is None
+    assert isinstance(mc._datareader, DefaultDataReader)
+
+    # Create testing datagrabber
+    dg = PartlyCloudyTestingDataGrabber(reduce_confounds=False)
+    mc.validate(dg)
 
 
 def test_marker_collection_storage(tmp_path: Path) -> None:


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

As of c6508a76, preprocess is not respected by `junifer run`.

### Expected Behavior

Preprocess step should be executed.

### Steps To Reproduce

As of c6508a76, `DataladAOMICPIOP1 > DefaultDataReader > fMRIPrepConfoundRemover > FunctionalConnectivityParcels`.

### Environment

```markdown
junifer:
  version: 0.0.1
python:
  version: 3.11.0
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.23.4
  datalad: 0.17.8
  pandas: 1.4.4
  nibabel: 4.0.2
  nilearn: 0.9.2
  sqlalchemy: 1.4.42
  yaml: '6.0'
system:
  platform: macOS-13.1-arm64-arm-64bit
environment:
  LC_CTYPE: UTF-8
  LC_TERMINAL: iTerm2
  LC_TERMINAL_VERSION: 3.4.18
  PATH: /Users/synchon/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/sbin:/opt/homebrew/bin:/Users/synchon/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/synchon/opt/miniconda3/envs/junifer-dev/bin:/Users/synchon/opt/miniconda3/condabin:/Users/synchon/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/sbin:/opt/homebrew/bin
```


### Relevant log output

_No response_

### Anything else?

_No response_