### PR TITLE
Use the right branch for sphinx_multiversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docs = [
     "Sphinx>=5.3.0,<5.4",
     "sphinx-gallery>=0.11.0,<0.12",
     "furo>=2022.9.29,<2023.0.0",
-    "sphinx-multiversion@git+https://github.com/dls-controls/sphinx-multiversion#egg=only-arg",
+    "sphinx-multiversion@git+https://github.com/dls-controls/sphinx-multiversion@only-arg#egg=only-arg",
     "numpydoc>=1.5.0,<1.6",
     "julearn==0.2.5"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docs = [
     "Sphinx>=5.3.0,<5.4",
     "sphinx-gallery>=0.11.0,<0.12",
     "furo>=2022.9.29,<2023.0.0",
-    "sphinx-multiversion@git+https://github.com/dls-controls/sphinx-multiversion.git#egg=only-arg",
+    "sphinx-multiversion@git+https://github.com/dls-controls/sphinx-multiversion#egg=only-arg",
     "numpydoc>=1.5.0,<1.6",
     "julearn==0.2.5"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docs = [
     "Sphinx>=5.3.0,<5.4",
     "sphinx-gallery>=0.11.0,<0.12",
     "furo>=2022.9.29,<2023.0.0",
-    "sphinx-multiversion>=0.2.4,<0.3",
+    "sphinx-multiversion@git+https://github.com/dls-controls/sphinx-multiversion.git#egg=only-arg",
     "numpydoc>=1.5.0,<1.6",
     "julearn==0.2.5"
 ]


### PR DESCRIPTION
Currently, docs are being built for all versions. This fix provides the right branch for sphinx_multiversion.