### PR TITLE
[BUG]: The new "count" aggregation function does not respect multiple dimentions

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -69,6 +69,8 @@ Bugs
 
 - Fix an issue with datalad cache and locks in which the user-specific configuration might create a conflict in high throughput systems (:gh:`192` by `Fede Raimondo`_).
 
+- Fix a bug in which :func:`junifer.stats.count` will not be correctly applied across an axis (:gh:`195` by `Fede Raimondo`_).
+
 API changes
 ~~~~~~~~~~~
 

--- a/junifer/stats.py
+++ b/junifer/stats.py
@@ -91,7 +91,7 @@ def get_aggfunc_by_name(
     return func
 
 
-def count(data: np.ndarray, axis: int = 0) -> int:
+def count(data: np.ndarray, axis: int = 0) -> np.ndarray:
     """Count the number elements along the given axis.
 
     Parameters
@@ -103,10 +103,15 @@ def count(data: np.ndarray, axis: int = 0) -> int:
 
     Returns
     -------
-    int
+    numpy.ndarray
         Number of elements along the given axis.
     """
-    return data.shape[axis]
+    ax_size = data.shape[axis]
+    if axis < 0:
+        axis = data.ndim + axis
+    # keep the shape on the other axes
+    out = np.ones([x for i, x in enumerate(data.shape) if i != axis]) * ax_size
+    return out
 
 
 def winsorized_mean(

--- a/junifer/tests/test_stats.py
+++ b/junifer/tests/test_stats.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from junifer.stats import count, get_aggfunc_by_name, winsorized_mean
 
@@ -80,11 +81,16 @@ def test_winsorized_mean() -> None:
 def test_count() -> None:
     """Test count."""
     input = np.zeros((10, 3))
-    assert count(input, axis=-1) == 3
-    assert count(input, axis=1) == 3
-    assert count(input, axis=0) == 10
+    ax1 = np.ones((10)) * 3
+    ax2 = np.ones((3)) * 10
+    assert_array_equal(count(input, axis=-1), ax1)
+    assert_array_equal(count(input, axis=1), ax1)
+    assert_array_equal(count(input, axis=0), ax2)
 
     input = np.zeros((10, 0))
-    assert count(input, axis=-1) == 0
-    assert count(input, axis=1) == 0
-    assert count(input, axis=0) == 10
+    ax1 = np.zeros((10))
+    ax2 = np.zeros((0))
+
+    assert_array_equal(count(input, axis=-1), ax1)
+    assert_array_equal(count(input, axis=1), ax1)
+    assert_array_equal(count(input, axis=0), ax2)


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

Using the count aggregation function across one axis does not preserve the other dimensions.

### Expected Behavior

The other dimensions should be respected

### Steps To Reproduce

```python
import numpy as np
count(np.zeros((10, 0)), axis=-1)
```

This should give an array with 10 zeros.

Currently gives only a 0

### Environment

```markdown
(junifer) inm7537 ➜  junifer git:(fix/empty_parcel) junifer wtf
junifer:
  version: 0.0.1.dev75
python:
  version: 3.11.0
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.23.4
  datalad: 0.17.8
  pandas: 1.5.1
  nibabel: 4.0.2
  nilearn: 0.9.2
  sqlalchemy: 1.4.42
  yaml: '6.0'
system:
  platform: macOS-13.2.1-arm64-arm-64bit
environment:
  LC_CTYPE: UTF-8
  PATH: /Users/fraimondo/anaconda3/envs/junifer/bin:/Users/fraimondo/anaconda3/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/fraimondo/.local/bin:/Users/fraimondo/dev/tbox/junifer/junifer/api/res/afni
```


### Relevant log output

_No response_

### Anything else?

_No response_