### PR TITLE
fix: update `pypi.yml` to checkout git submodules

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,9 +10,11 @@ jobs:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout source
+      uses: actions/checkout@3
       with:
         fetch-depth: 0
+        submodules: true
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
This PR updates the `pypi.yml` to checkout git submodules and fix the build process.