### PR TITLE
[ENH]: Several bug fixes

### DIFF
--- a/docs/changes/newsfragments/185.bugfix
+++ b/docs/changes/newsfragments/185.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in which fitting a marker (e.g. ``SphereAggregation``) on a specific type (e.g.: ``BOLD``) will fail if another non-supported type (e.g.: ``BOLD_confounds``) is present in the data object by `Fede Raimondo`_

--- a/docs/changes/newsfragments/185.enh
+++ b/docs/changes/newsfragments/185.enh
@@ -1,0 +1,1 @@
+Improved logging output for preprocessing, collecting and pipeline building from YAML by `Fede Raimondo`_

--- a/docs/changes/newsfragments/201.enh
+++ b/docs/changes/newsfragments/201.enh
@@ -1,1 +1,1 @@
-Force datalad to be non-interactive on _queued_ jobs by `Fede Raimondo`_
+Force datalad to be non-interactive on *queued* jobs by `Fede Raimondo`_

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -512,17 +512,21 @@ def _queue_condor(
             )
         if collect == "yes":
             dag_file.write(f"FINAL collect {submit_collect_fname}\n")
-            dag_file.write("SCRIPT PRE collect collect_pre.pl $DAG_STATUS\n")
-            collect_pre_fname = jobdir / "collect_pre.pl"
+            collect_pre_fname = jobdir / "collect_pre.sh"
+            dag_file.write(
+                f"SCRIPT PRE collect {collect_pre_fname.as_posix()} "
+                "$DAG_STATUS\n")
             with open(collect_pre_fname, "w") as pre_file:
-                pre_file.write("#!/usr/bin/env perl\n\n")
-                pre_file.write("if ($ARGV[0] eq 4) {\n")
-                pre_file.write("    exit(1);\n")
-                pre_file.write("}\n")
+                pre_file.write("#!/bin/bash\n\n")
+                pre_file.write("if [ \"${1}\" == \"4\" ]; then\n")
+                pre_file.write("    exit 1\n")
+                pre_file.write("fi\n")
+
+            make_executable(collect_pre_fname)
         elif collect == "on_success_only":
             dag_file.write(f"JOB collect {submit_collect_fname}\n")
             dag_file.write("PARENT ")
-            for i_job, _t_elem in enumerate(elements):
+            for i_job, _ in enumerate(elements):
                 dag_file.write(f"run{i_job} ")
             dag_file.write("CHILD collect\n\n")
 

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -755,9 +755,14 @@ def test_queue_condor_assets_generation(
 
             if has_final_collect_job is True:
                 pre_collect_fname = Path(
-                    tmp_path / "junifer_jobs" / jobname / "collect_pre.pl"
+                    tmp_path / "junifer_jobs" / jobname / "collect_pre.sh"
                 )
                 assert pre_collect_fname.exists()
+                assert (
+                    stat.S_IMODE(pre_collect_fname.stat().st_mode)
+                    & stat.S_IEXEC
+                    != 0
+                )
 
             # Check submit log
             assert (

--- a/junifer/datagrabber/datalad_base.py
+++ b/junifer/datagrabber/datalad_base.py
@@ -72,7 +72,7 @@ class DataladDataGrabber(BaseDataGrabber):
         **kwargs,
     ):
         if datadir is None:
-            logger.warning("`datadir` is None, creating a temporary directory")
+            logger.info("`datadir` is None, creating a temporary directory")
             # Create temporary directory
             tmpdir = Path(tempfile.mkdtemp())
             datadir = tmpdir / "datadir"

--- a/junifer/datareader/default.py
+++ b/junifer/datareader/default.py
@@ -34,7 +34,7 @@ _readers["TSV"] = {"func": pd.read_csv, "params": {"sep": "\t"}}
 class DefaultDataReader(PipelineStepMixin, UpdateMetaMixin):
     """Mixin class for default data reader."""
 
-    def validate_input(self, input: List[str]) -> None:
+    def validate_input(self, input: List[str]) -> List[str]:
         """Validate input.
 
         Parameters
@@ -43,9 +43,14 @@ class DefaultDataReader(PipelineStepMixin, UpdateMetaMixin):
             The input to the pipeline step. The list must contain the
             available Junifer Data dictionary keys.
 
+        Returns
+        -------
+        list of str
+            The actual elements of the input that will be processed by this
+            pipeline step.
         """
         # Nothing to validate, any input is fine
-        pass
+        return input
 
     def get_output_type(self, input: List[str]) -> List[str]:
         """Get output type.

--- a/junifer/datareader/tests/test_default_reader.py
+++ b/junifer/datareader/tests/test_default_reader.py
@@ -29,7 +29,7 @@ def test_validation(type_) -> None:
 
     """
     reader = DefaultDataReader()
-    assert reader.validate_input(type_) is None
+    assert reader.validate_input(type_) == type_
     assert reader.get_output_type(type_) == type_
     assert reader.validate(type_) == type_
 

--- a/junifer/markers/base.py
+++ b/junifer/markers/base.py
@@ -58,7 +58,7 @@ class BaseMarker(ABC, PipelineStepMixin, UpdateMetaMixin):
             klass=NotImplementedError,
         )
 
