### PR TITLE
[ENH]: Allow to queue a collect job that will run even if some of the previous jobs fail in HTCondor

### DIFF
--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -630,11 +630,35 @@ def test_queue_condor_venv_python(
         ),
         (
             ["sub-001"],
+            {"kind": "conda", "name": "conda-env"},
+            "4G",
+            4,
+            "4G",
+            "yes",
+        ),
+        (
+            ["sub-001"],
+            {"kind": "conda", "name": "conda-env"},
+            "4G",
+            4,
+            "4G",
+            "on_success_only",
+        ),
+        (
+            ["sub-001"],
             {"kind": "venv", "name": "venv-env"},
             "8G",
             8,
             "8G",
             False,
+        ),
+        (
+            ["sub-001"],
+            {"kind": "venv", "name": "venv-env"},
+            "8G",
+            8,
+            "8G",
+            "no",
         ),
         (["sub-001"], {"kind": "local"}, "12G", 12, "12G", True),
     ],
@@ -648,7 +672,7 @@ def test_queue_condor_assets_generation(
     mem: str,
     cpus: int,
     disk: str,
-    collect: bool,
+    collect: Union[str, bool],
 ) -> None:
     """Test HTCondor generated assets.
 
@@ -670,7 +694,7 @@ def test_queue_condor_assets_generation(
         The parametrized CPUs.
     disk : str
         The parametrized disk size.
-    collect : bool
+    collect : bool or str
         The parametrized collect option.
 
     """
@@ -723,19 +747,33 @@ def test_queue_condor_assets_generation(
             # Read dag file to check if collect job is found
             element_count = 0
             has_collect_job = False
+            has_final_collect_job = False
             with open(dag_file_path, "r") as f:
                 for line in f.read().splitlines():
                     if "JOB" in line:
                         element_count += 1
                     if "collect" in line:
                         has_collect_job = True
+                    if "FINAL" in line:
+                        has_final_collect_job = True
 
-            if collect:
+            if collect in ["yes", True]:
+                assert len(elements) == element_count
+                assert has_collect_job is True
+                assert has_final_collect_job is True
+            elif collect == "on_success_only":
                 assert len(elements) == element_count - 1
                 assert has_collect_job is True
+                assert has_final_collect_job is False
             else:
                 assert len(elements) == element_count
                 assert has_collect_job is False
+
+            if has_final_collect_job is True:
+                pre_collect_fname = Path(
+                    tmp_path / "junifer_jobs" / jobname / "collect_pre.pl"
+                )
+                assert pre_collect_fname.exists()
 
             # Check submit log
             assert (


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

Currently, we are using a DAG to do "run" on all elements and finally do a "collect. The main issue with this DAG is that if any of the jobs fail, the collect is not run. With small datasets, this is not a problem. But it is unrealistic to expect this on big datasets.

This leads to manually needing to queueing the collect job later.

Fortunately, DAGman allows to set a "FINAL" jobs which runs once at the end of the dag: https://htcondor.readthedocs.io/en/latest/users-manual/dagman-workflows.html#id2

### How do you imagine this integrated in junifer?

Change the `collect` argument from `_queue_condor` from boolean to three options:

1) No: will not collect
2) Yes: will collect if all previous jobs were succesfull
3) Always: will collect no matter what happened before

It also needs a new script to be there, so if the users removes the DAG using condor_rm, then the collect job is not run.

the script must be this one (according to the doc), named `collect_pre.pl`. Maybe we can do the same in bash.

```perl
#!/usr/bin/env perl

if ($ARGV[0] eq 4) {
    exit(1);
}
```
### Do you have a sample code that implements this outside of junifer?

```python
        if collect is True:
            dag_file.write(f"JOB collect {submit_collect_fname}\n")
            dag_file.write("PARENT ")
            for i_job, _t_elem in enumerate(elements):
                dag_file.write(f"run{i_job} ")
            dag_file.write("CHILD collect\n\n")
        elif collect is "always":
            dag_file.write(f"FINAL collect {submit_collect_fname}\n")
            dag_file.write(f"SCRIPT PRE collect collect_pre.pl $DAG_STATUS\n")
```


### Anything else to say?

_No response_