### PR TITLE
[ENH]: Support for multiple computed masks

### DIFF
--- a/docs/builtin.rst
+++ b/docs/builtin.rst
@@ -529,21 +529,28 @@ Available
        | Chimpanzee and Human Gray Matter Masks [Data set]. Zenodo.
        | https://doi.org/10.5281/zenodo.6463123
    * - Nilearn's MNI152 1mm-resolution mask
-     - | ``compute_brain``
+     - | ``compute_brain_mask``
      - 0.0.2
      - | Compute the whole-brain mask. This mask is calculated using MNI152 1mm-resolution template mask onto the 
        | target image. See :func:`nilearn.masking.compute_brain_mask`
    * - Nilearn's mask computed from FMRI data
-     - | ``compute_epi``
+     - | ``compute_epi_mask``
      - 0.0.2
      - | Compute a brain mask from fMRI data. This is based on an heuristic proposed by T.Nichols: find the least 
        | dense point of the histogram, between fractions ``lower_cutoff`` and ``upper_cutoff`` of the total image 
        | histogram. See :func:`nilearn.masking.compute_epi_mask`
    * - Nilearn's background mask
-     - | ``compute_background``
+     - | ``compute_background_mask``
      - 0.0.2
      - | Compute a brain mask for the images by guessing the value of the background from the border of the image.
        | See :func:`nilearn.masking.compute_background_mask`
+
+   * - Nilearn's ICBM152 template gray-matter mask
+     - | ``fetch_icbm152_brain_gm_mask``
+     - 0.0.2
+     - | Compute a gray-matter mask from the asymmetrical ICBM152 2009 template, release a.
+       | See :func:`nilearn.datasets.fetch_icbm152_brain_gm_mask`
+
 
 Planned
 ~~~~~~~

--- a/docs/builtin.rst
+++ b/docs/builtin.rst
@@ -515,7 +515,7 @@ Available
    * - Name
      - Keys
      - Version added
-     - Publication
+     - Description - Publication
    * - Vickery-Patil (Gray Matter)
      - | ``GM_prob0.2``
      - 0.0.1
@@ -528,6 +528,22 @@ Available
      - | Vickery, Sam, & Patil, Kaustubh. (2022).
        | Chimpanzee and Human Gray Matter Masks [Data set]. Zenodo.
        | https://doi.org/10.5281/zenodo.6463123
+   * - Nilearn's MNI152 1mm-resolution mask
+     - | ``compute_brain``
+     - 0.0.2
+     - | Compute the whole-brain mask. This mask is calculated using MNI152 1mm-resolution template mask onto the 
+       | target image. See :func:`nilearn.masking.compute_brain_mask`
+   * - Nilearn's mask computed from FMRI data
+     - | ``compute_epi``
+     - 0.0.2
+     - | Compute a brain mask from fMRI data. This is based on an heuristic proposed by T.Nichols: find the least 
+       | dense point of the histogram, between fractions ``lower_cutoff`` and ``upper_cutoff`` of the total image 
+       | histogram. See :func:`nilearn.masking.compute_epi_mask`
+   * - Nilearn's background mask
+     - | ``compute_background``
+     - 0.0.2
+     - | Compute a brain mask for the images by guessing the value of the background from the border of the image.
+       | See :func:`nilearn.masking.compute_background_mask`
 
 Planned
 ~~~~~~~

--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -37,8 +37,8 @@ Enhancements
 
 - Change HCP datagrabber tests to decrease CI running time (:gh:`155` by `Fede Raimondo`_).
 
-- Add support for nilearn computed masks (`compute_epi_mask`, `compute_brain_mask`, `compute_background_mask`)
-  (:gh:`175` by `Fede Raimondo`_).
+- Add support for nilearn computed masks (`compute_epi_mask`, `compute_brain_mask`, `compute_background_mask`,
+  `fetch_icbm152_brain_gm_mask`) (:gh:`175` by `Fede Raimondo`_).
 
 Bugs
 ~~~~

