### PR TITLE
[BUG]: HCP1200 datagrabber does not provide the correct BOLD files

### DIFF
--- a/docs/changes/newsfragments/183.bugfix
+++ b/docs/changes/newsfragments/183.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in which only `REST1` and `REST2` tasks could be accesed in :class:`.DataladHCP1200` and :class:`.HCP1200` datagrabbers by `Fede Raimondo`_

--- a/docs/changes/newsfragments/183.bugfix
+++ b/docs/changes/newsfragments/183.bugfix
@@ -1,1 +1,1 @@
-Fix a bug in which only `REST1` and `REST2` tasks could be accesed in :class:`.DataladHCP1200` and :class:`.HCP1200` datagrabbers by `Fede Raimondo`_
+Fix a bug in which only ``REST1`` and ``REST2`` tasks could be accesed in :class:`.DataladHCP1200` and :class:`.HCP1200` datagrabbers by `Fede Raimondo`_

--- a/docs/changes/newsfragments/183.change
+++ b/docs/changes/newsfragments/183.change
@@ -1,0 +1,1 @@
+Add ``ica_fix`` parameter to :class:`.DataladHCP1200` and :class:`.HCP1200` datagrabbers to allow for selecting data processed with ICA+FIX. Default value is ``False`` which changes behaviour since 0.0.1 release. By `Fede Raimondo`_

--- a/junifer/datagrabber/hcp.py
+++ b/junifer/datagrabber/hcp.py
@@ -26,9 +26,12 @@ class HCP1200(PatternDataGrabber):
     phase_encodings : {"LR", "RL"} or list of the options, optional
         HCP phase encoding directions. If None, both will be used
         (default None).
+    icafix : bool, optional
+        Whether to use retrieve data that was processed with ICA+FIX.
+        Only 'REST1' and 'REST2' tasks are available with ICA+FIX (default
+        False).
     **kwargs
         Keyword arguments passed to superclass.
-
     """
 
     def __init__(
@@ -36,6 +39,7 @@ class HCP1200(PatternDataGrabber):
         datadir: Union[str, Path],
         tasks: Union[str, List[str], None] = None,
         phase_encodings: Union[str, List[str], None] = None,
+        ica_fix: bool = False,
         **kwargs,
     ) -> None:
         # All tasks
@@ -82,6 +86,12 @@ class HCP1200(PatternDataGrabber):
                     f"{all_phase_encodings}."
                 )
 
+        if ica_fix is True:
+            if not all([task in ["REST1", "REST2"] for task in self.tasks]):
+                raise_error(
+                    "ICA+FIX is only available for 'REST1' and 'REST2' tasks."
+                )
+        suffix = "_hp2000_clean" if ica_fix is True else ""
         # The types of data
         types = ["BOLD"]
         # The patterns
@@ -89,7 +99,8 @@ class HCP1200(PatternDataGrabber):
             "BOLD": (
                 "{subject}/MNINonLinear/Results/"
                 "{task}_{phase_encoding}/"
-                "{task}_{phase_encoding}_hp2000_clean.nii.gz"
+                "{task}_{phase_encoding}"
+                f"{suffix}.nii.gz"
             )
         }
         # The replacements
@@ -173,6 +184,10 @@ class DataladHCP1200(DataladDataGrabber, HCP1200):
     phase_encodings : {"LR", "RL"} or list of the options, optional
         HCP phase encoding directions. If None, both will be used
         (default None).
+    icafix : bool, optional
+        Whether to use retrieve data that was processed with ICA+FIX.
+        Only 'REST1' and 'REST2' tasks are available with ICA+FIX (default
+        False).
     """
 
     def __init__(
@@ -180,6 +195,7 @@ class DataladHCP1200(DataladDataGrabber, HCP1200):
         datadir: Union[str, Path, None] = None,
         tasks: Union[str, List[str], None] = None,
         phase_encodings: Union[str, List[str], None] = None,
+        ica_fix: bool = False,
     ) -> None:
         uri = (
             "https://github.com/datalad-datasets/"
@@ -192,6 +208,7 @@ class DataladHCP1200(DataladDataGrabber, HCP1200):
             phase_encodings=phase_encodings,
             uri=uri,
             rootdir=rootdir,
+            ica_fix=ica_fix,
         )
 
     @property

