### PR TITLE
[BUG]: Storage URI in yaml config does not behave as I would expect.

### DIFF
--- a/docs/changes/newsfragments/127.bugfix
+++ b/docs/changes/newsfragments/127.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in which relative storage URIs will be computed relative to the CWD and not to the location of the YAML file by `Fede Raimondo`_.

--- a/junifer/api/parser.py
+++ b/junifer/api/parser.py
@@ -71,4 +71,5 @@ def parse_yaml(filepath: Union[str, Path]) -> Dict:
                 logger.info(f"Importing module: {t_module}")
                 importlib.import_module(t_module)
 
+    # Compute path for the URI parameter in storage files that are relative
     return contents

--- a/junifer/api/parser.py
+++ b/junifer/api/parser.py
@@ -72,4 +72,21 @@ def parse_yaml(filepath: Union[str, Path]) -> Dict:
                 importlib.import_module(t_module)
 
     # Compute path for the URI parameter in storage files that are relative
+    # This is a tricky thing that appeared in #127. The problem is that
+    # the path in the URI parameter is relative to YAML file, not to the
+    # current working directory. If we leave it as is in the contents
+    # dict, then it will be used later in the ``build`` function as is,
+    # which will be computed relative to the current working directory.
+    # The solution is to compute the absolute path and replace the
+    # relative path in the contents dict with the absolute path.
+
+    # Check if the storage file is defined
+    if "storage" in contents:
+        if "uri" in contents["storage"]:
+            # Check if the storage file is relative
+            uri_path = Path(contents["storage"]["uri"])
+            if not uri_path.is_absolute():
+                # Compute the absolute path
+                contents["storage"]["uri"] = str(
+                    (filepath.parent / uri_path).resolve())
     return contents

--- a/junifer/api/parser.py
+++ b/junifer/api/parser.py
@@ -88,5 +88,6 @@ def parse_yaml(filepath: Union[str, Path]) -> Dict:
             if not uri_path.is_absolute():
                 # Compute the absolute path
                 contents["storage"]["uri"] = str(
-                    (filepath.parent / uri_path).resolve())
+                    (filepath.parent / uri_path).resolve()
+                )
     return contents

--- a/junifer/api/tests/test_parser.py
+++ b/junifer/api/tests/test_parser.py
@@ -77,6 +77,28 @@ def test_parse_yaml_failure_with_multi_module_autoload(tmp_path: Path) -> None:
         parse_yaml(fname)
 
 
+def test_parse_yaml_with_wrong_path(tmp_path: Path) -> None:
+    """Test YAML parsing with wrong paths in with.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    t_tmp_path = tmp_path / "test_relative_with"
+    # Write yaml that includes a relative path
+    yaml_path = t_tmp_path / "yamls"
+    yaml_path.mkdir(exist_ok=True, parents=True)
+    yaml_fname = yaml_path / "test_parse_yaml_wrong_path.yaml"
+
+    yaml_fname.write_text("foo: bar\nwith:\n  -  missingt.py\n  - scipy\n")
+
+    # Check test file
+    with pytest.raises(ValueError, match="does not exist"):
+        parse_yaml(yaml_fname)
+
+
 def test_parse_yaml_relative_path(tmp_path: Path) -> None:
     """Test YAML parsing with relative paths in with.
 
@@ -181,3 +203,12 @@ def test_parse_storage_uri_relative(tmp_path: Path) -> None:
     assert "storage" in contents
     assert "uri" in contents["storage"]
     assert contents["storage"]["uri"] == "/absolute/test.db"
+
+    # Just to trick coverage
+    fname = tmp_path / "test_parse_yaml_with_storage_uri.yaml"
+    fname.write_text("foo: bar\nwith: numpy\nstorage:\n  kind: SomeStorage\n")
+
+    contents = parse_yaml(fname)
+    assert "foo" in contents
+    assert contents["foo"] == "bar"
+    assert "storage" in contents