--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -37,6 +37,9 @@ Enhancements
 
 - Change HCP datagrabber tests to decrease CI running time (:gh:`155` by `Fede Raimondo`_).
 
+- Add support for nilearn computed masks (`compute_epi_mask`, `compute_brain_mask`, `compute_background_mask`)
+  (:gh:`175` by `Fede Raimondo`_).
+
 Bugs
 ~~~~
 

--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -37,8 +37,8 @@ Enhancements
 
 - Change HCP datagrabber tests to decrease CI running time (:gh:`155` by `Fede Raimondo`_).
 
-- Add support for nilearn computed masks (`compute_epi_mask`, `compute_brain_mask`, `compute_background_mask`,
-  `fetch_icbm152_brain_gm_mask`) (:gh:`175` by `Fede Raimondo`_).
+- Add support for nilearn computed masks (``compute_epi_mask``, ``compute_brain_mask``, ``compute_background_mask``,
+  ``fetch_icbm152_brain_gm_mask``) (:gh:`175` by `Fede Raimondo`_).
 
 Bugs
 ~~~~

--- a/junifer/data/__init__.py
+++ b/junifer/data/__init__.py
@@ -19,6 +19,7 @@ from .masks import (
     list_masks,
     load_mask,
     register_mask,
+    get_mask,
 )
 
 from . import utils