--- a/junifer/datagrabber/hcp.py
+++ b/junifer/datagrabber/hcp.py
@@ -26,7 +26,7 @@ class HCP1200(PatternDataGrabber):
     phase_encodings : {"LR", "RL"} or list of the options, optional
         HCP phase encoding directions. If None, both will be used
         (default None).
-    icafix : bool, optional
+    ica_fix : bool, optional
         Whether to retrieve data that was processed with ICA+FIX.
         Only 'REST1' and 'REST2' tasks are available with ICA+FIX (default
         False).

--- a/junifer/datagrabber/hcp.py
+++ b/junifer/datagrabber/hcp.py
@@ -27,7 +27,7 @@ class HCP1200(PatternDataGrabber):
         HCP phase encoding directions. If None, both will be used
         (default None).
     icafix : bool, optional
-        Whether to use retrieve data that was processed with ICA+FIX.
+        Whether to retrieve data that was processed with ICA+FIX.
         Only 'REST1' and 'REST2' tasks are available with ICA+FIX (default
         False).
     **kwargs
@@ -86,12 +86,12 @@ class HCP1200(PatternDataGrabber):
                     f"{all_phase_encodings}."
                 )
 
-        if ica_fix is True:
+        if ica_fix:
             if not all([task in ["REST1", "REST2"] for task in self.tasks]):
                 raise_error(
                     "ICA+FIX is only available for 'REST1' and 'REST2' tasks."
                 )
-        suffix = "_hp2000_clean" if ica_fix is True else ""
+        suffix = "_hp2000_clean" if ica_fix else ""
         # The types of data
         types = ["BOLD"]
         # The patterns
@@ -184,8 +184,8 @@ class DataladHCP1200(DataladDataGrabber, HCP1200):
     phase_encodings : {"LR", "RL"} or list of the options, optional
         HCP phase encoding directions. If None, both will be used
         (default None).
