### PR TITLE
Add `junifer` to `conda-forge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,18 @@ The documentation is available at [https://juaml.github.io/junifer](https://juam
   * `testing`: Testing components module.
   * `utils`: Utilities module (e.g. logging)
 
-
 ## Installation
 
 Use `pip` to install from PyPI like so:
 
 ```
 pip install junifer
+```
+
+You can also install via `conda`, like so:
+
+```
+conda install -c conda-forge junifer
 ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![PyPI](https://img.shields.io/pypi/v/junifer?style=flat-square)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/junifer?style=flat-square)
 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/junifer?style=flat-square)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/junifer/badges/version.svg)](https://anaconda.org/conda-forge/junifer)
 ![GitHub](https://img.shields.io/github/license/juaml/junifer?style=flat-square)
 ![Codecov](https://img.shields.io/codecov/c/github/juaml/junifer?style=flat-square)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,6 +54,13 @@ You can also install via ``conda``, like so:
 
     conda install -c conda-forge junifer
 
+.. attention::
+
+   Installation on macOS and Windows might fail via ``conda`` due to ``datalad``.
+   In that case, please refer to
+   `Datalad installation instructions
+   <http://handbook.datalad.org/en/latest/intro/installation.html>`_ for solutions.
+   In case the problem persists, please install it via ``pip`` as mentioned earlier.
 
 .. _install_development_git:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,6 +48,12 @@ Use ``pip`` to install julearn from `PyPI <https://pypi.org>`_, like so:
 
     pip install junifer
 
+You can also install via ``conda``, like so:
+
+.. code-block:: bash
+
+    conda install -c conda-forge junifer
+
 
 .. _install_development_git:
 


### PR DESCRIPTION
Make `junifer` available via `conda` by adding recipe to [conda-forge](https://conda-forge.org) channel. This will enable users to install `junifer` via:
```shell
conda install -c conda-forge junifer
```