### PR TITLE
Use `ruamel.yaml` in place of `pyyaml`

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -10,7 +10,7 @@ dependencies:
   - nibabel>=3.2.0,<4.1
   - nilearn>=0.9.0,<=0.10.0
   - sqlalchemy>=1.4.27,<= 1.5.0
-  - pyyaml>=5.1.2,<7.0
+  - ruamel.yaml=0.17.*
   - h5py=3.8.*
   - seaborn=0.11.*
   - Sphinx=5.3.*

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -23,7 +23,7 @@ The following steps are specific to VSCode and you can choose to go with it:
 
    .. code-block:: bash
 
-       conda env create -n <your-environment-name> -f conda-env.yml python=3.10
+       conda env create -n <your-environment-name> -f conda-env.yml
        conda activate <your-environment-name>
 
    The ``conda-env.yml`` can be found at the root of the repository.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,7 @@ junifer is compatible with `Python`_ >= 3.8 and requires the following packages:
 * ``nibabel>=3.2.0,<4.1``
 * ``nilearn>=0.9.0,<=0.10.0``
 * ``sqlalchemy>=1.4.27,<= 1.5.0``
-* ``pyyaml>=5.1.2,<7.0``
+* ``ruamel.yaml>=0.17,<0.18``
 * ``h5py>=3.8.0,<3.9``
 
 Depending on the installation method, these packages might be installed

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 import click
-import yaml
 
 from ..utils.logging import (
     configure_logging,
@@ -29,6 +28,7 @@ from .utils import (
     _get_junifer_version,
     _get_python_information,
     _get_system_information,
+    yaml,
 )
 
 
@@ -275,7 +275,7 @@ def wtf(long_: bool) -> None:
         "system": _get_system_information(),
         "environment": _get_environment_information(long_=long_),
     }
-    click.echo(yaml.dump(report, sort_keys=False))
+    click.echo(yaml.dump(report, stream=sys.stdout))
 
 
 @cli.command()

--- a/junifer/api/decorators.py
+++ b/junifer/api/decorators.py
@@ -4,6 +4,7 @@
 #          Leonard Sasse <l.sasse@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
+
 from typing import Type
 
 from ..pipeline.registry import register

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -12,8 +12,6 @@ import typing
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
-import yaml
-
 from ..datagrabber.base import BaseDataGrabber
 from ..markers.base import BaseMarker
 from ..markers.collection import MarkerCollection
@@ -22,6 +20,7 @@ from ..preprocess.base import BasePreprocessor
 from ..storage.base import BaseFeatureStorage
 from ..utils import logger, raise_error
 from ..utils.fs import make_executable
+from .utils import yaml
 
 
 def _get_datagrabber(datagrabber_config: Dict) -> BaseDataGrabber:
@@ -270,8 +269,7 @@ def queue(
 
     yaml_config = jobdir / "config.yaml"
     logger.info(f"Writing YAML config to {str(yaml_config.absolute())}")
-    with open(yaml_config, "w") as f:
-        f.write(yaml.dump(config))
+    yaml.dump(config, stream=yaml_config)
 
     # Get list of elements
     if elements is None:

--- a/junifer/api/parser.py
+++ b/junifer/api/parser.py
@@ -10,9 +10,8 @@ import sys
 from pathlib import Path
 from typing import Dict, Union
 
-import yaml
-
 from ..utils.logging import logger, raise_error
+from .utils import yaml
 
 
 def parse_yaml(filepath: Union[str, Path]) -> Dict:
@@ -38,8 +37,7 @@ def parse_yaml(filepath: Union[str, Path]) -> Dict:
     if not filepath.exists():
         raise_error(f"File does not exist: {str(filepath.absolute())}")
     # Filepath reading
-    with open(filepath, "r") as f:
-        contents = yaml.safe_load(f)
+    contents = yaml.load(filepath)
     if "elements" in contents:
         if contents["elements"] is None:
             raise_error(

--- a/junifer/api/tests/test_api_utils.py
+++ b/junifer/api/tests/test_api_utils.py
@@ -40,7 +40,7 @@ def test_get_dependency_information_short() -> None:
         "nibabel",
         "nilearn",
         "sqlalchemy",
-        "yaml",
+        "ruamel.yaml",
     ]
 
 
@@ -58,7 +58,7 @@ def test_get_dependency_information_long() -> None:
         "nibabel",
         "nilearn",
         "sqlalchemy",
-        "yaml",
+        "ruamel.yaml",
     ]:
         assert key in dependency_information_keys
 

--- a/junifer/api/tests/test_cli.py
+++ b/junifer/api/tests/test_cli.py
@@ -8,11 +8,17 @@ from pathlib import Path
 from typing import Tuple
 
 import pytest
