### PR TITLE
[ENH]: Consistent `DataGrabber` naming in `testing`

### DIFF
--- a/docs/changes/newsfragments/222.change
+++ b/docs/changes/newsfragments/222.change
@@ -1,0 +1,1 @@
+Rename ``junifer.testing.datagrabbers.SPMAuditoryTestingDatagrabber`` to :class:`.SPMAuditoryTestingDataGrabber` and ``junifer.testing.datagrabbers.OasisVBMTestingDatagrabber`` to :class:`.OasisVBMTestingDataGrabber` by `Synchon Mandal`_

--- a/docs/changes/newsfragments/222.enh
+++ b/docs/changes/newsfragments/222.enh
@@ -1,0 +1,1 @@
+Rename instances of "Datagrabber" to "DataGrabber" especially in ``junifer.testing`` to be consistent by `Synchon Mandal`_

--- a/docs/understanding/data.rst
+++ b/docs/understanding/data.rst
@@ -26,12 +26,12 @@ step only contains information about the datagrabber used.
 
 .. code-block:: python
 
-   {'BOLD': {'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDatagrabber',
+   {'BOLD': {'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDataGrabber',
                                       'types': ['BOLD', 'T1w']},
                       'dependencies': set(),
                       'element': {'subject': 'sub001'}},
              'path': PosixPath('/var/folders/dv/2lbr8f8j0q12zrx3mz3ll5m40000gp/T/tmpgxcyjfo1/sub001_bold.nii.gz')},
-    'T1w': {'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDatagrabber',
+    'T1w': {'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDataGrabber',
                                      'types': ['BOLD', 'T1w']},
                      'dependencies': set(),
                      'element': {'subject': 'sub001'}},
@@ -44,14 +44,14 @@ adds information about the datareader used to read the data.
 .. code-block:: python
 
    {'BOLD': {'data': <nibabel.nifti1.Nifti1Image object at 0x16b5d8910>,
-             'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDatagrabber',
+             'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDataGrabber',
                                       'types': ['BOLD', 'T1w']},
                       'datareader': {'class': 'DefaultDataReader'},
                       'dependencies': {'nilearn'},
                       'element': {'subject': 'sub001'}},
              'path': PosixPath('/var/folders/dv/2lbr8f8j0q12zrx3mz3ll5m40000gp/T/tmpe49321ce/sub001_bold.nii.gz')},
     'T1w': {'data': <nibabel.nifti1.Nifti1Image object at 0x16b5d78d0>,
-            'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDatagrabber',
+            'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDataGrabber',
                                      'types': ['BOLD', 'T1w']},
                      'datareader': {'class': 'DefaultDataReader'},
                      'dependencies': set(),