-    icafix : bool, optional
-        Whether to use retrieve data that was processed with ICA+FIX.
+    ica_fix : bool, optional
+        Whether to retrieve data that was processed with ICA+FIX.
         Only 'REST1' and 'REST2' tasks are available with ICA+FIX (default
         False).
     """

--- a/junifer/datagrabber/tests/test_hcp.py
+++ b/junifer/datagrabber/tests/test_hcp.py
@@ -29,33 +29,38 @@ def hcpdg() -> Iterable[DataladHCP1200]:
 
 
 @pytest.mark.parametrize(
-    "tasks, phase_encodings, expected_path_name",
+    "tasks, phase_encodings, ica_fix, expected_path_name",
     [
-        (None, None, "rfMRI_REST1_LR_hp2000_clean.nii.gz"),
-        ("REST1", "LR", "rfMRI_REST1_LR_hp2000_clean.nii.gz"),
-        ("REST1", "RL", "rfMRI_REST1_RL_hp2000_clean.nii.gz"),
-        ("REST2", "LR", "rfMRI_REST2_LR_hp2000_clean.nii.gz"),
-        ("REST2", "RL", "rfMRI_REST2_RL_hp2000_clean.nii.gz"),
-        ("SOCIAL", "LR", "tfMRI_SOCIAL_LR_hp2000_clean.nii.gz"),
-        ("SOCIAL", "RL", "tfMRI_SOCIAL_RL_hp2000_clean.nii.gz"),
-        ("WM", "LR", "tfMRI_WM_LR_hp2000_clean.nii.gz"),
-        ("WM", "RL", "tfMRI_WM_RL_hp2000_clean.nii.gz"),
-        ("RELATIONAL", "LR", "tfMRI_RELATIONAL_LR_hp2000_clean.nii.gz"),
-        ("RELATIONAL", "RL", "tfMRI_RELATIONAL_RL_hp2000_clean.nii.gz"),
-        ("EMOTION", "LR", "tfMRI_EMOTION_LR_hp2000_clean.nii.gz"),
-        ("EMOTION", "RL", "tfMRI_EMOTION_RL_hp2000_clean.nii.gz"),
-        ("LANGUAGE", "LR", "tfMRI_LANGUAGE_LR_hp2000_clean.nii.gz"),
-        ("LANGUAGE", "RL", "tfMRI_LANGUAGE_RL_hp2000_clean.nii.gz"),
-        ("GAMBLING", "LR", "tfMRI_GAMBLING_LR_hp2000_clean.nii.gz"),
-        ("GAMBLING", "RL", "tfMRI_GAMBLING_RL_hp2000_clean.nii.gz"),
-        ("MOTOR", "LR", "tfMRI_MOTOR_LR_hp2000_clean.nii.gz"),
-        ("MOTOR", "RL", "tfMRI_MOTOR_RL_hp2000_clean.nii.gz"),
+        (None, None, False, "rfMRI_REST1_LR.nii.gz"),
+        ("REST1", "LR", False, "rfMRI_REST1_LR.nii.gz"),
+        ("REST1", "RL", False, "rfMRI_REST1_RL.nii.gz"),
+        ("REST2", "LR", False, "rfMRI_REST2_LR.nii.gz"),
+        ("REST2", "RL", False, "rfMRI_REST2_RL.nii.gz"),
+        ("SOCIAL", "LR", False, "tfMRI_SOCIAL_LR.nii.gz"),
+        ("SOCIAL", "RL", False, "tfMRI_SOCIAL_RL.nii.gz"),
+        ("WM", "LR", False, "tfMRI_WM_LR.nii.gz"),
+        ("WM", "RL", False, "tfMRI_WM_RL.nii.gz"),
+        ("RELATIONAL", "LR", False, "tfMRI_RELATIONAL_LR.nii.gz"),
+        ("RELATIONAL", "RL", False, "tfMRI_RELATIONAL_RL.nii.gz"),
+        ("EMOTION", "LR", False, "tfMRI_EMOTION_LR.nii.gz"),
+        ("EMOTION", "RL", False, "tfMRI_EMOTION_RL.nii.gz"),
+        ("LANGUAGE", "LR", False, "tfMRI_LANGUAGE_LR.nii.gz"),
+        ("LANGUAGE", "RL", False, "tfMRI_LANGUAGE_RL.nii.gz"),
+        ("GAMBLING", "LR", False, "tfMRI_GAMBLING_LR.nii.gz"),
+        ("GAMBLING", "RL", False, "tfMRI_GAMBLING_RL.nii.gz"),
+        ("MOTOR", "LR", False, "tfMRI_MOTOR_LR.nii.gz"),
+        ("MOTOR", "RL", False, "tfMRI_MOTOR_RL.nii.gz"),
+        ("REST1", "LR", True, "rfMRI_REST1_LR_hp2000_clean.nii.gz"),
+        ("REST1", "RL", True, "rfMRI_REST1_RL_hp2000_clean.nii.gz"),
+        ("REST2", "LR", True, "rfMRI_REST2_LR_hp2000_clean.nii.gz"),
+        ("REST2", "RL", True, "rfMRI_REST2_RL_hp2000_clean.nii.gz"),
     ],
 )
 def test_hcp1200_datagrabber(
     hcpdg: DataladHCP1200,
     tasks: Optional[str],
     phase_encodings: Optional[str],
+    ica_fix: bool,
     expected_path_name: str,
 ) -> None:
     """Test HCP1200 datagrabber.
