### PR TITLE
[BUG]: HDF5FeatureStorage raises errors under normal operation

### DIFF
--- a/docs/changes/latest.inc
+++ b/docs/changes/latest.inc
@@ -61,6 +61,8 @@ Enhancements
 
 - Allow for empty parcels in :class:`junifer.markers.ParcelAggregation`, that will result in NaNs (:gh:`194` by `Fede Raimondo`_).
 
+- Improve metadata and data I/O for :class:`junifer.storage.HDF5FeatureStorage` (:gh:`196` by `Synchon Mandal`_).
+
 Bugs
 ~~~~
 

--- a/junifer/storage/hdf5.py
+++ b/junifer/storage/hdf5.py
@@ -474,11 +474,15 @@ class HDF5FeatureStorage(BaseFeatureStorage):
             The metadata as a dictionary.
 
         """
-        # Read metadata; if no file found, create an empty dictionary
-        try:
+        # Get correct URI for element;
+        # is different from uri if single_output is False
+        uri = self._fetch_correct_uri_for_io(element=element)
+
+        # Check if file exists, then read metadata else create empty dictionary
+        if Path(uri).exists():
             metadata = self._read_metadata(element=element)
-        except IOError:
-            logger.debug(f"Creating new metadata map for {meta_md5} ...")
+        else:
+            logger.debug(f"Creating new file at {uri} ...")
             metadata = {}
 
         # Only add entry if MD5 is not present
@@ -486,10 +490,6 @@ class HDF5FeatureStorage(BaseFeatureStorage):
             logger.debug(f"HDF5 metadata for {meta_md5} not found, adding ...")
             # Update metadata
             metadata[meta_md5] = meta
-
-            # Get correct URI for element;
-            # is different from uri if single_output is False
-            uri = self._fetch_correct_uri_for_io(element=element)
 
             logger.info(f"Writing HDF5 metadata for {meta_md5} to: {uri}")
             logger.debug(f"HDF5 overwrite is set to: {self.overwrite} ...")

--- a/junifer/storage/hdf5.py
+++ b/junifer/storage/hdf5.py
@@ -540,10 +540,15 @@ class HDF5FeatureStorage(BaseFeatureStorage):
             Keyword arguments passed from the calling method.
 
         """
-        # Read existing data; if no file found, create an empty dictionary
-        try:
+        # Get correct URI for element;
+        # is different from uri if single_output is False
+        uri = self._fetch_correct_uri_for_io(element=element[0])
+
+        # Check if MD5 exists, then read data else create empty dictionary
+        # File should be present here already
+        if has_hdf5(fname=uri, title=meta_md5):
             stored_data = self._read_data(md5=meta_md5, element=element[0])
-        except IOError:
+        else:
             logger.debug(f"Creating new data map for {meta_md5} ...")
             stored_data = {}
 
@@ -615,10 +620,6 @@ class HDF5FeatureStorage(BaseFeatureStorage):
                     "kind": kind,
                 }
             )
-
-        # Get correct URI for element;
-        # is different from uri if single_output is False
-        uri = self._fetch_correct_uri_for_io(element=element[0])
 
         logger.info(f"Writing HDF5 data for {meta_md5} to: {uri}")
         logger.debug(f"HDF5 overwrite is set to: {self.overwrite} ...")

--- a/junifer/storage/tests/test_hdf5.py
+++ b/junifer/storage/tests/test_hdf5.py
@@ -6,6 +6,7 @@
 
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
@@ -34,22 +35,6 @@ def test_single_output(tmp_path: Path) -> None:
     # Single storage, must be the uri
     storage = HDF5FeatureStorage(uri=uri, single_output=True)
     assert storage.single_output is True
-
-
-def test_single_output_file_not_found_error(tmp_path: Path) -> None:
-    """Test single output file not found error.
-
-    Parameters
-    ----------
-    tmp_path : pathlib.Path
-        The path to the test directory.
-
-    """
-    uri = tmp_path / "test_single_output_no_file.hdf5"
-    storage = HDF5FeatureStorage(uri=uri, single_output=True)
-    # Check file error
-    with pytest.raises(IOError, match="HDF5 file not found at:"):
-        storage._read_data(md5="md5")
 
 
 def test_multi_output_error(tmp_path: Path) -> None:
@@ -84,6 +69,76 @@ def test_single_output_parent_path_creation(tmp_path: Path) -> None:
     _ = HDF5FeatureStorage(uri=uri, single_output=True)
     # Path exists now
     assert to_create_hdf5.exists()
+
+
+def test_read_metadata_file_not_found_error(tmp_path: Path) -> None:
+    """Test file not found error when reading metadata.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    uri = tmp_path / "test_read_metadata_no_file.hdf5"
+    storage = HDF5FeatureStorage(uri=uri, single_output=True)
+    # Check file not found error
+    with pytest.raises(FileNotFoundError, match="HDF5 file not found at:"):
+        storage._read_metadata()
+
+
+def test_read_metadata_meta_not_found_error(tmp_path: Path) -> None:
+    """Test meta not found error when reading metadata.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    uri = tmp_path / "test_read_metadata_no_meta.hdf5"
+    storage = HDF5FeatureStorage(uri=uri, single_output=True)
+    # Create file
+    with h5py.File(uri, "w") as f:
+        f.create_dataset("mydataset", (100,), dtype="i")
+    # Check meta not found error
+    with pytest.raises(RuntimeError, match="Invalid junifer HDF5 file at:"):
+        storage._read_metadata()
+
+
+def test_read_data_file_not_found_error(tmp_path: Path) -> None:
+    """Test file not found error when reading data.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    uri = tmp_path / "test_read_data_no_file.hdf5"
+    storage = HDF5FeatureStorage(uri=uri, single_output=True)
+    # Check file not found error
+    with pytest.raises(FileNotFoundError, match="HDF5 file not found at:"):
+        storage._read_data(md5="md5")
+
+
+def test_read_data_md5_not_found_error(tmp_path: Path) -> None:
+    """Test meta not found error when reading data.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    uri = tmp_path / "test_read_data_no_md5.hdf5"
+    storage = HDF5FeatureStorage(uri=uri, single_output=True)
+    # Create file
+    with h5py.File(uri, "w") as f:
+        f.create_dataset("mydataset", (100,), dtype="i")
+    # Check MD5 not found error
+    with pytest.raises(RuntimeError, match="not found in HDF5 file at:"):
+        storage._read_data(md5="md5")
 
 
 def test_store_metadata_and_list_features(tmp_path: Path) -> None:

--- a/junifer/storage/tests/test_hdf5.py
+++ b/junifer/storage/tests/test_hdf5.py
@@ -36,29 +36,6 @@ def test_single_output(tmp_path: Path) -> None:
     assert storage.single_output is True
 
 