-import yaml
 from click.testing import CliRunner
+from ruamel.yaml import YAML
 
 from junifer.api.cli import collect, run, selftest, wtf
 
+
+# Configure YAML class
+yaml = YAML()
+yaml.default_flow_style = False
+yaml.allow_unicode = True
+yaml.indent(mapping=2, sequence=4, offset=2)
 
 # Create click test runner
 runner = CliRunner()
@@ -33,19 +39,17 @@ def test_run_and_collect_commands(
     # Get test config
     infile = Path(__file__).parent / "data" / "gmd_mean.yaml"
     # Read test config
-    with open(infile, mode="r") as f:
-        contents = yaml.safe_load(f)
+    contents = yaml.load(infile)
     # Working directory
     workdir = tmp_path / "workdir"
-    contents["workdir"] = str(workdir.absolute())
+    contents["workdir"] = str(workdir.resolve())
     # Output directory
     outdir = tmp_path / "outdir"
     # Storage
-    contents["storage"]["uri"] = str(outdir.absolute())
+    contents["storage"]["uri"] = str(outdir.resolve())
     # Write new test config
     outfile = tmp_path / "in.yaml"
-    with open(outfile, mode="w") as f:
-        yaml.dump(contents, f)
+    yaml.dump(contents, stream=outfile)
     # Run command arguments
     run_args = [
         str(outfile.absolute()),

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -11,13 +11,19 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 import junifer.testing.registry  # noqa: F401
 from junifer.api.functions import collect, queue, run
 from junifer.datagrabber.base import BaseDataGrabber
 from junifer.pipeline.registry import build
 
+
+# Configure YAML class
+yaml = YAML()
+yaml.default_flow_style = False
+yaml.allow_unicode = True
+yaml.indent(mapping=2, sequence=4, offset=2)
 
 # Define datagrabber
 datagrabber = {
@@ -264,8 +270,7 @@ def test_queue_correct_yaml_config(
         generated_config_yaml_path = Path(
             tmp_path / "junifer_jobs" / "yaml_config_gen_check" / "config.yaml"
         )
-        with open(generated_config_yaml_path, "r") as f:
-            yaml_config = yaml.unsafe_load(f)
+        yaml_config = yaml.load(generated_config_yaml_path)
         # Check for correct YAML config generation
         assert all(
             key in yaml_config.keys()

--- a/junifer/api/utils.py
+++ b/junifer/api/utils.py
@@ -9,8 +9,17 @@ import re
 from importlib.metadata import distribution
 from typing import Dict
 
+from ruamel.yaml import YAML
+
 from .._version import __version__
 from ..utils.logging import get_versions
+
+
+# Configure YAML class once for further use
+yaml = YAML()
+yaml.default_flow_style = False
+yaml.allow_unicode = True
+yaml.indent(mapping=2, sequence=4, offset=2)
 
 
 def _get_junifer_version() -> Dict[str, str]:
@@ -71,16 +80,13 @@ def _get_dependency_information(long_: bool) -> Dict[str, str]:
         # Get dependencies for junifer
         dist = distribution("junifer")
         # Compile regex pattern
-        re_pattern = re.compile("[a-z-]+")
+        re_pattern = re.compile("[a-z-_.]+")
 
         for pkg_with_version in dist.requires:  # type: ignore
             # Perform regex search
             matches = re.findall(pattern=re_pattern, string=pkg_with_version)
-            # Fix issue with PyYAML name registration
-            if matches[0] == "pyyaml":
-                key = "yaml"
-            else:
-                key = matches[0]
+            # Extract package name
+            key = matches[0]
 
             if key in dependency_versions.keys():
                 # Check if pkg part of optional dependencies

--- a/junifer/utils/logging.py
+++ b/junifer/utils/logging.py
@@ -90,7 +90,9 @@ def get_versions() -> Dict:
     """
     module_versions = {}
     for name, module in sys.modules.items():
-        if "." in name:
+        # Bypassing sub-modules of packages and
+        # allowing ruamel.yaml
+        if "." in name and name != "ruamel.yaml":
             continue
         if name in ["_curses"]:
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "nibabel>=3.2.0,<4.1",
     "nilearn>=0.9.0,<=0.10.0",
     "sqlalchemy>=1.4.27,<= 1.5.0",
-    "pyyaml>=5.1.2,<7.0",
+    "ruamel.yaml>=0.17,<0.18",
     "importlib_metadata; python_version < '3.10'",
     "h5py>=3.8.0,<3.9",
 ]


### PR DESCRIPTION
`pyyaml` is lacking two features which we are interested in:

- Support for YAML 1.2
- Multiline string

`ruaml.yaml` provides support for them, so will be worth using it over `pyyaml`.