### PR TITLE
[BUG]: allow for empty parcels in ParcelAggregation

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -59,6 +59,7 @@ Enhancements
 
 - Modify the behaviour of the ``collect`` parameter in HTCondor ``queue`` function to run a collect job even if some of the previous jobs fail. This is useful to collect the results of a pipeline even if some of the jobs fail (:gh:`190` by `Fede Raimondo`_).
 
+- Allow for empty parcels in :class:`junifer.markers.ParcelAggregation`, that will result in NaNs (:gh:`194` by `Fede Raimondo`_).
 
 Bugs
 ~~~~
@@ -75,6 +76,8 @@ Bugs
 - Fix a bug in which :func:`junifer.stats.count` will not be correctly applied across an axis (:gh:`195` by `Fede Raimondo`_).
 
 - Fix an issue with datalad cache and locks in which the overriden settings in Junifer were not propagated to subprocesses, resulting in using the default settings (:gh:`199` by `Fede Raimondo`_).
+
+- Fix a bug in which :class:`junifer.markers.ParcelAggregation` could yield duplicated colum names if two or more parcels were used and label names were not unique (:gh:`194` by `Fede Raimondo`_).
 
 API changes
 ~~~~~~~~~~~

--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -77,7 +77,7 @@ Bugs
 
 - Fix an issue with datalad cache and locks in which the overriden settings in Junifer were not propagated to subprocesses, resulting in using the default settings (:gh:`199` by `Fede Raimondo`_).
 
-- Fix a bug in which :class:`junifer.markers.ParcelAggregation` could yield duplicated colum names if two or more parcels were used and label names were not unique (:gh:`194` by `Fede Raimondo`_).
+- Fix a bug in which :class:`junifer.markers.ParcelAggregation` could yield duplicated column names if two or more parcels were used and label names were not unique (:gh:`194` by `Fede Raimondo`_).
 
 API changes
 ~~~~~~~~~~~

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -13,7 +13,7 @@ from nilearn.maskers import NiftiMasker
 from ..api.decorators import register_marker
 from ..data import get_mask, load_parcellation
 from ..stats import get_aggfunc_by_name
-from ..utils import logger
+from ..utils import logger, warn_with_log
 from .base import BaseMarker
 
 
@@ -159,6 +159,22 @@ class ParcelAggregation(BaseMarker):
             labels = all_labels[0]
         else:
             # Merge the parcellations
+
+            # Check for duplicated labels
+            all_labels_flat = [
+                item for sublist in all_labels for item in sublist
+            ]
+            if len(all_labels_flat) != len(set(all_labels_flat)):
+                warn_with_log(
+                    "The parcellations have duplicated labels. "
+                    "Each label will be prefixed with the parcellation name."
+                )
+                for i_parcellation, t_labels in enumerate(all_labels):
+                    all_labels[i_parcellation] = [
+                        f"{self.parcellation[i_parcellation]}_{t_label}"
+                        for t_label in t_labels
+                    ]
+            overlapping_voxels = False
             parc_data = all_parcelations[0].get_fdata()
             labels = all_labels[0]
             for t_parc, t_labels in zip(all_parcelations[1:], all_labels[1:]):
@@ -171,8 +187,18 @@ class ParcelAggregation(BaseMarker):
                 # This makes sure that the voxels that are in multiple
                 # parcellations are assigned to the parcellation that was
                 # first in the list.
+                if np.any(parc_data[t_parc_data != 0] != 0):
+                    overlapping_voxels = True
+
                 parc_data[parc_data == 0] += t_parc_data[parc_data == 0]
                 labels.extend(t_labels)
