### PR TITLE
Fix/datalad cache

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -71,6 +71,8 @@ Bugs
 
 - Fix a bug in which :func:`junifer.stats.count` will not be correctly applied across an axis (:gh:`195` by `Fede Raimondo`_).
 
+- Fix an issue with datalad cache and locks in which the overriden settings in Junifer were not propagated to subprocesses, resulting in using the default settings (:gh:`199` by `Fede Raimondo`_).
+
 API changes
 ~~~~~~~~~~~
 

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -93,18 +93,23 @@ def _validate_verbose(
     str or int
         The validated value.
     """
-    valid_values = ["error", "warning", "info", "debug"]
     if isinstance(value, int):
         return value
-    elif isinstance(value, str) and value.lower() in valid_values:
+
+    valid_strings = ["error", "warning", "info", "debug"]
+    if isinstance(value, str) and value.lower() in valid_strings:
         return value.upper()
+
     try:
         value = int(value)  # type: ignore
         return value
     except ValueError:
+        # If we get here, the value is not a valid integer.
         pass
+
+    # If we get here, the value is not valid.
     raise click.BadParameter(
-        f"verbose must be one of {valid_values} or an integer"
+        f"verbose must be one of {valid_strings} or an integer"
     )
 
 

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -74,7 +74,9 @@ def _parse_elements(element: str, config: Dict) -> Union[List, None]:
     return elements
 
 
-def _validate_verbose(ctx: click.Context, param: str, value: str):
+def _validate_verbose(
+    ctx: click.Context, param: str, value: str
+) -> Union[str, int]:
     """Validate verbose option.
 
     Parameters
@@ -96,12 +98,11 @@ def _validate_verbose(ctx: click.Context, param: str, value: str):
         return value
     elif isinstance(value, str) and value.lower() in valid_values:
         return value.upper()
-    else:
-        try:
-            value = int(value)  # type: ignore
-            return value
-        except ValueError:
-            pass
+    try:
+        value = int(value)  # type: ignore
+        return value
+    except ValueError:
+        pass
     raise click.BadParameter(
         f"verbose must be one of {valid_values} or an integer"
     )

--- a/junifer/datagrabber/tests/test_datalad_base.py
+++ b/junifer/datagrabber/tests/test_datalad_base.py
@@ -160,9 +160,7 @@ def test_datalad_clone_cleanup(
     assert len(list(datadir.glob("*"))) == 0
 
 
-def test_datalad_clone_create_cleanup(
-    concrete_datagrabber: Type
-) -> None:
+def test_datalad_clone_create_cleanup(concrete_datagrabber: Type) -> None:
     """Test datalad base tempdir clone and remove.
 
     Parameters
@@ -203,8 +201,6 @@ def test_datalad_clone_create_cleanup(
 
     assert datadir.exists() is False
     assert len(list(datadir.glob("*"))) == 0
-
-
 
 
 def test_datalad_previously_cloned(

--- a/junifer/datagrabber/tests/test_datalad_base.py
+++ b/junifer/datagrabber/tests/test_datalad_base.py
@@ -160,6 +160,53 @@ def test_datalad_clone_cleanup(
     assert len(list(datadir.glob("*"))) == 0
 
 
+def test_datalad_clone_create_cleanup(
+    concrete_datagrabber: Type
+) -> None:
+    """Test datalad base tempdir clone and remove.
+
+    Parameters
+    ----------
+    concrete_datagrabber : DataladDataGrabber
+        A concrete datagrabber class to use.
+    """
+
+    # Clone whole dataset
+    uri = _testing_dataset["example_bids"]["uri"]
+    with concrete_datagrabber(datadir=None, uri=uri) as dg:
+        datadir = dg._tmpdir
+        elem1_bold = (
+            datadir / "example_bids/sub-01/func/sub-01_task-rest_bold.nii.gz"
+        )
+        elem1_t1w = datadir / "example_bids/sub-01/anat/sub-01_T1w.nii.gz"
+
+        assert elem1_bold.is_file() is False
+        assert elem1_t1w.is_file() is False
+        assert datadir.exists() is True
+        assert dg._was_cloned is True
+        assert elem1_bold.is_file() is False
+        assert elem1_bold.is_symlink() is True
+        assert elem1_t1w.is_file() is False
+        assert elem1_t1w.is_symlink() is True
+        elem1 = dg["sub-01"]
+        assert "meta" in elem1["BOLD"]
+        meta = elem1["BOLD"]["meta"]
+        assert "datagrabber" in meta
+        assert "datalad_dirty" in meta["datagrabber"]
+        assert meta["datagrabber"]["datalad_dirty"] is False
+        assert hasattr(dg, "_got_files") is False
+        assert datadir.exists() is True
+        assert elem1_bold.is_file() is True
+        assert elem1_bold.is_symlink() is True
+        assert elem1_t1w.is_file() is True
+        assert elem1_t1w.is_symlink() is True
+
+    assert datadir.exists() is False
+    assert len(list(datadir.glob("*"))) == 0
+
+
+
+
 def test_datalad_previously_cloned(
     tmp_path: Path, concrete_datagrabber: Type
 ) -> None:

--- a/junifer/datagrabber/tests/test_datalad_base.py
+++ b/junifer/datagrabber/tests/test_datalad_base.py
@@ -172,7 +172,7 @@ def test_datalad_clone_create_cleanup(concrete_datagrabber: Type) -> None:
     # Clone whole dataset
     uri = _testing_dataset["example_bids"]["uri"]
     with concrete_datagrabber(datadir=None, uri=uri) as dg:
-        datadir = dg._tmpdir
+        datadir = dg._tmpdir / "datadir"
         elem1_bold = (
             datadir / "example_bids/sub-01/func/sub-01_task-rest_bold.nii.gz"
         )


### PR DESCRIPTION
Fix an issue with datalad cache/locks on independent clones (temporary directories)

The main issue is a scalability issue and the cache/locks set in the home folder. At some point, there are way too many processes looking to get the lock, and even with the retries and waiting periods, they just give up and start failing.

Solution: use os.environ["DATALAD_LOCATIONS_LOCKS"] = ... to set an override (so each process has an independent lock/cache) and then datalad.cfg.reload() to force reload the configuration. This is supposed to propagate the override to subproccesses.

Also, this PR allows to use numbers for verbosity levels.