-    def validate_input(self, input: List[str]) -> None:
+    def validate_input(self, input: List[str]) -> List[str]:
         """Validate input.
 
         Parameters
@@ -66,6 +66,12 @@ class BaseMarker(ABC, PipelineStepMixin, UpdateMetaMixin):
         input : list of str
             The input to the pipeline step. The list must contain the
             available Junifer Data dictionary keys.
+
+        Returns
+        -------
+        list of str
+            The actual elements of the input that will be processed by this
+            pipeline step.
 
         Raises
         ------
@@ -79,6 +85,7 @@ class BaseMarker(ABC, PipelineStepMixin, UpdateMetaMixin):
                 f"\t Input: {input}"
                 f"\t Required (any of): {self._on}"
             )
+        return [x for x in self._on if x in input]
 
     @abstractmethod
     def get_output_type(self, input_type: str) -> str:

--- a/junifer/markers/tests/test_markers_base.py
+++ b/junifer/markers/tests/test_markers_base.py
@@ -58,6 +58,8 @@ def test_base_marker_subclassing() -> None:
     with pytest.raises(ValueError, match="not have the required data"):
         marker.validate_input(["T1w"])
 
+    assert marker.validate_input(["BOLD", "Other"]) == ["BOLD"]
+
     output = marker.fit_transform(input=input_)  # process
     # Check output
     assert "BOLD" in output

--- a/junifer/markers/tests/test_markers_base.py
+++ b/junifer/markers/tests/test_markers_base.py
@@ -27,7 +27,9 @@ def test_base_marker_subclassing() -> None:
             return ["BOLD", "T1w"]
 
         def get_output_type(self, input):
-            return ["timeseries"]
+            if input == "BOLD":
+                return "timeseries"
+            raise ValueError(f"Cannot compute output type for {input}")
 
         def compute(self, input, extra_input):
             return {
@@ -75,3 +77,30 @@ def test_base_marker_subclassing() -> None:
 
     # Check attributes
     assert marker.name == "MyBaseMarker"
+
+    # Add one extra input that will not be used to compute
+    input_ = {
+        "BOLD": {
+            "path": ".",
+            "data": "data",
+            "meta": {
+                "datagrabber": "dg",
+                "element": "elem",
+                "datareader": "dr",
+            },
+        },
+        "T2": {
+            "path": ".",
+            "data": "data",
+            "meta": {
+                "datagrabber": "dg",
+                "element": "elem",
+                "datareader": "dr",
+            },
+        }
+    }
+    marker = MyBaseMarker(on=["BOLD"])
+    output = marker.fit_transform(input=input_)  # process
+    # Check output
+    assert "BOLD" in output
+    assert "T2" not in output

--- a/junifer/pipeline/pipeline_step_mixin.py
+++ b/junifer/pipeline/pipeline_step_mixin.py
@@ -20,7 +20,7 @@ from .utils import check_ext_dependencies
 class PipelineStepMixin:
     """Mixin class for a pipeline step."""
 
-    def validate_input(self, input: List[str]) -> None:
+    def validate_input(self, input: List[str]) -> List[str]:
         """Validate the input to the pipeline step.
 
         Parameters