@@ -70,7 +70,7 @@ and adds further keys needed for the storage, for example, ``col_names``.
 
    {'BOLD': {'col_names': ['root_sum_of_squares_ets'],
              'data': ...,
-             'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDatagrabber',
+             'meta': {'datagrabber': {'class': 'SPMAuditoryTestingDataGrabber',
                                       'types': ['BOLD', 'T1w']},
                       'datareader': {'class': 'DefaultDataReader'},
                       'dependencies': {'nilearn'},

--- a/docs/using/codeless.rst
+++ b/docs/using/codeless.rst
@@ -100,7 +100,7 @@ In the ``Oasis VBM Testing dataset`` example, the section will look like this:
 .. code-block:: yaml
 
   datagrabber:
-    kind: OasisVBMTestingDatagrabber
+    kind: OasisVBMTestingDataGrabber
 
 
 Data Reader
@@ -212,7 +212,7 @@ looks like:
   workdir: /tmp
 
   datagrabber:
-    kind: OasisVBMTestingDatagrabber
+    kind: OasisVBMTestingDataGrabber
 
   markers:
     - name: Schaefer100x7_mean

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -220,7 +220,7 @@ Enhancements
 Features
 ^^^^^^^^
 
-- Implement :class:`.SPMAuditoryTestingDatagrabber` datagrabber by
+- Implement :class:`.SPMAuditoryTestingDataGrabber` datagrabber by
   `Fede Raimondo`_ (:gh:`52`)
 
 - Implement matrix storage in SQliteFeatureStorage by `Fede Raimondo`_

--- a/examples/run_ets_rss_marker.py
+++ b/examples/run_ets_rss_marker.py
@@ -27,7 +27,7 @@ configure_logging(level="INFO")
 ##############################################################################
 # Define the datagrabber interface
 datagrabber = {
-    "kind": "SPMAuditoryTestingDatagrabber",
+    "kind": "SPMAuditoryTestingDataGrabber",
 }
 
 ###############################################################################

--- a/examples/run_junifer_julearn.py
+++ b/examples/run_junifer_julearn.py
@@ -75,7 +75,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     # run the defined junifer feature extraction pipeline
     run(
         workdir="/tmp",
-        datagrabber={"kind": "OasisVBMTestingDatagrabber"},
+        datagrabber={"kind": "OasisVBMTestingDataGrabber"},
         markers=marker_dicts,
         storage=storage,
     )

--- a/examples/run_run_gmd_mean.py
+++ b/examples/run_run_gmd_mean.py
@@ -13,7 +13,7 @@ from junifer.api import run
 
 
 datagrabber = {
-    "kind": "OasisVBMTestingDatagrabber",
+    "kind": "OasisVBMTestingDataGrabber",
 }
 
 markers = [

--- a/examples/yamls/gmd_mean.yaml
+++ b/examples/yamls/gmd_mean.yaml
@@ -2,7 +2,7 @@ with: junifer.testing.registry
 workdir: /tmp
 
 datagrabber:
-  kind: OasisVBMTestingDatagrabber
+  kind: OasisVBMTestingDataGrabber
 elements:
 markers:
   - name: Schaefer1000x7_TrimMean80
@@ -19,7 +19,6 @@ markers:
     kind: ParcelAggregation
     parcellation: Schaefer1000x7
     method: std
-storage: 
+storage:
   kind: SQLiteFeatureStorage
   uri: /Users/fraimondo/dev/tbox/junifer/scratch/db/test.sqlite
-

--- a/examples/yamls/gmd_mean_htcondor.yaml
+++ b/examples/yamls/gmd_mean_htcondor.yaml
@@ -2,13 +2,13 @@ with: junifer.testing.registry
 workdir: /tmp
 
 datagrabber:
-  kind: OasisVBMTestingDatagrabber
+  kind: OasisVBMTestingDataGrabber
 markers:
   - name: Schaefer1000x7_Mean
     kind: ParcelAggregation
     parcellation: Schaefer1000x7
     method: mean
-storage: 
+storage:
   kind: SQLiteFeatureStorage
   uri: /data/group/appliedml/fraimondo/junifer_test/test.sqlite
 queue:

--- a/junifer/api/tests/data/gmd_mean.yaml
+++ b/junifer/api/tests/data/gmd_mean.yaml
@@ -2,14 +2,13 @@ with: junifer.testing.registry
 workdir: /tmp
 
 datagrabber:
-  kind: OasisVBMTestingDatagrabber
+  kind: OasisVBMTestingDataGrabber
 elements: [1, 2]
 markers:
   - name: Schaefer1000x7_Mean
     kind: ParcelAggregation
     parcellation: Schaefer1000x7
     method: mean
-storage: 
+storage:
   kind: SQLiteFeatureStorage
   uri: /Users/fraimondo/dev/tbox/junifer/scratch/db/test.sqlite
-

--- a/junifer/api/tests/data/gmd_mean_htcondor.yaml
+++ b/junifer/api/tests/data/gmd_mean_htcondor.yaml
@@ -2,13 +2,13 @@ with: junifer.testing.registry
 workdir: /tmp
 
 datagrabber:
-  kind: OasisVBMTestingDatagrabber
+  kind: OasisVBMTestingDataGrabber
 markers:
   - name: Schaefer1000x7_Mean
     kind: ParcelAggregation
     parcellation: Schaefer1000x7
     method: mean
-storage: 
+storage:
   kind: SQLiteFeatureStorage
   uri: /Users/fraimondo/dev/tbox/junifer/scratch/db/test.sqlite
 queue:

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -21,7 +21,7 @@ from junifer.pipeline.registry import build
 
 # Define datagrabber
 datagrabber = {
-    "kind": "OasisVBMTestingDatagrabber",
+    "kind": "OasisVBMTestingDataGrabber",
 }
 
 # Define markers

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -30,8 +30,8 @@ from junifer.data.masks import (
 )
 from junifer.datareader import DefaultDataReader
 from junifer.testing.datagrabbers import (
-    OasisVBMTestingDatagrabber,
-    SPMAuditoryTestingDatagrabber,
+    OasisVBMTestingDataGrabber,
+    SPMAuditoryTestingDataGrabber,
 )
 
 
@@ -181,7 +181,7 @@ def test_vickery_patil() -> None:
 def test_get_mask() -> None:
     """Test the get_mask function."""
     reader = DefaultDataReader()
-    with OasisVBMTestingDatagrabber() as dg:
+    with OasisVBMTestingDataGrabber() as dg:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
         vbm_gm = input["VBM_GM"]
@@ -209,7 +209,7 @@ def test_mask_callable() -> None:
 
     _available_masks["identity"] = {"family": "Callable", "func": ident}
     reader = DefaultDataReader()
-    with OasisVBMTestingDatagrabber() as dg:
+    with OasisVBMTestingDataGrabber() as dg:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
         vbm_gm = input["VBM_GM"]
@@ -224,7 +224,7 @@ def test_mask_callable() -> None:
 def test_get_mask_errors() -> None:
     """Test passing wrong parameters to get_mask."""
     reader = DefaultDataReader()
-    with OasisVBMTestingDatagrabber() as dg:
+    with OasisVBMTestingDataGrabber() as dg:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
         vbm_gm = input["VBM_GM"]
@@ -306,7 +306,7 @@ def test_nilearn_compute_masks(
         Whether to resample the mask to the target data.
     """
     reader = DefaultDataReader()
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         input = dg["sub001"]
         input = reader.fit_transform(input)
         bold = input["BOLD"]
@@ -339,7 +339,7 @@ def test_nilearn_compute_masks(
 def test_get_mask_inherit() -> None:
     """Test using the inherit mask functionality."""
     reader = DefaultDataReader()
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         input = dg["sub001"]
         input = reader.fit_transform(input)
         # Compute brain mask using nilearn
@@ -394,7 +394,7 @@ def test_get_mask_multiple(
         Parameters to pass to the intersect_masks function.
     """
     reader = DefaultDataReader()
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         input = dg["sub001"]
         input = reader.fit_transform(input)
         if not isinstance(masks, list):

--- a/junifer/markers/functional_connectivity/tests/test_crossparcellation_functional_connectivity.py
+++ b/junifer/markers/functional_connectivity/tests/test_crossparcellation_functional_connectivity.py
@@ -11,7 +11,7 @@ from nilearn import image
 
 from junifer.markers.functional_connectivity import CrossParcellationFC
 from junifer.storage import SQLiteFeatureStorage
-from junifer.testing.datagrabbers import SPMAuditoryTestingDatagrabber
+from junifer.testing.datagrabbers import SPMAuditoryTestingDataGrabber
 
 
 parcellation_ONE = "Schaefer100x17"
@@ -21,7 +21,7 @@ parcellation_TWO = "Schaefer200x17"
 def test_compute() -> None:
     """Test CrossParcellationFC compute()."""
 
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         out = dg["sub001"]
         niimg = image.load_img(str(out["BOLD"]["path"].absolute()))
         input_dict = {
@@ -53,7 +53,7 @@ def test_store(tmp_path: Path) -> None:
 
     """
 
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         input_dict = dg["sub001"]
         niimg = image.load_img(str(input_dict["BOLD"]["path"].absolute()))
 

--- a/junifer/markers/reho/tests/test_reho_parcels.py
+++ b/junifer/markers/reho/tests/test_reho_parcels.py
@@ -12,7 +12,7 @@ from scipy.stats import pearsonr
 from junifer.markers.reho.reho_parcels import ReHoParcels
 from junifer.pipeline.utils import _check_afni
 from junifer.storage.sqlite import SQLiteFeatureStorage
-from junifer.testing.datagrabbers import SPMAuditoryTestingDatagrabber
+from junifer.testing.datagrabbers import SPMAuditoryTestingDataGrabber
 
 
 PARCELLATION = "Schaefer100x7"
@@ -20,7 +20,7 @@ PARCELLATION = "Schaefer100x7"
 
 def test_reho_parcels_computation() -> None:
     """Test ReHoParcels fit-transform."""
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Use first subject
         subject_data = dg["sub001"]
         # Load image to memory
@@ -51,7 +51,7 @@ def test_reho_parcels_computation() -> None:
 )
 def test_reho_parcels_computation_comparison() -> None:
     """Test ReHoParcels fit-transform implementation comparison.."""
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Use first subject
         subject_data = dg["sub001"]
         # Load image to memory
@@ -96,7 +96,7 @@ def test_reho_parcels_storage(tmp_path: Path) -> None:
         The path to the test directory.
 
     """
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Use first subject
         subject_data = dg["sub001"]
         # Load image to memory

--- a/junifer/markers/reho/tests/test_reho_spheres.py
+++ b/junifer/markers/reho/tests/test_reho_spheres.py
@@ -12,7 +12,7 @@ from scipy.stats import pearsonr
 from junifer.markers.reho.reho_spheres import ReHoSpheres
 from junifer.pipeline.utils import _check_afni
 from junifer.storage.sqlite import SQLiteFeatureStorage
-from junifer.testing.datagrabbers import SPMAuditoryTestingDatagrabber
+from junifer.testing.datagrabbers import SPMAuditoryTestingDataGrabber
 
 
 COORDINATES = "DMNBuckner"
@@ -20,7 +20,7 @@ COORDINATES = "DMNBuckner"
 
 def test_reho_spheres_computation() -> None:
     """Test ReHoSpheres fit-transform."""
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Use first subject
         subject_data = dg["sub001"]
         # Load image to memory
@@ -51,7 +51,7 @@ def test_reho_spheres_computation() -> None:
 )
 def test_reho_spheres_computation_comparison() -> None:
     """Test ReHoSpheres fit-transform implementation comparison.."""
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Use first subject
         subject_data = dg["sub001"]
         # Load image to memory
@@ -96,7 +96,7 @@ def test_reho_spheres_storage(tmp_path: Path) -> None:
         The path to the test directory.
 
     """
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Use first subject
         subject_data = dg["sub001"]
         # Load image to memory

--- a/junifer/markers/tests/test_collection.py
+++ b/junifer/markers/tests/test_collection.py
@@ -19,7 +19,7 @@ from junifer.pipeline import PipelineStepMixin
 from junifer.preprocess import fMRIPrepConfoundRemover
 from junifer.storage import SQLiteFeatureStorage
 from junifer.testing.datagrabbers import (
-    OasisVBMTestingDatagrabber,
+    OasisVBMTestingDataGrabber,
     PartlyCloudyTestingDataGrabber,
 )
 
@@ -69,7 +69,7 @@ def test_marker_collection() -> None:
     assert isinstance(mc._datareader, DefaultDataReader)
 
     # Create testing datagrabber
-    dg = OasisVBMTestingDatagrabber()
+    dg = OasisVBMTestingDataGrabber()
     mc.validate(dg)
 
     with dg:
@@ -168,7 +168,7 @@ def test_marker_collection_storage(tmp_path: Path) -> None:
         ),
     ]
     # Test storage
-    dg = OasisVBMTestingDatagrabber()
+    dg = OasisVBMTestingDataGrabber()
 
     uri = tmp_path / "test_marker_collection_storage.sqlite"
     storage = SQLiteFeatureStorage(uri=uri)

--- a/junifer/markers/tests/test_ets_rss.py
+++ b/junifer/markers/tests/test_ets_rss.py
@@ -14,7 +14,7 @@ from nilearn.maskers import NiftiLabelsMasker
 from junifer.data import load_parcellation
 from junifer.markers.ets_rss import RSSETSMarker
 from junifer.storage import SQLiteFeatureStorage
-from junifer.testing.datagrabbers import SPMAuditoryTestingDatagrabber
+from junifer.testing.datagrabbers import SPMAuditoryTestingDataGrabber
 
 
 # Set parcellation
@@ -23,7 +23,7 @@ PARCELLATION = "Schaefer100x17"
 
 def test_compute() -> None:
     """Test RSS ETS compute()."""
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Fetch element
         out = dg["sub001"]
         # Load BOLD image
@@ -61,7 +61,7 @@ def test_store(tmp_path: Path) -> None:
         The path to the test directory.
 
     """
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         # Fetch element
         elem = dg["sub001"]
         # Load BOLD image

--- a/junifer/preprocess/confounds/tests/test_fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/tests/test_fmriprep_confound_remover.py
@@ -19,7 +19,7 @@ from junifer.datareader import DefaultDataReader
 from junifer.preprocess.confounds import fMRIPrepConfoundRemover
 from junifer.testing import get_testing_data
 from junifer.testing.datagrabbers import (
-    OasisVBMTestingDatagrabber,
+    OasisVBMTestingDataGrabber,
     PartlyCloudyTestingDataGrabber,
 )
 
@@ -327,7 +327,7 @@ def test_fMRIPrepConfoundRemover__validate_data() -> None:
     """Test fMRIPrepConfoundRemover validate data."""
     confound_remover = fMRIPrepConfoundRemover(strategy={"wm_csf": "full"})
     reader = DefaultDataReader()
-    with OasisVBMTestingDatagrabber() as dg:
+    with OasisVBMTestingDataGrabber() as dg:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
         new_input = input["VBM_GM"]

--- a/junifer/testing/datagrabbers.py
+++ b/junifer/testing/datagrabbers.py
@@ -14,8 +14,12 @@ from nilearn import datasets, image
 from ..datagrabber.base import BaseDataGrabber
 
 
-class OasisVBMTestingDatagrabber(BaseDataGrabber):
-    """Data Grabber for Oasis VBM testing data."""
+class OasisVBMTestingDataGrabber(BaseDataGrabber):
+    """Data Grabber for Oasis VBM testing data.
+
+    Wrapper for :func:`nilearn.datasets.fetch_oasis_vbm`
+
+    """
 
     def __init__(self) -> None:
         # Create temporary directory
@@ -55,12 +59,12 @@ class OasisVBMTestingDatagrabber(BaseDataGrabber):
 
         return out
 
-    def __enter__(self) -> "OasisVBMTestingDatagrabber":
+    def __enter__(self) -> "OasisVBMTestingDataGrabber":
         """Implement context entry.
 
         Returns
         -------
-        OasisVBMTestingDatagrabber
+        OasisVBMTestingDataGrabber
 
         """
         self._dataset = datasets.fetch_oasis_vbm(n_subjects=10)

--- a/junifer/testing/datagrabbers.py
+++ b/junifer/testing/datagrabbers.py
@@ -82,7 +82,7 @@ class OasisVBMTestingDataGrabber(BaseDataGrabber):
         return [f"sub-{x:02d}" for x in list(range(1, 11))]
 
 
-class SPMAuditoryTestingDatagrabber(BaseDataGrabber):
+class SPMAuditoryTestingDataGrabber(BaseDataGrabber):
     """Data Grabber for SPM Auditory dataset.
 
     Wrapper for :func:`nilearn.datasets.fetch_spm_auditory`.

--- a/junifer/testing/registry.py
+++ b/junifer/testing/registry.py
@@ -7,8 +7,8 @@
 from ..pipeline.registry import register
 from .datagrabbers import (
     OasisVBMTestingDataGrabber,
-    SPMAuditoryTestingDataGrabber,
     PartlyCloudyTestingDataGrabber,
+    SPMAuditoryTestingDataGrabber,
 )
 
 

--- a/junifer/testing/registry.py
+++ b/junifer/testing/registry.py
@@ -6,23 +6,23 @@
 
 from ..pipeline.registry import register
 from .datagrabbers import (
-    OasisVBMTestingDatagrabber,
+    OasisVBMTestingDataGrabber,
+    SPMAuditoryTestingDataGrabber,
     PartlyCloudyTestingDataGrabber,
-    SPMAuditoryTestingDatagrabber,
 )
 
 
 # Register testing datagrabber
 register(
     step="datagrabber",
-    name="OasisVBMTestingDatagrabber",
-    klass=OasisVBMTestingDatagrabber,
+    name="OasisVBMTestingDataGrabber",
+    klass=OasisVBMTestingDataGrabber,
 )
 
 register(
     step="datagrabber",
-    name="SPMAuditoryTestingDatagrabber",
-    klass=SPMAuditoryTestingDatagrabber,
+    name="SPMAuditoryTestingDataGrabber",
+    klass=SPMAuditoryTestingDataGrabber,
 )
 
 register(

--- a/junifer/testing/tests/test_oasisvmbtesting_datagrabber.py
+++ b/junifer/testing/tests/test_oasisvmbtesting_datagrabber.py
@@ -3,10 +3,10 @@
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 # License: AGPL
 
-from junifer.testing.datagrabbers import OasisVBMTestingDatagrabber
+from junifer.testing.datagrabbers import OasisVBMTestingDataGrabber
 
 
-def test_OasisVBMTestingDatagrabber() -> None:
+def test_OasisVBMTestingDataGrabber() -> None:
     """Test Oasis VBM Testing datagrabber."""
     expected_elements = [
         "sub-01",
@@ -20,7 +20,7 @@ def test_OasisVBMTestingDatagrabber() -> None:
         "sub-09",
         "sub-10",
     ]
-    with OasisVBMTestingDatagrabber() as dg:
+    with OasisVBMTestingDataGrabber() as dg:
         all_elements = dg.get_elements()
         assert set(all_elements) == set(expected_elements)
         out = dg["sub-01"]

--- a/junifer/testing/tests/test_spmauditory_datagrabber.py
+++ b/junifer/testing/tests/test_spmauditory_datagrabber.py
@@ -3,10 +3,10 @@
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 # License: AGPL
 
-from junifer.testing.datagrabbers import SPMAuditoryTestingDatagrabber
+from junifer.testing.datagrabbers import SPMAuditoryTestingDataGrabber
 
 
-def test_SPMAuditoryTestingDatagrabber() -> None:
+def test_SPMAuditoryTestingDataGrabber() -> None:
     """Test SPM Auditory datagrabber."""
     expected_elements = [
         "sub001",
@@ -20,7 +20,7 @@ def test_SPMAuditoryTestingDatagrabber() -> None:
         "sub009",
         "sub010",
     ]
-    with SPMAuditoryTestingDatagrabber() as dg:
+    with SPMAuditoryTestingDataGrabber() as dg:
         all_elements = dg.get_elements()
         assert set(all_elements) == set(expected_elements)
         out = dg["sub001"]

--- a/junifer/testing/tests/test_testing_registry.py
+++ b/junifer/testing/tests/test_testing_registry.py
@@ -14,7 +14,9 @@ def test_testing_registry() -> None:
 
     assert "OasisVBMTestingDataGrabber" not in get_step_names("datagrabber")
     assert "SPMAuditoryTestingDataGrabber" not in get_step_names("datagrabber")
-    assert "PartlyCloudyTestingDataGrabber" not in get_step_names("datagrabber")
+    assert "PartlyCloudyTestingDataGrabber" not in get_step_names(
+        "datagrabber"
+    )
     importlib.reload(junifer.testing.registry)  # type: ignore
 
     assert "OasisVBMTestingDataGrabber" in get_step_names("datagrabber")

--- a/junifer/testing/tests/test_testing_registry.py
+++ b/junifer/testing/tests/test_testing_registry.py
@@ -12,9 +12,11 @@ def test_testing_registry() -> None:
     importlib.reload(junifer.pipeline.registry)
     importlib.reload(junifer)
 
-    assert "OasisVBMTestingDatagrabber" not in get_step_names("datagrabber")
-    assert "SPMAuditoryTestingDatagrabber" not in get_step_names("datagrabber")
+    assert "OasisVBMTestingDataGrabber" not in get_step_names("datagrabber")
+    assert "SPMAuditoryTestingDataGrabber" not in get_step_names("datagrabber")
+    assert "PartlyCloudyTestingDataGrabber" not in get_step_names("datagrabber")
     importlib.reload(junifer.testing.registry)  # type: ignore
 
-    assert "OasisVBMTestingDatagrabber" in get_step_names("datagrabber")
-    assert "SPMAuditoryTestingDatagrabber" in get_step_names("datagrabber")
+    assert "OasisVBMTestingDataGrabber" in get_step_names("datagrabber")
+    assert "SPMAuditoryTestingDataGrabber" in get_step_names("datagrabber")
+    assert "PartlyCloudyTestingDataGrabber" in get_step_names("datagrabber")


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR renames the datagrabbers to `*DataGrabber` in `junifer.testing` to be consistent with the generally available ones in `junifer.datagrabber`.