--- a/junifer/data/masks.py
+++ b/junifer/data/masks.py
@@ -45,12 +45,12 @@ data/masks directory. The user can also register their own masks.
 _available_masks: Dict[str, Dict[str, Any]] = {
     "GM_prob0.2": {"family": "Vickery-Patil"},
     "GM_prob0.2_cortex": {"family": "Vickery-Patil"},
-    "compute_brain": {"family": "Callable", "func": compute_brain_mask},
-    "compute_background": {
+    "compute_brain_mask": {"family": "Callable", "func": compute_brain_mask},
+    "compute_backgroun_mask": {
         "family": "Callable",
         "func": compute_background_mask,
     },
-    "compute_epi": {"family": "Callable", "func": compute_epi_mask},
+    "compute_epi_mask": {"family": "Callable", "func": compute_epi_mask},
 }
 
 
@@ -113,7 +113,7 @@ def list_masks() -> List[str]:
 
 def get_mask(
     name: str,
-    target_img: "Nifti1Image",
+    target_data: Dict[str, Any],
     callable_params: Optional[Dict[str, Any]] = None,
 ) -> "Nifti1Image":
     """Get mask, tailored for the target image.
@@ -122,8 +122,9 @@ def get_mask(
     ----------
     name : str
         The name of the mask.
-    target_img : Nifti1Image
-        The image to which the mask will be applied.
+    target_data : Dict[str, Any]
+        The corresponding item of the data object to which the mask will be
+        applied.
     callable_params : dict, optional
         Parameters to pass to the callable mask function (default None).
     Returns
@@ -132,6 +133,7 @@ def get_mask(
         The mask image.
     """
     # Get the min of the voxels sizes and use it as the resolution
+    target_img = target_data["data"]
     resolution = np.min(target_img.header.get_zooms()[:3])
     mask_img, _ = load_mask(name, path_only=False, resolution=resolution)
     if callable(mask_img):

--- a/junifer/data/masks.py
+++ b/junifer/data/masks.py
@@ -37,14 +37,14 @@ if TYPE_CHECKING:
 _masks_path = Path(__file__).parent / "masks"
 
 
-def _fetch_icbm152_brain_gm_mask(target_img, **kwargs):
+def _fetch_icbm152_brain_gm_mask(target_img: "Nifti1Image", **kwargs):
     """Fetch ICBM152 brain mask and resample.
 
     Parameters
     ----------
     target_img : nibabel.Nifti1Image
         The image to which the mask will be resampled.
-    kwargs : dict
+    **kwargs : dict
         Keyword arguments to be passed to
         :func:`nilearn.datasets.fetch_icbm152_brain_gm_mask`.
 
@@ -157,9 +157,10 @@ def get_mask(
     masks : str or dict
         The name of the mask, or the name of a callable mask and the parameters
         of the mask.
-    target_data : Dict[str, Any]
+    target_data : dict
         The corresponding item of the data object to which the mask will be
         applied.
+
     Returns
     -------
     Nifti1Image
@@ -190,7 +191,7 @@ def get_mask(
         mask_img = mask_object(target_img, **mask_params)
     else:  # Mask is a Nifti1Image
         if mask_params is not None:
-            raise_error("Cannot pass callable_params to a non-callable mask.")
+            raise_error("Cannot pass callable params to a non-callable mask.")
         mask_img = resample_to_img(
             mask_object,
             target_img,

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -6,7 +6,6 @@
 # License: AGPL
 
 from pathlib import Path
-import operator
 
 import pytest
 from numpy.testing import (

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -178,16 +178,17 @@ def test_get_mask() -> None:
     with OasisVBMTestingDatagrabber() as dg:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
-        vbm_gm = input["VBM_GM"]["data"]
-        mask = get_mask(name="GM_prob0.2", target_img=vbm_gm)
+        vbm_gm = input["VBM_GM"]
+        vbm_gm_img = vbm_gm["data"]
+        mask = get_mask(name="GM_prob0.2", target_data=vbm_gm)
 
-        assert mask.shape == vbm_gm.shape
-        assert_array_equal(mask.affine, vbm_gm.affine)
+        assert mask.shape == vbm_gm_img.shape
+        assert_array_equal(mask.affine, vbm_gm_img.affine)
 
         raw_mask_img, _ = load_mask("GM_prob0.2", resolution=1.5)
         res_mask_img = resample_to_img(
             raw_mask_img,
-            vbm_gm,
+            vbm_gm_img,
             interpolation="nearest",
             copy=True,
         )
@@ -205,10 +206,11 @@ def test_mask_callable() -> None:
     with OasisVBMTestingDatagrabber() as dg:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
-        vbm_gm = input["VBM_GM"]["data"]
-        mask = get_mask(name="identity", target_img=vbm_gm)
+        vbm_gm = input["VBM_GM"]
+        vbm_gm_img = vbm_gm["data"]
+        mask = get_mask(name="identity", target_data=vbm_gm)
 
-        assert_array_equal(mask.get_fdata(), vbm_gm.get_fdata())
+        assert_array_equal(mask.get_fdata(), vbm_gm_img.get_fdata())
 
     del _available_masks["identity"]
 
@@ -219,11 +221,12 @@ def test_nilearn_compute_masks() -> None:
     with SPMAuditoryTestingDatagrabber() as dg:
         input = dg["sub001"]
         input = reader.fit_transform(input)
-        bold_img = input["BOLD"]["data"]
+        bold = input["BOLD"]
+        bold_img = bold["data"]
 
-        mask_1 = get_mask(name="compute_brain", target_img=bold_img)
-        mask_2 = get_mask(name="compute_epi", target_img=bold_img)
-        mask_3 = get_mask(name="compute_background", target_img=bold_img)
+        mask_1 = get_mask(name="compute_brain", target_data=bold)
+        mask_2 = get_mask(name="compute_epi", target_data=bold)
+        mask_3 = get_mask(name="compute_background", target_data=bold)
 
         assert_array_equal(mask_1.affine, bold_img.affine)
         assert_array_equal(mask_2.affine, bold_img.affine)

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -237,12 +237,19 @@ def test_get_mask_errors() -> None:
         ("compute_brain_mask", compute_brain_mask, {"threshold": 0.2}, False),
         ("compute_background_mask", compute_background_mask, None, False),
         ("compute_epi_mask", compute_epi_mask, None, False),
-        ("fetch_icbm152_brain_gm_mask", fetch_icbm152_brain_gm_mask, None, True),
+        (
+            "fetch_icbm152_brain_gm_mask",
+            fetch_icbm152_brain_gm_mask,
+            None,
+            True,
+        ),
     ],
 )
 def test_nilearn_compute_masks(
-    mask_name: str, function: Callable, params: Union[Dict, None],
-    resample: bool
+    mask_name: str,
+    function: Callable,
+    params: Union[Dict, None],
+    resample: bool,
 ) -> None:
     """Test using nilearn compute mask functions.
 
@@ -270,9 +277,7 @@ def test_nilearn_compute_masks(
         else:
             mask_spec = {mask_name: params}
 
-        mask = get_mask(
-            mask=mask_spec, target_data=bold
-        )
+        mask = get_mask(mask=mask_spec, target_data=bold)
 
         assert_array_equal(mask.affine, bold_img.affine)
 

--- a/junifer/markers/ets_rss.py
+++ b/junifer/markers/ets_rss.py
@@ -49,7 +49,7 @@ class RSSETSMarker(BaseMarker):
         parcellation: Union[str, List[str]],
         agg_method: str = "mean",
         agg_method_params: Optional[Dict] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         name: Optional[str] = None,
     ) -> None:
         self.parcellation = parcellation

--- a/junifer/markers/falff/falff_parcels.py
+++ b/junifer/markers/falff/falff_parcels.py
@@ -70,7 +70,7 @@ class AmplitudeLowFrequencyFluctuationParcels(
         lowpass: float = 0.1,
         tr: Optional[float] = None,
         use_afni: Optional[bool] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         method: str = "mean",
         method_params: Optional[Dict] = None,
         name: Optional[str] = None,

--- a/junifer/markers/falff/falff_spheres.py
+++ b/junifer/markers/falff/falff_spheres.py
@@ -5,7 +5,7 @@
 #          Kaustubh R. Patil <k.patil@fz-juelich.de>
 # License: AGPL
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from ...api.decorators import register_marker
 from .. import SphereAggregation
@@ -75,7 +75,7 @@ class AmplitudeLowFrequencyFluctuationSpheres(
         lowpass: float = 0.1,
         tr: Optional[float] = None,
         use_afni: Optional[bool] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         method: str = "mean",
         method_params: Optional[Dict] = None,
         name: Optional[str] = None,

--- a/junifer/markers/functional_connectivity/crossparcellation_functional_connectivity.py
+++ b/junifer/markers/functional_connectivity/crossparcellation_functional_connectivity.py
@@ -4,7 +4,7 @@
 #          Kaustubh R. Patil <k.patil@fz-juelich.de>
 # License: AGPL
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
@@ -47,7 +47,7 @@ class CrossParcellationFC(BaseMarker):
         parcellation_two: str,
         aggregation_method: str = "mean",
         correlation_method: str = "pearson",
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         name: Optional[str] = None,
     ) -> None:
         if parcellation_one == parcellation_two:

--- a/junifer/markers/functional_connectivity/functional_connectivity_base.py
+++ b/junifer/markers/functional_connectivity/functional_connectivity_base.py
@@ -5,7 +5,7 @@
 
 
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from nilearn.connectome import ConnectivityMeasure
 from sklearn.covariance import EmpiricalCovariance
@@ -50,7 +50,7 @@ class FunctionalConnectivityBase(BaseMarker):
         agg_method_params: Optional[Dict] = None,
         cor_method: str = "covariance",
         cor_method_params: Optional[Dict] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         name: Optional[str] = None,
     ) -> None:
         self.agg_method = agg_method

--- a/junifer/markers/functional_connectivity/functional_connectivity_parcels.py
+++ b/junifer/markers/functional_connectivity/functional_connectivity_parcels.py
@@ -51,7 +51,7 @@ class FunctionalConnectivityParcels(FunctionalConnectivityBase):
         agg_method_params: Optional[Dict] = None,
         cor_method: str = "covariance",
         cor_method_params: Optional[Dict] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         name: Optional[str] = None,
     ) -> None:
         self.parcellation = parcellation

