### PR TITLE
[ENH]: Add missing decorators for `BaseMarker` and `BasePreprocessor`

### DIFF
--- a/docs/changes/newsfragments/214.enh
+++ b/docs/changes/newsfragments/214.enh
@@ -1,0 +1,1 @@
+Add missing ``abstractmethod`` decorators for ``get_valid_inputs`` methods of :class:`junifer.markers.BaseMarker` and :class:`junifer.preprocess.BasePreprocessor`.

--- a/docs/changes/newsfragments/214.enh
+++ b/docs/changes/newsfragments/214.enh
@@ -1,1 +1,1 @@
-Add missing ``abstractmethod`` decorators for ``get_valid_inputs`` methods of :class:`junifer.markers.BaseMarker` and :class:`junifer.preprocess.BasePreprocessor`.
+Add missing ``abstractmethod`` decorators for ``get_valid_inputs`` methods of :class:`junifer.markers.BaseMarker` and :class:`junifer.preprocess.BasePreprocessor` by `Synchon Mandal`_

--- a/junifer/markers/base.py
+++ b/junifer/markers/base.py
@@ -45,6 +45,7 @@ class BaseMarker(ABC, PipelineStepMixin, UpdateMetaMixin):
             raise ValueError(f"{self.name} cannot be computed on {wrong_on}")
         self._on = on
 
+    @abstractmethod
     def get_valid_inputs(self) -> List[str]:
         """Get valid data types for input.
 

--- a/junifer/preprocess/base.py
+++ b/junifer/preprocess/base.py
@@ -79,6 +79,7 @@ class BasePreprocessor(ABC, PipelineStepMixin, UpdateMetaMixin):
             klass=NotImplementedError,
         )
 
+    @abstractmethod
     def get_valid_inputs(self) -> List[str]:
         """Get valid data types for input.
 


### PR DESCRIPTION
* [ ] fix #(issue number)
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds missing `abstractmethod` decorators for `get_valid_inputs` methods of `BaseMarker` and `BasePreprocessor`.