@@ -28,6 +28,12 @@ class PipelineStepMixin:
         input : list of str
             The input to the pipeline step. The list must contain the
             available Junifer Data dictionary keys.
+
+        Returns
+        -------
+        list of str
+            The actual elements of the input that will be processed by this
+            pipeline step.
 
         Raises
         ------
@@ -132,10 +138,7 @@ class PipelineStepMixin:
                     # Set attribute for using external tools
                     setattr(self, f"use_{dependency['name']}", out)
 
-        self.validate_input(input=input)
-        fit_input = input
-        if hasattr(self, "_on"):
-            fit_input = [i for i in input if i in getattr(self, "_on")]
+        fit_input = self.validate_input(input=input)
         outputs = [self.get_output_type(t_input) for t_input in fit_input]
         return outputs
 

--- a/junifer/pipeline/pipeline_step_mixin.py
+++ b/junifer/pipeline/pipeline_step_mixin.py
@@ -133,7 +133,10 @@ class PipelineStepMixin:
                     setattr(self, f"use_{dependency['name']}", out)
 
         self.validate_input(input=input)
-        outputs = [self.get_output_type(t_input) for t_input in input]
+        fit_input = input
+        if hasattr(self, "_on"):
+            fit_input = [i for i in input if i in getattr(self, "_on")]
+        outputs = [self.get_output_type(t_input) for t_input in fit_input]
         return outputs
 
     def fit_transform(

--- a/junifer/pipeline/registry.py
+++ b/junifer/pipeline/registry.py
@@ -132,7 +132,10 @@ def build(
     if init_params is None:
         init_params = {}
     # Get class of the registered function
+    logger.debug(f"Building {step}/{name}")
     klass = get_class(step=step, name=name)
+    logger.debug(f"\tClass: {klass.__name__}")
+    logger.debug(f"\tInit params: {init_params}")
     # Create instance of the class
     object_ = klass(**init_params)
     # Verify created instance belongs to the base class

--- a/junifer/pipeline/registry.py
+++ b/junifer/pipeline/registry.py
@@ -136,8 +136,18 @@ def build(
     klass = get_class(step=step, name=name)
     logger.debug(f"\tClass: {klass.__name__}")
     logger.debug(f"\tInit params: {init_params}")
-    # Create instance of the class
-    object_ = klass(**init_params)
+    try:
+        # Create instance of the class
+        object_ = klass(**init_params)
+    except Exception as e:
+        raise_error(
+            msg=(
+                f"Failed to create {step} ({name}). "
+                f"Error: {e}"
+            ),
+            klass=RuntimeError,
+            exception=e,
+        )
     # Verify created instance belongs to the base class
     if not isinstance(object_, baseclass):
         raise_error(

--- a/junifer/pipeline/tests/test_pipeline_step_mixin.py
+++ b/junifer/pipeline/tests/test_pipeline_step_mixin.py
@@ -32,8 +32,8 @@ def test_pipeline_step_mixin_validate_correct_dependencies() -> None:
 
         _DEPENDENCIES = {"setuptools"}
 
-        def validate_input(self, input: List[str]) -> None:
-            print(input)
+        def validate_input(self, input: List[str]) -> List[str]:
+            return input
 
         def get_output_type(self, input_type: str) -> str:
             return input_type
@@ -53,8 +53,8 @@ def test_pipeline_step_mixin_validate_incorrect_dependencies() -> None:
 
         _DEPENDENCIES = {"foobar"}
 
-        def validate_input(self, input: List[str]) -> None:
-            print(input)
+        def validate_input(self, input: List[str]) -> List[str]:
+            return input
 
         def get_output_type(self, input_type: str) -> str:
             return input_type
@@ -78,8 +78,8 @@ def test_pipeline_step_mixin_validate_correct_ext_dependencies() -> None:
 
         _EXT_DEPENDENCIES = [{"name": "afni", "optional": False}]
 
-        def validate_input(self, input: List[str]) -> None:
-            print(input)
+        def validate_input(self, input: List[str]) -> List[str]:
+            return input
 
         def get_output_type(self, input_type: str) -> str:
             return input_type
@@ -104,8 +104,8 @@ def test_pipeline_step_mixin_validate_ext_deps_correct_commands() -> None:
             {"name": "afni", "optional": False, "commands": ["3dReHo"]}
         ]
 
-        def validate_input(self, input: List[str]) -> None:
-            print(input)
+        def validate_input(self, input: List[str]) -> List[str]:
+            return input
 
         def get_output_type(self, input_type: str) -> str:
             return input_type
@@ -132,8 +132,8 @@ def test_pipeline_step_mixin_validate_ext_deps_incorrect_commands() -> None:
             {"name": "afni", "optional": False, "commands": ["3d"]}
         ]
 
-        def validate_input(self, input: List[str]) -> None:
-            print(input)
+        def validate_input(self, input: List[str]) -> List[str]:
+            return input
 
         def get_output_type(self, input_type: str) -> str:
             return input_type
@@ -154,8 +154,8 @@ def test_pipeline_step_mixin_validate_incorrect_ext_dependencies() -> None:
 
         _EXT_DEPENDENCIES = [{"name": "foobar", "optional": True}]
 
-        def validate_input(self, input: List[str]) -> None:
-            print(input)
+        def validate_input(self, input: List[str]) -> List[str]:
+            return input
 
         def get_output_type(self, input_type: str) -> str:
             return input_type

--- a/junifer/pipeline/tests/test_registry.py
+++ b/junifer/pipeline/tests/test_registry.py
@@ -139,3 +139,12 @@ def test_build():
     # Check error
     with pytest.raises(ValueError, match="Must inherit"):
         build(step="datagrabber", name="concrete", baseclass=np.ndarray)
+
+    # Check error
+    with pytest.raises(RuntimeError, match="Failed to create"):
+        build(
+            step="datagrabber",
+            name="concrete",
+            baseclass=SuperClass,
+            init_params={"wrong": 2},
+        )

--- a/junifer/preprocess/base.py
+++ b/junifer/preprocess/base.py
@@ -36,7 +36,7 @@ class BasePreprocessor(ABC, PipelineStepMixin, UpdateMetaMixin):
             raise ValueError(f"{name} cannot be computed on {wrong_on}")
         self._on = on
 
-    def validate_input(self, input: List[str]) -> None:
+    def validate_input(self, input: List[str]) -> List[str]:
         """Validate input.
 
         Parameters
@@ -44,6 +44,12 @@ class BasePreprocessor(ABC, PipelineStepMixin, UpdateMetaMixin):
         input : list of str
             The input to the pipeline step. The list must contain the
             available Junifer Data dictionary keys.
+
+        Returns
+        -------
+        list of str
+            The actual elements of the input that will be processed by this
+            pipeline step.
 
         Raises
         ------
@@ -56,6 +62,7 @@ class BasePreprocessor(ABC, PipelineStepMixin, UpdateMetaMixin):
                 f"\t Input: {input}"
                 f"\t Required (any of): {self._on}"
             )
+        return [x for x in self._on if x in input]
 
     @abstractmethod
     def get_output_type(self, input: List[str]) -> List[str]:

--- a/junifer/preprocess/base.py
+++ b/junifer/preprocess/base.py
@@ -113,22 +113,27 @@ class BasePreprocessor(ABC, PipelineStepMixin, UpdateMetaMixin):
         out = input
         for type_ in self._on:
             if type_ in input.keys():
-                logger.info(f"Computing {type_}")
+                logger.info(f"Preprocessing {type_}")
                 t_input = input[type_]
 
                 # Pass the other data types as extra input, removing
                 # the current type
                 extra_input = input
                 extra_input.pop(type_)
+                logger.debug(
+                    f"Extra input for preprocess: {extra_input.keys()}"
+                )
                 key, t_out = self.preprocess(
                     input=t_input, extra_input=extra_input
                 )
 
                 # Add the output to the Junifer Data object
+                logger.debug(f"Adding {key} to output")
                 out[key] = t_out
 
                 # In case we are creating a new type, re-add the original input
                 if key != type_:
+                    logger.debug("Adding original input back to output")
                     out[type_] = t_input
 
                 self.update_meta(out[key], "preprocess")

--- a/junifer/preprocess/confounds/fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/fmriprep_confound_remover.py
@@ -200,7 +200,7 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
             )
         super().__init__()
 
-    def validate_input(self, input: List[str]) -> None:
+    def validate_input(self, input: List[str]) -> List[str]:
         """Validate the input to the pipeline step.
 
         Parameters
@@ -208,6 +208,11 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
         input : list of str
             The input to the pipeline step. The list must contain the
             available Junifer Data object keys.
+        Returns
+        -------
+        list of str
+            The actual elements of the input that will be processed by this
+            pipeline step.
 
         Raises
         ------
@@ -223,6 +228,8 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
                 f"Required (all off): {_required_inputs} \n",
                 klass=ValueError,
             )
+
+        return [x for x in self._on if x in input]
 
     def get_output_type(self, input: List[str]) -> List[str]:
         """Get the kind of the pipeline step.

--- a/junifer/storage/hdf5.py
+++ b/junifer/storage/hdf5.py
@@ -940,6 +940,14 @@ class HDF5FeatureStorage(BaseFeatureStorage):
             f"{self.uri.parent}/*_{self.uri.name}"  # type: ignore
         )
         logger.info(f"Will collect {len(elements_per_feature_md5)} features.")
+
+        # Print info before to avoid tqdm progress bar interference
+        for feature_md5, element_files in elements_per_feature_md5.items():
+            logger.info(
+                f"Collecting {len(element_files)} files for feature MD5: "
+                f"{feature_md5}."
+            )
+
         for feature_md5, element_files in tqdm(
             elements_per_feature_md5.items(), desc="feature"
         ):


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

This PR addresses several issues:

- [X] Better logging for pre-processing

The fmriPrepConfound remover and preprocessing in general do not have a good logging:

```
2023-03-14 21:52:18,428 - JUNIFER - INFO - Preprocessing data
2023-03-14 21:52:18,428 - JUNIFER - INFO - Computing BOLD
```

For example, it should say "Preprocessing BOLD"

And even in DEBUG mode, the messages are not verbose, so it might get stuck and we don't know where.

- [X] Better INFO logging for collect:

This is the current output:
```
2023-03-29 22:57:24,256 - JUNIFER - INFO - Parsing yaml file: /home/fraimondo/dev/projects/brain_size/1_compute_features/junifer_jobs/FCness_HCP_epi_brain_10mm/config.yaml
2023-03-29 22:57:24,260 - JUNIFER - INFO - Registering HCPCATConfounds in datagrabber
2023-03-29 22:57:24,260 - JUNIFER - INFO - Registering MultipleHCP in datagrabber
2023-03-29 22:57:24,261 - JUNIFER - INFO - Registering FCness in marker
2023-03-29 22:57:24,261 - JUNIFER - INFO - Collecting data using HDF5FeatureStorage
2023-03-29 22:57:24,326 - JUNIFER - INFO - Collecting metadata from /data/project/SPP2041/results/fraimondo/brain_size_project/storage/HCP_epi_brain_mask_fcness_10mm/*_HCP_epi_brain_mask_fcness_10mm.hdf5
2023-03-29 22:57:32,277 - JUNIFER - INFO - Writing metadata to HDF5 file ...
2023-03-29 22:57:32,280 - JUNIFER - INFO - Collecting data from /data/project/SPP2041/results/fraimondo/brain_size_project/storage/HCP_epi_brain_mask_fcness_10mm/*_HCP_epi_brain_mask_fcness_10mm.hdf5
2023-03-29 22:57:32,280 - JUNIFER - INFO - Will collect 2 features.
2023-03-29 23:07:10,247 - JUNIFER - INFO - Collect done
```

- [X] Better logging to the `build` function of the registry.

If a parameter is bad in the yaml (wrong argument name) this will currently fail with an uncaught exception in the `build` function in the registry.

Solution: log the parameters (class, args) and catch the exception if something fails.

- [X] Bug in which fitting a marker (e.g. SphereAggregation) on a specific type (e.g.: BOLD) will fail if another non-supported type (e.g.: BOLD_confounds) is present in the data object.

Solution: Modify `validate_input` so it returns the actual input in which the marker will be applied. Then this can be used by the `validate` function in `PipelineStepMixin` to send it to `get_output_type`.