-def test_single_output_meta_not_found_error(tmp_path: Path) -> None:
-    """Test single output metadata not found error.
-
-    Parameters
-    ----------
-    tmp_path : pathlib.Path
-        The path to the test directory.
-
-    """
-    uri = tmp_path / "test_single_output_no_meta.hdf5"
-    storage = HDF5FeatureStorage(uri=uri, single_output=True)
-    # Store data to create the file
-    storage._store_data(
-        kind="vector",
-        meta_md5="md5",
-        element=[{"sub": "001"}],
-        data=np.empty((1, 1)),
-    )
-    # Check metadata error
-    with pytest.raises(IOError, match="`meta` not found in:"):
-        storage._read_metadata()
-
-
 def test_single_output_file_not_found_error(tmp_path: Path) -> None:
     """Test single output file not found error.
 
@@ -270,64 +247,6 @@ def test_read_df(tmp_path: Path) -> None:
         data=data,
         col_names=col_headers,
     )
-
-
-def test_store_data_ignore_duplicate(tmp_path: Path) -> None:
-    """Test duplicate ignore for data store.
-
-    Parameters
-    ----------
-    tmp_path : pathlib.Path
-        The path to the test directory.
-
-    """
-    uri = tmp_path / "test_duplicate_data_store.hdf5"
-    # Single storage, must be the uri
-    storage = HDF5FeatureStorage(uri=uri, single_output=True)
-    # Store data first time
-    storage._store_data(
-        kind="vector",
-        meta_md5="md5",
-        element=[{"sub": "001"}],
-        data=np.empty((1, 1)),
-    )
-    # Store data second time, should be ignored
-    storage._store_data(
-        kind="vector",
-        meta_md5="md5",
-        element=[{"sub": "001"}],
-        data=np.empty((1, 1)),
-    )
-
-
-def test_store_data_incorrect_kwargs(tmp_path: Path) -> None:
-    """Test incorrect kwargs for data store.
-
-    Parameters
-    ----------
-    tmp_path : pathlib.Path
-        The path to the test directory.
-
-    """
-    uri = tmp_path / "test_incorrect_kwargs_data_store.hdf5"
-    # Single storage, must be the uri
-    storage = HDF5FeatureStorage(uri=uri, single_output=True)
-    # Store data first time
-    storage._store_data(
-        kind="vector",
-        meta_md5="md5",
-        element=[{"sub": "001"}],
-        data=np.empty((1, 1)),
-    )
-    # Store data second time, should be ignored
-    with pytest.raises(RuntimeError, match="The additional data for"):
-        storage._store_data(
-            kind="vector",
-            meta_md5="md5",
-            element=[{"sub": "001"}],
-            data=np.empty((1, 1)),
-            col_names="col",
-        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

When using an HDF5FeatureStorage, the output log contains ERRORs related to HDF% storage.

```
2023-03-16 22:09:43,370 - JUNIFER - ERROR - HDF5 file not found at: /data/project/SPP2041/results/fraimondo/brain_size_project/storage/HCP_epi_mask_falff/element_100307_REST1_LR_HCP_epi_mask_falff.hdf5
2023-03-16 22:09:43,374 - JUNIFER - ERROR - `17194dc0bc12a30565cb1c46e04e2ea9` not found in: /data/project/SPP2041/results/fraimondo/brain_size_project/storage/HCP_epi_mask_falff/element_100307_REST1_LR_HCP_epi_mask_falff.hdf5
```

This is because the current implementation of H5io does not allow to test if a file contains certain variables. So all the "flow" of checking if the `meta` or certain md5 variable exists is done by try/catch blocks.

This is a not a good programming practice. For example, an IOError might be due to a failure in the underlying storage, but we will consider it as something "normal because there is no meta variable".

Solution: Implement a function in h5io to test for variables and use it.


```python
def has_hdf5(fname, title="h5io"):
    h5py = _check_h5py()
    if isinstance(fname, str):
        if not op.isfile(fname):
            raise IOError('file "%s" not found' % fname)
    elif isinstance(fname, h5py.File):
        if fname.mode == 'w':
            raise UnsupportedOperation(
                'file must not be opened be opened with "w"'
            )
        print(fname.mode)
    else:
        raise ValueError(f'fname must be str or h5py.File, got {type(fname)}')
    if not isinstance(title, str):
        raise ValueError('title must be a string')
    if isinstance(fname, h5py.File):
        return title in fname
    else:
        with h5py.File(fname, mode='r') as fid:
            return title in fname
```
### Expected Behavior

No errors in the log, no expceptions being raised.

### Steps To Reproduce

1. Install junifer
2. Run one example with HDF5FeatureStorage

### Environment

```markdown
(junifer)juseless ➜  logs git:(main) ✗ junifer wtf 
junifer:
  version: 0.0.1.dev927
python:
  version: 3.9.16
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.21.2
  datalad: 0.18.2
  pandas: 1.4.1
  nibabel: 3.2.2
  nilearn: 0.9.0
  sqlalchemy: 1.4.32
  yaml: '6.0'
system:
  platform: Linux-4.19.0-21-amd64-x86_64-with-glibc2.28
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: /usr/lib/fsl/5.0:/home/fraimondo/anaconda3/envs/junifer/bin:/home/fraimondo/anaconda3/condabin:/home/fraimondo/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games
```


### Relevant log output

_No response_

### Anything else?

_No response_