### PR TITLE
[FIX]: Make timeseries output 2D for `RSSETSMarker`

### DIFF
--- a/docs/changes/newsfragments/215.bugfix
+++ b/docs/changes/newsfragments/215.bugfix
@@ -1,0 +1,1 @@
+Fix the output of :class:`junifer.markers.RSSETSMarker` to be 2D by `Synchon Mandal`_

--- a/junifer/markers/ets_rss.py
+++ b/junifer/markers/ets_rss.py
@@ -133,6 +133,8 @@ class RSSETSMarker(BaseMarker):
         edge_ts, _ = _ets(out["data"])
         # Compute the RSS
         out["data"] = np.sum(edge_ts**2, 1) ** 0.5
+        # Make it 2D
+        out["data"] = out["data"][:, np.newaxis]
         # Set correct column label
         out["col_names"] = ["root_sum_of_squares_ets"]
         return out


### PR DESCRIPTION
* [ ] fix #(issue number)
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR makes the `RSSETSMarker.compute()` output 2D instead of 1D.