--- a/junifer/api/tests/test_parser.py
+++ b/junifer/api/tests/test_parser.py
@@ -147,9 +147,7 @@ def test_parse_storage_uri_relative(tmp_path: Path) -> None:
 
     """
     fname = tmp_path / "test_parse_yaml_with_storage_uri.yaml"
-    fname.write_text(
-        "foo: bar\nwith: numpy\nstorage:\n  uri: test.db\n"
-    )
+    fname.write_text("foo: bar\nwith: numpy\nstorage:\n  uri: test.db\n")
 
     contents = parse_yaml(fname)
     assert "foo" in contents
@@ -169,7 +167,8 @@ def test_parse_storage_uri_relative(tmp_path: Path) -> None:
     assert "storage" in contents
     assert "uri" in contents["storage"]
     assert contents["storage"]["uri"] == str(
-        (tmp_path / "../another/test.db").resolve())
+        (tmp_path / "../another/test.db").resolve()
+    )
 
     fname = tmp_path / "test_parse_yaml_with_storage_uri.yaml"
     fname.write_text(

--- a/junifer/api/tests/test_parser.py
+++ b/junifer/api/tests/test_parser.py
@@ -135,3 +135,50 @@ def test_parse_yaml_absolute_path(tmp_path: Path) -> None:
 
     # Check test file
     parse_yaml(yaml_fname)
+
+
+def test_parse_storage_uri_relative(tmp_path: Path) -> None:
+    """Test YAML parsing with storage and relative URI.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    fname = tmp_path / "test_parse_yaml_with_storage_uri.yaml"
+    fname.write_text(
+        "foo: bar\nwith: numpy\nstorage:\n  uri: test.db\n"
+    )
+
+    contents = parse_yaml(fname)
+    assert "foo" in contents
+    assert contents["foo"] == "bar"
+    assert "storage" in contents
+    assert "uri" in contents["storage"]
+    assert contents["storage"]["uri"] == str(tmp_path / "test.db")
+
+    fname = tmp_path / "test_parse_yaml_with_storage_uri.yaml"
+    fname.write_text(
+        "foo: bar\nwith: numpy\nstorage:\n  uri: ../another/test.db\n"
+    )
+
+    contents = parse_yaml(fname)
+    assert "foo" in contents
+    assert contents["foo"] == "bar"
+    assert "storage" in contents
+    assert "uri" in contents["storage"]
+    assert contents["storage"]["uri"] == str(
+        (tmp_path / "../another/test.db").resolve())
+
+    fname = tmp_path / "test_parse_yaml_with_storage_uri.yaml"
+    fname.write_text(
+        "foo: bar\nwith: numpy\nstorage:\n  uri: /absolute/test.db\n"
+    )
+
+    contents = parse_yaml(fname)
+    assert "foo" in contents
+    assert contents["foo"] == "bar"
+    assert "storage" in contents
+    assert "uri" in contents["storage"]
+    assert contents["storage"]["uri"] == "/absolute/test.db"


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

I use this yaml file:

```
workdir: /tmp

datagrabber:
    kind: DataladAOMICPIOP1
    tasks: "restingstate"
markers:
  - name: Schaefer100x17_FC
    kind: FunctionalConnectivityParcels
    parcellation: Schaefer100x17
    cor_method: correlation
storage: 
  kind: SQLiteFeatureStorage
  uri: ../storage/PIOP1
queue:
  jobname: TestHTCondorQueue
  kind: HTCondor
  env:
    kind: conda
    name: junifer
  mem: 8G
```

I would expect that the storage uri is interpreted relative from the directory where I run `junifer queue`, but it is interpreted relative to the cwd of the process.

### Expected Behavior

I think it will be more intuitive to interpret relative from the directory where i run the `junifer queue`, i.e. my "perceived working directory".

### Steps To Reproduce

Install junifer.

Use this yaml file and run `junifer queue`

```
workdir: /tmp

datagrabber:
    kind: DataladAOMICPIOP1
    tasks: "restingstate"
markers:
  - name: Schaefer100x17_FC
    kind: FunctionalConnectivityParcels
    parcellation: Schaefer100x17
    cor_method: correlation
storage: 
  kind: SQLiteFeatureStorage
  uri: ../storage/PIOP1
queue:
  jobname: TestHTCondorQueue
  kind: HTCondor
  env:
    kind: conda
    name: junifer
  mem: 8G
```

### Environment

```markdown
❱ junifer wtf
junifer:
  version: 0.0.1.dev909
python:
  version: 3.10.6
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.22.4
  datalad: 0.17.9
  pandas: 1.4.4
  nibabel: 4.0.2
  nilearn: 0.9.2
  sqlalchemy: 1.4.44
  yaml: '6.0'
system:
  platform: Linux-4.19.0-21-amd64-x86_64-with-glibc2.28
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: /home/lsasse/miniconda3/envs/junifer/bin:/home/lsasse/miniconda3/condabin:/home/lsasse/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games
```
```


### Relevant log output

_No response_

### Anything else?

_No response_