@@ -69,6 +74,8 @@ def test_hcp1200_datagrabber(
         The parametrized tasks.
     phase_encodings : str
         The parametrized phase encodings.
+    ica_fix : bool
+        The parametrized ICA-FIX flag.
     expected_path_name : str
         The parametrized expected path name.
 
@@ -78,6 +85,7 @@ def test_hcp1200_datagrabber(
         datadir=hcpdg.datadir,
         tasks=tasks,
         phase_encodings=phase_encodings,
+        ica_fix=ica_fix,
     )
     # Get all elements
     all_elements = dg.get_elements()
@@ -342,3 +350,38 @@ def test_hcp1200_datagrabber_elements(
             assert element[2] in ["LR", "RL"]
 
         assert set(found_subjects) == set(expected_subjects)
+
+
+@pytest.mark.parametrize(
+    "tasks, ica_fix",
+    [
+        ("SOCIAL", True),
+        ("WM", True),
+        ("RELATIONAL", True),
+        ("EMOTION", True),
+        ("LANGUAGE", True),
+        ("GAMBLING", True),
+        ("MOTOR", True),
+    ],
+)
+def test_hcp1200_datagrabber_incorrect_access_icafix(
+    tasks: Optional[str],
+    ica_fix: bool
+) -> None:
+    """Test HCP1200 datagrabber incorrect access for icafix.
+
+    Parameters
+    ----------
+    tasks : str
+        The parametrized tasks.
+    ica_fix : bool
+        The parametrized ICA-FIX flag.
+
+    """
+    configure_logging(level="DEBUG")
+    with pytest.raises(ValueError, match="is only available for"):
+        _ = HCP1200(
+            datadir=".",
+            tasks=tasks,
+            ica_fix=ica_fix,
+        )

--- a/tools/create_hcp1200_example_dataset.py
+++ b/tools/create_hcp1200_example_dataset.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         # Set base directory
         basedir = tmpdir_path / "example_hcp1200"
         # Create new datalad dataset
-        dataset = dl.create(path=str(basedir.absolute()))
+        dataset = dl.create(path=str(basedir.absolute()))  # type: ignore
         # Generate subject directories
         for sub in range(1, 10):
             subdir = basedir / f"sub-{sub:02d}"
@@ -57,14 +57,25 @@ if __name__ == "__main__":
                 )
                 # Create subject data directory
                 sub_datadir.mkdir(parents=True)
+
                 # Set subject data file
                 sub_datafile = (
                     sub_datadir
-                    / f"{new_task}_{phase_encoding}_hp2000_clean.nii.gz"
+                    / f"{new_task}_{phase_encoding}.nii.gz"
                 )
                 # Create subject data file
                 with open(sub_datafile, "w") as f:
                     f.write("placeholder")
+
+                if "REST" in task:
+                    # Set subject data file with ICA+FIX
+                    sub_datafile = (
+                        sub_datadir
+                        / f"{new_task}_{phase_encoding}_hp2000_clean.nii.gz"
+                    )
+                    # Create subject data file with ICA+FIX
+                    with open(sub_datafile, "w") as f:
+                        f.write("placeholder")
 
         # Save datalad dataset
         dataset.save(recursive=True)


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

HCP1200 preprocessed BOLD data has the ICA+FIX preprocessed data. By default, we are providing this as BOLD. However, this is only present in the REST task, so it fails to find the files from other tasks.

This also means that the testing dataset in GIN is wrong.

### Expected Behavior

The user should get the right files, even for NON REST tasks.

### Steps To Reproduce

1. Use the HCP1200 datagrabber with a task to get bold data.

### Environment

```markdown
junifer:
  version: 0.0.2.dev78
python:
  version: 3.11.0
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.23.4
  datalad: 0.17.9
  pandas: 1.5.1
  nibabel: 4.0.2
  nilearn: 0.9.2
  sqlalchemy: 1.4.43
  yaml: '6.0'
system:
  platform: macOS-13.1-x86_64-i386-64bit
environment:
  LC_CTYPE: UTF-8
  PATH: /Users/fraimondo/Applications/workbench/bin_macosx64:/Users/fraimondo/.rbenv/shims:/Users/fraimondo/dev/tbox/freesurfer/bin:/Users/fraimondo/dev/tbox/freesurfer/fsfast/bin:/Users/fraimondo/dev/tbox/fsl/bin:/Users/fraimondo/dev/tbox/freesurfer/mni/bin:/usr/local/opt/ruby/bin:/Users/fraimondo/miniconda3/envs/junifer/bin:/Users/fraimondo/miniconda3/condabin:/Users/fraimondo/dev/tbox/fsl/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/TeX/texbin:/opt/X11/bin:/Library/Apple/usr/bin:/Users/fraimondo/.platformio/penv/bin:/Users/fraimondo/gems/bin:/Users/fraimondo/.gem/ruby/3.0.0/bin:/Users/fraimondo/dev/tbox/junifer/junifer/api/res/afni
```


### Relevant log output

_No response_

### Anything else?

Proposed solution:

1) add a parameter to the HCP1200 datagrabber constructor (`ica_fix`) with a default of `False`.
2) in the suffix, if `ica_fix` is True, then add the `hp1200_clean` suffix to the filename, something like this

```Python
            suffix = "_hp2000_clean" if ica_fix is True else ""
            "BOLD": (
                "{subject}/MNINonLinear/Results/"
                "{task}_{phase_encoding}/"
                "{task}_{phase_encoding}{suffix}.nii.gz"
            )
```
3) Fix the HCP1200 testing dataset in gin to add the non hp1200_clean files and remove them from the non REST tasks.