--- a/junifer/markers/functional_connectivity/functional_connectivity_spheres.py
+++ b/junifer/markers/functional_connectivity/functional_connectivity_spheres.py
@@ -5,7 +5,7 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from ...api.decorators import register_marker
 from ..sphere_aggregation import SphereAggregation
@@ -57,7 +57,7 @@ class FunctionalConnectivitySpheres(FunctionalConnectivityBase):
         agg_method_params: Optional[Dict] = None,
         cor_method: str = "covariance",
         cor_method_params: Optional[Dict] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         name: Optional[str] = None,
     ) -> None:
         self.coords = coords

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -186,7 +186,7 @@ class ParcelAggregation(BaseMarker):
 
         if self.mask is not None:
             logger.debug(f"Masking with {self.mask}")
-            mask_img = get_mask(name=self.mask, target_data=input)
+            mask_img = get_mask(mask=self.mask, target_data=input)
 
             parcellation_bin = math_img(
                 "np.logical_and(img, mask)",

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -11,7 +11,7 @@ from nilearn.image import math_img, new_img_like, resample_to_img
 from nilearn.maskers import NiftiMasker
 
 from ..api.decorators import register_marker
-from ..data import load_mask, load_parcellation
+from ..data import get_mask, load_parcellation
 from ..stats import get_aggfunc_by_name
 from ..utils import logger
 from .base import BaseMarker
@@ -186,13 +186,8 @@ class ParcelAggregation(BaseMarker):
 
         if self.mask is not None:
             logger.debug(f"Masking with {self.mask}")
-            mask_img, _ = load_mask(name=self.mask, resolution=resolution)
-            mask_img = resample_to_img(
-                mask_img,
-                t_input,
-                interpolation="nearest",
-                copy=True,
-            )
+            mask_img = get_mask(name=self.mask, target_img=t_input)
+
             parcellation_bin = math_img(
                 "np.logical_and(img, mask)",
                 img=parcellation_bin,

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -52,7 +52,7 @@ class ParcelAggregation(BaseMarker):
         parcellation: Union[str, List[str]],
         method: str,
         method_params: Optional[Dict[str, Any]] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         on: Union[List[str], str, None] = None,
         name: Optional[str] = None,
     ) -> None:

--- a/junifer/markers/reho/reho_parcels.py
+++ b/junifer/markers/reho/reho_parcels.py
@@ -4,7 +4,7 @@
 # License: AGPL
 
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
@@ -91,7 +91,7 @@ class ReHoParcels(ReHoBase):
         reho_params: Optional[Dict] = None,
         agg_method: str = "mean",
         agg_method_params: Optional[Dict] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         name: Optional[str] = None,
     ) -> None:
         self.parcellation = parcellation