+
+            if overlapping_voxels:
+                warn_with_log(
+                    "The parcellations have overlapping voxels. "
+                    "The overlapping voxels will be assigned to the "
+                    "parcellation that was first in the list."
+                )
 
             parcellation_img_res = new_img_like(
                 all_parcelations[0],
@@ -210,7 +236,7 @@ class ParcelAggregation(BaseMarker):
         logger.debug("Computing ROI means")
         out_values = []
         # Iterate over the parcels (existing)
-        for t_v in range(1, len(labels)+1):
+        for t_v in range(1, len(labels) + 1):
             t_values = agg_func(data[:, parcellation_values == t_v], axis=-1)
             out_values.append(t_values)
             # Update the labels just in case a parcel has no voxels

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -208,17 +208,14 @@ class ParcelAggregation(BaseMarker):
 
         # Get the values for each parcel and apply agg function
         logger.debug("Computing ROI means")
-        parcellation_roi_vals = sorted(np.unique(parcellation_values))
-        out_labels = []
         out_values = []
         # Iterate over the parcels (existing)
-        for t_v in parcellation_roi_vals:
+        for t_v in range(1, len(labels)+1):
             t_values = agg_func(data[:, parcellation_values == t_v], axis=-1)
             out_values.append(t_values)
             # Update the labels just in case a parcel has no voxels
             # in it
-            out_labels.append(labels[t_v - 1])
 
         out_values = np.array(out_values).T
-        out = {"data": out_values, "col_names": out_labels}
+        out = {"data": out_values, "col_names": labels}
         return out

--- a/junifer/markers/tests/test_parcel_aggregation.py
+++ b/junifer/markers/tests/test_parcel_aggregation.py
@@ -329,8 +329,12 @@ def test_ParcelAggregation_3D_multiple_non_overlapping(tmp_path: Path) -> None:
     nib.save(parcellation1_img, parcellation1_path)
     nib.save(parcellation2_img, parcellation2_path)
 
-    register_parcellation("Schaefer100x7_low", parcellation1_path, labels1)
-    register_parcellation("Schaefer100x7_high", parcellation2_path, labels2)
+    register_parcellation(
+        "Schaefer100x7_low", parcellation1_path, labels1, overwrite=True
+    )
+    register_parcellation(
+        "Schaefer100x7_high", parcellation2_path, labels2, overwrite=True
+    )
 
     # Use the ParcelAggregation object on the original parcellation
     marker_original = ParcelAggregation(
@@ -413,8 +417,12 @@ def test_ParcelAggregation_3D_multiple_overlapping(tmp_path: Path) -> None:
     nib.save(parcellation1_img, parcellation1_path)
     nib.save(parcellation2_img, parcellation2_path)
 
-    register_parcellation("Schaefer100x7_low2", parcellation1_path, labels1)
-    register_parcellation("Schaefer100x7_high2", parcellation2_path, labels2)
+    register_parcellation(
+        "Schaefer100x7_low2", parcellation1_path, labels1, overwrite=True
+    )
+    register_parcellation(
+        "Schaefer100x7_high2", parcellation2_path, labels2, overwrite=True
+    )
 
     # Use the ParcelAggregation object on the original parcellation
     marker_original = ParcelAggregation(
@@ -501,8 +509,12 @@ def test_ParcelAggregation_3D_multiple_duplicated_labels(
     nib.save(parcellation1_img, parcellation1_path)
     nib.save(parcellation2_img, parcellation2_path)
 
-    register_parcellation("Schaefer100x7_low", parcellation1_path, labels1)
-    register_parcellation("Schaefer100x7_high", parcellation2_path, labels2)
+    register_parcellation(
+        "Schaefer100x7_low", parcellation1_path, labels1, overwrite=True
+    )
+    register_parcellation(
+        "Schaefer100x7_high", parcellation2_path, labels2, overwrite=True
+    )
 
     # Use the ParcelAggregation object on the original parcellation
     marker_original = ParcelAggregation(


### PR DESCRIPTION
Currently, subjects in which a parcel has 0 voxels will result in different sized vectors/matrix/timeseries, which will later fail on collect.

As with spheres, we should allow for "empty" parcels and compute the corresponding NAN value.
