### PR TITLE
refactor: consistent use of `DataReader`

### DIFF
--- a/docs/understanding/data.rst
+++ b/docs/understanding/data.rst
@@ -39,7 +39,7 @@ step only contains information about the datagrabber used.
 
 The :ref:`Data Reader <datareader>` step adds the ``data`` second-level key
 which is the actual data loaded into memory. The ``meta`` key in this step
-adds information about the datareader used to read the data.
+adds information about the DataReader used to read the data.
 
 .. code-block:: python
 

--- a/docs/understanding/datareader.rst
+++ b/docs/understanding/datareader.rst
@@ -14,7 +14,7 @@ files in junifer. It reads the value of the key ``path`` for each
 them into memory. After reading the data into memory, it adds the key ``data``
 to the same level as ``path`` and the value is the actual data in the memory.
 
-Datareaders are meant to be used inside the datagrabber context but you can
+DataReaders are meant to be used inside the datagrabber context but you can
 operate on them outside the context as long as the actual data is in the memory
 and the Python runtime has not garbage-collected it.
 

--- a/docs/using/codeless.rst
+++ b/docs/using/codeless.rst
@@ -107,12 +107,12 @@ Data Reader
 ^^^^^^^^^^^
 
 As mentioned before, this section is entirely optional, as junifer only provides
-one data reader (:class:`.DefaultDataReader`), which is the default in case the
+one DataReader (:class:`.DefaultDataReader`), which is the default in case the
 section is not specified.
 
 In any case, the syntax of the section is the same as for the ``datagrabber``
-section, using the ``kind`` key to specify the datareader to use, and additional
-keys to pass parameters to the datareader:
+section, using the ``kind`` key to specify the DataReader to use, and additional
+keys to pass parameters to the DataReader constructor:
 
 .. code-block:: yaml
 

--- a/junifer/api/decorators.py
+++ b/junifer/api/decorators.py
@@ -35,19 +35,23 @@ def register_datagrabber(klass: Type) -> Type:
 
 
 def register_datareader(klass: Type) -> Type:
-    """Datareader registration decorator.
+    """Register DataReader.
 
-    Registers the datareader so it can be used by name.
+    Registers the DataReader so it can be used by name.
 
     Parameters
     ----------
     klass: class
-        The class of the datareader to register.
+        The class of the DataReader to register.
 
     Returns
     -------
     klass: class
         The unmodified input class.
+
+    Notes
+    -----
+    It should only be used as a decorator.
 
     """
     register(

--- a/junifer/markers/collection.py
+++ b/junifer/markers/collection.py
@@ -25,8 +25,8 @@ class MarkerCollection:
     ----------
     markers : list of marker-like
         The markers to compute.
-    datareader : datareader-like, optional
-        The datareader to use (default None).
+    datareader : DataReader-like object, optional
+        The DataReader to use (default None).
     preprocessing : preprocessing-like, optional
         The preprocessing steps to apply.
     storage : storage-like, optional


### PR DESCRIPTION
* [x] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry for the latest changes

This PR removes datareader / DataReader naming convention issue in the codebase and adopts DataReader to make the code consistent with the docs.