--- a/junifer/markers/reho/reho_spheres.py
+++ b/junifer/markers/reho/reho_spheres.py
@@ -4,7 +4,7 @@
 # License: AGPL
 
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
@@ -97,7 +97,7 @@ class ReHoSpheres(ReHoBase):
         reho_params: Optional[Dict] = None,
         agg_method: str = "mean",
         agg_method_params: Optional[Dict] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         name: Optional[str] = None,
     ) -> None:
         self.coords = coords

--- a/junifer/markers/sphere_aggregation.py
+++ b/junifer/markers/sphere_aggregation.py
@@ -129,7 +129,7 @@ class SphereAggregation(BaseMarker):
             * ``columns`` : the column labels for the computed values as a list
 
         """
-        t_input = input["data"]
+        t_input_img = input["data"]
         logger.debug(f"Sphere aggregation using {self.method}")
         # Get aggregation function
         agg_func = get_aggfunc_by_name(
@@ -139,7 +139,7 @@ class SphereAggregation(BaseMarker):
         mask_img = None
         if self.mask is not None:
             logger.debug(f"Masking with {self.mask}")
-            mask_img = get_mask(name=self.mask, target_img=t_input)
+            mask_img = get_mask(name=self.mask, target_data=input)
         # Get seeds and labels
         coords, out_labels = load_coordinates(name=self.coords)
         masker = JuniferNiftiSpheresMasker(
@@ -149,7 +149,7 @@ class SphereAggregation(BaseMarker):
             agg_func=agg_func,
         )
         # Fit and transform the marker on the data
-        out_values = masker.fit_transform(t_input)
+        out_values = masker.fit_transform(t_input_img)
         # Format the output
         out = {"data": out_values, "columns": out_labels}
         return out

--- a/junifer/markers/sphere_aggregation.py
+++ b/junifer/markers/sphere_aggregation.py
@@ -139,7 +139,7 @@ class SphereAggregation(BaseMarker):
         mask_img = None
         if self.mask is not None:
             logger.debug(f"Masking with {self.mask}")
-            mask_img = get_mask(name=self.mask, target_data=input)
+            mask_img = get_mask(mask=self.mask, target_data=input)
         # Get seeds and labels
         coords, out_labels = load_coordinates(name=self.coords)
         masker = JuniferNiftiSpheresMasker(

--- a/junifer/markers/sphere_aggregation.py
+++ b/junifer/markers/sphere_aggregation.py
@@ -7,7 +7,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from ..api.decorators import register_marker
-from ..data import load_coordinates, load_mask
+from ..data import load_coordinates, get_mask
 from ..external.nilearn import JuniferNiftiSpheresMasker
 from ..stats import get_aggfunc_by_name
 from ..utils import logger
@@ -139,7 +139,7 @@ class SphereAggregation(BaseMarker):
         mask_img = None
         if self.mask is not None:
             logger.debug(f"Masking with {self.mask}")
-            mask_img, _ = load_mask(self.mask)
+            mask_img = get_mask(name=self.mask, target_img=t_input)
         # Get seeds and labels
         coords, out_labels = load_coordinates(name=self.coords)
         masker = JuniferNiftiSpheresMasker(

--- a/junifer/markers/sphere_aggregation.py
+++ b/junifer/markers/sphere_aggregation.py
@@ -56,7 +56,7 @@ class SphereAggregation(BaseMarker):
         radius: Optional[float] = None,
         method: str = "mean",
         method_params: Optional[Dict[str, Any]] = None,
-        mask: Optional[str] = None,
+        mask: Union[str, Dict, None] = None,
         on: Union[List[str], str, None] = None,
         name: Optional[str] = None,
     ) -> None:

--- a/junifer/markers/tests/test_parcel_aggregation.py
+++ b/junifer/markers/tests/test_parcel_aggregation.py
@@ -242,11 +242,10 @@ def test_ParcelAggregation_3D_mask() -> None:
 
 
 def test_ParcelAggregation_3D_mask_computed() -> None:
-    """Test ParcelAggregation object on 3D images with nilearn computed mask."""
+    """Test ParcelAggregation object on 3D images with computed masks."""
 
     # Get the testing parcellation (for nilearn)
     parcellation = datasets.fetch_atlas_schaefer_2018(n_rois=100)
-
 
     # Get the oasis VBM data
     oasis_dataset = datasets.fetch_oasis_vbm(n_subjects=1)
@@ -288,7 +287,6 @@ def test_ParcelAggregation_3D_mask_computed() -> None:
 
     with pytest.raises(AssertionError):
         assert_array_almost_equal(jun_values3d_mean, auto_bad)
-
 
 
 def test_ParcelAggregation_3D_multiple_non_overlapping(tmp_path: Path) -> None:


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

Extracted from comment on #170 by @LeSasse:

> i would probably just take the literal name of the function and for now implement it with these three functions until there is demand for more:
>
> "compute_epi_mask" -> https://nilearn.github.io/dev/modules/generated/nilearn.masking.compute_epi_mask.html#nilearn.masking.compute_epi_mask
>
>"compute_brain_mask" -> https://nilearn.github.io/dev/modules/generated/nilearn.masking.compute_brain_mask.html#nilearn.masking.compute_brain_mask
>
>"compute_background_mask" -> https://nilearn.github.io/dev/modules/generated/nilearn.masking.compute_background_mask.html#nilearn.masking.compute_background_mask
>
>I think most of the parameters for the functions should be possible to use as well, the important ones are strings and numbers I think. In the very least i think, for "compute_brain_mask" you can set the mask_type as a string. There is an optional target affine parameter as well, but this is only required if you also want to do resampling, which is not needed in this particular step.

### How do you imagine this integrated in junifer?

In a pipeline step.

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_