### PR TITLE
update: add support for `ruff` linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,26 +6,18 @@ on:
 
 jobs:
   lint:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.11']
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install tox tox-gh-actions
-      - name: Check with flake8
-        run: |
-          tox -e flake8
-      - name: Check with codespell
-        run: |
-          tox -e codespell
+          python -m pip install --upgrade pip
+          python -m pip install tox ruff
+      - name: Run ruff
+        run: ruff check --format=github .
+      - name: Run codespell
+        run: tox -e codespell

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![GitHub](https://img.shields.io/github/license/juaml/junifer?style=flat-square)
 ![Codecov](https://img.shields.io/codecov/c/github/juaml/junifer?style=flat-square)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/charliermarsh/ruff)
 
 ## About
 

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -22,13 +22,10 @@ dependencies:
   - sphinxcontrib-mermaid=0.8.*
   - tox
   - ipykernel
-  - isort
   - pytest-cov
   - pytest
   - black
-  - flake8
-  - flake8-docstrings
-  - flake8-bugbear
+  - ruff
   - codespell
   - pip
   - pip:

--- a/docs/changes/newsfragments/229.misc
+++ b/docs/changes/newsfragments/229.misc
@@ -1,0 +1,1 @@
+Adopt ``ruff`` as the only linter for the codebase by `Synchon Mandal`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,6 @@ intersphinx_mapping = {
     "julearn": ("https://juaml.github.io/julearn/main", None),
     "nibabel": ("https://nipy.org/nibabel/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/dev", None),
     # "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -135,6 +135,7 @@ def cli() -> None:  # pragma: no cover
 )
 def run(filepath: click.Path, element: str, verbose: Union[str, int]) -> None:
     """Run command for CLI.
+
     \f
     Parameters
     ----------
@@ -182,6 +183,7 @@ def run(filepath: click.Path, element: str, verbose: Union[str, int]) -> None:
 )
 def collect(filepath: click.Path, verbose: Union[str, int]) -> None:
     """Collect command for CLI.
+
     \f
     Parameters
     ----------
@@ -224,6 +226,7 @@ def queue(
     verbose: Union[str, int],
 ) -> None:
     """Queue command for CLI.
+
     \f
     Parameters
     ----------
@@ -261,6 +264,7 @@ def queue(
 @click.option("--long", "long_", is_flag=True)
 def wtf(long_: bool) -> None:
     """Wtf command for CLI.
+
     \f
     Parameters
     ----------
@@ -282,6 +286,7 @@ def wtf(long_: bool) -> None:
 @click.argument("subpkg", type=str)
 def selftest(subpkg: str) -> None:
     """Selftest command for CLI.
+
     \f
     Parameters
     ----------

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -234,19 +234,19 @@ def queue(
     # Create a folder within the CWD to store the job files / config
     cwd = Path.cwd()
     jobdir = cwd / "junifer_jobs" / jobname
-    logger.info(f"Creating job in {str(jobdir.absolute())}")
+    logger.info(f"Creating job in {jobdir.absolute()!s}")
     if jobdir.exists():
         if not overwrite:
             raise_error(
                 f"Job folder for {jobname} already exists. "
                 "This error is raised to prevent overwriting job files "
                 "that might be scheduled but not yet executed. "
-                f"Either delete the directory {str(jobdir.absolute())} "
+                f"Either delete the directory {jobdir.absolute()!s} "
                 "or set overwrite=True."
             )
         else:
             logger.info(
-                f"Deleting existing job directory at {str(jobdir.absolute())}"
+                f"Deleting existing job directory at {jobdir.absolute()!s}"
             )
             shutil.rmtree(jobdir)
     jobdir.mkdir(exist_ok=True, parents=True)
@@ -268,7 +268,7 @@ def queue(
         config["with"] = fixed_load
 
     yaml_config = jobdir / "config.yaml"
-    logger.info(f"Writing YAML config to {str(yaml_config.absolute())}")
+    logger.info(f"Writing YAML config to {yaml_config.absolute()!s}")
     yaml.dump(config, stream=yaml_config)
 
     # Get list of elements
@@ -378,11 +378,11 @@ def _queue_condor(
     """
     logger.debug("Creating HTCondor job")
     run_junifer_args = (
-        f"run {str(yaml_config.absolute())} "
+        f"run {yaml_config.absolute()!s} "
         f"--verbose {verbose} --element $(element)"
     )
     collect_junifer_args = (
-        f"collect {str(yaml_config.absolute())} --verbose {verbose} "
+        f"collect {yaml_config.absolute()!s} --verbose {verbose} "
     )
 
     if not isinstance(collect, str):
@@ -401,7 +401,7 @@ def _queue_condor(
         executable = "run_conda.sh"
         arguments = f"{env_name} junifer"
         exec_path = jobdir / executable
-        logger.info(f"Copying {executable} to {str(exec_path.absolute())}")
+        logger.info(f"Copying {executable} to {exec_path.absolute()!s}")
         shutil.copy(Path(__file__).parent / "res" / executable, exec_path)
         make_executable(exec_path)
     elif env["kind"] == "venv":
@@ -441,7 +441,7 @@ def _queue_condor(
         request_disk = {disk}
 
         # Executable
-        initial_dir = {str(jobdir.absolute())}
+        initial_dir = {jobdir.absolute()!s}
         executable = $(initial_dir)/{executable}
         transfer_executable = False
 
@@ -450,9 +450,9 @@ def _queue_condor(
         {extra_preamble}
 
         # Logs
-        log = {str(log_dir.absolute())}/junifer_run_$(log_element).log
-        output = {str(log_dir.absolute())}/junifer_run_$(log_element).out
-        error = {str(log_dir.absolute())}/junifer_run_$(log_element).err
+        log = {log_dir.absolute()!s}/junifer_run_$(log_element).log
+        output = {log_dir.absolute()!s}/junifer_run_$(log_element).out
+        error = {log_dir.absolute()!s}/junifer_run_$(log_element).err
         """
 
     submit_run_fname = jobdir / f"run_{jobname}.submit"
@@ -475,7 +475,7 @@ def _queue_condor(
         request_disk = {disk}
 
         # Executable
-        initial_dir = {str(jobdir.absolute())}
+        initial_dir = {jobdir.absolute()!s}
         executable = $(initial_dir)/{executable}
         transfer_executable = False
 
@@ -484,9 +484,9 @@ def _queue_condor(
         {extra_preamble}
 
         # Logs
-        log = {str(log_dir.absolute())}/junifer_collect.log
-        output = {str(log_dir.absolute())}/junifer_collect.out
-        error = {str(log_dir.absolute())}/junifer_collect.err
+        log = {log_dir.absolute()!s}/junifer_collect.log
+        output = {log_dir.absolute()!s}/junifer_collect.out
+        error = {log_dir.absolute()!s}/junifer_collect.err
         """
 
     # Now create the collect submit file
@@ -535,7 +535,7 @@ def _queue_condor(
         subprocess.run(["condor_submit_dag", dag_fname])
         logger.info("HTCondor job submitted")
     else:
-        cmd = f"condor_submit_dag {str(dag_fname.absolute())}"
+        cmd = f"condor_submit_dag {dag_fname.absolute()!s}"
         logger.info(
             f"HTCondor job files created, to submit the job, run `{cmd}`"
         )

--- a/junifer/api/parser.py
+++ b/junifer/api/parser.py
@@ -32,10 +32,10 @@ def parse_yaml(filepath: Union[str, Path]) -> Dict:
     if not isinstance(filepath, Path):
         filepath = Path(filepath)
 
-    logger.info(f"Parsing yaml file: {str(filepath.absolute())}")
+    logger.info(f"Parsing yaml file: {filepath.absolute()!s}")
     # Filepath existence check
     if not filepath.exists():
-        raise_error(f"File does not exist: {str(filepath.absolute())}")
+        raise_error(f"File does not exist: {filepath.absolute()!s}")
     # Filepath reading
     contents = yaml.load(filepath)
     if "elements" in contents:

--- a/junifer/api/tests/test_api_utils.py
+++ b/junifer/api/tests/test_api_utils.py
@@ -32,7 +32,7 @@ def test_get_python_information() -> None:
 def test_get_dependency_information_short() -> None:
     """Test short version of _get_dependency_information()."""
     dependency_information = _get_dependency_information(long_=False)
-    assert [key for key in dependency_information.keys()] == [
+    assert list(dependency_information.keys()) == [
         "click",
         "numpy",
         "datalad",
@@ -47,9 +47,7 @@ def test_get_dependency_information_short() -> None:
 def test_get_dependency_information_long() -> None:
     """Test long version of _get_dependency_information()."""
     dependency_information = _get_dependency_information(long_=True)
-    dependency_information_keys = [
-        key for key in dependency_information.keys()
-    ]
+    dependency_information_keys = list(dependency_information.keys())
     for key in [
         "click",
         "numpy",

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -718,7 +718,7 @@ def test_queue_condor_assets_generation(
             # Check junifer run submit file
             assert run_submit_file_path.is_file()
             # Read run submit file to check if resources are correct
-            with open(run_submit_file_path, "r") as f:
+            with open(run_submit_file_path) as f:
                 for line in f.read().splitlines():
                     if "request_cpus" in line:
                         assert int(line.split("=")[1].strip()) == cpus
@@ -744,7 +744,7 @@ def test_queue_condor_assets_generation(
             element_count = 0
             has_collect_job = False
             has_final_collect_job = False
-            with open(dag_file_path, "r") as f:
+            with open(dag_file_path) as f:
                 for line in f.read().splitlines():
                     if "JOB" in line:
                         element_count += 1
@@ -812,7 +812,7 @@ def test_queue_condor_extra_preamble(
         run_submit_file_path = Path(
             tmp_path / "junifer_jobs" / jobname / f"run_{jobname}.submit"
         )
-        with open(run_submit_file_path, "r") as f:
+        with open(run_submit_file_path) as f:
             for line in f.read().splitlines():
                 if "FOO" in line:
                     assert line.strip() == extra_preamble
@@ -821,7 +821,7 @@ def test_queue_condor_extra_preamble(
         collect_submit_file_path = Path(
             tmp_path / "junifer_jobs" / jobname / f"collect_{jobname}.submit"
         )
-        with open(collect_submit_file_path, "r") as f:
+        with open(collect_submit_file_path) as f:
             for line in f.read().splitlines():
                 if "FOO" in line:
                     assert line.strip() == extra_preamble

--- a/junifer/data/coordinates.py
+++ b/junifer/data/coordinates.py
@@ -143,7 +143,7 @@ def load_coordinates(name: str) -> Tuple[ArrayLike, List[str]]:
     if isinstance(t_coord, Path):
         df_coords = pd.read_csv(t_coord, sep="\t", header=None)
         coords = df_coords.iloc[:, [0, 1, 2]].to_numpy()
-        names = [x for x in df_coords.iloc[:, [3]].values[:, 0]]
+        names = list(df_coords.iloc[:, [3]].values[:, 0])
     else:
         coords = t_coord["coords"]
         coords = typing.cast(ArrayLike, coords)

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -103,6 +103,7 @@ def register_parcellation(
     ValueError
         If the parcellation name is already registered and overwrite is set to
         False or if the parcellation name is a built-in parcellation.
+
     """
     # Check for attempt of overwriting built-in parcellations
     if name in _available_parcellations:
@@ -139,6 +140,7 @@ def list_parcellations() -> List[str]:
     -------
     list of str
         A list with all available parcellations.
+
     """
     return sorted(_available_parcellations.keys())
 
@@ -187,6 +189,7 @@ def load_parcellation(
         Parcellation labels.
     pathlib.Path
         File path to the parcellation image.
+
     """
     # Invalid parcellation name
     if name not in _available_parcellations:
@@ -209,7 +212,7 @@ def load_parcellation(
             **parcellation_definition,
         )
 
-    logger.info(f"Loading parcellation {str(parcellation_fname.absolute())}")
+    logger.info(f"Loading parcellation {parcellation_fname.absolute()!s}")
 
     parcellation_img = None
     if path_only is False:
@@ -254,12 +257,12 @@ def _retrieve_parcellation(
         available, the closest resolution will be loaded. Preferably, use a
         resolution higher than the desired one. By default, will load the
         highest one (default None).
+    **kwargs
+        Use to specify parcellation-specific keyword arguments found in the
+        following section.
 
     Other Parameters
     ----------------
-    **kwargs
-        Use to specify parcellation-specific keyword arguments:
-
     * Schaefer :
       ``n_rois`` : {100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
             Granularity of parcellation to be used.
@@ -289,6 +292,7 @@ def _retrieve_parcellation(
     ------
     ValueError
         If the parcellation's name is invalid.
+
     """
     if parcellations_dir is None:
         parcellations_dir = (
@@ -364,6 +368,7 @@ def _retrieve_schaefer(
     ValueError
         If invalid value is provided for `n_rois` or `yeo_networks` or if
         there is a problem fetching the parcellation.
+
     """
     logger.info("Parcellation parameters:")
     logger.info(f"\tn_rois: {n_rois}")
@@ -471,6 +476,7 @@ def _retrieve_tian(
     ValueError
         If invalid value is provided for `scale` or `magneticfield` or `space`
         or if there is a problem fetching the parcellation.
+
     """
     # show parameters to user
     logger.info("Parcellation parameters:")
@@ -619,7 +625,7 @@ def _retrieve_suit(
         see http://www.diedrichsenlab.org/imaging/suit.htm).
 
     Returns
-    ------
+    -------
     pathlib.Path
         File path to the parcellation image.
     list of str
@@ -630,6 +636,7 @@ def _retrieve_suit(
     ValueError
         If invalid value is provided for `space` or if there is a problem
         fetching the parcellation.
+
     """
     logger.info("Parcellation parameters:")
     logger.info(f"\tspace: {space}")

--- a/junifer/data/tests/test_parcellations.py
+++ b/junifer/data/tests/test_parcellations.py
@@ -94,7 +94,7 @@ def test_parcellation_wrong_labels_values(tmp_path: Path) -> None:
         load_parcellation("WrongLabels")
 
     # Test wrong number of labels
-    register_parcellation("WrongLabels2", schaefer_path, labels + ["wrong"])
+    register_parcellation("WrongLabels2", schaefer_path, [*labels, "wrong"])
 
     with pytest.raises(ValueError, match=r"has 100 parcels but 101"):
         load_parcellation("WrongLabels2")

--- a/junifer/datagrabber/base.py
+++ b/junifer/datagrabber/base.py
@@ -56,8 +56,7 @@ class BaseDataGrabber(ABC, UpdateMetaMixin):
             An element that can be indexed by the DataGrabber.
 
         """
-        for elem in self.get_elements():
-            yield elem
+        yield from self.get_elements()
 
     def __getitem__(self, element: Union[str, Tuple]) -> Dict[str, Dict]:
         """Enable indexing support.

--- a/junifer/datagrabber/datalad_base.py
+++ b/junifer/datagrabber/datalad_base.py
@@ -230,7 +230,7 @@ class DataladDataGrabber(BaseDataGrabber):
 
             # Check for dirty datasets:
             status = self._dataset.status()
-            if any([x["state"] != "clean" for x in status]):
+            if any(x["state"] != "clean" for x in status):
                 self.datalad_dirty = True
                 warn_with_log(
                     "At least one file is not clean, Junifer will "

--- a/junifer/datagrabber/hcp1200/hcp1200.py
+++ b/junifer/datagrabber/hcp1200/hcp1200.py
@@ -92,7 +92,7 @@ class HCP1200(PatternDataGrabber):
                 )
 
         if ica_fix:
-            if not all([task in ["REST1", "REST2"] for task in self.tasks]):
+            if not all(task in ["REST1", "REST2"] for task in self.tasks):
                 raise_error(
                     "ICA+FIX is only available for 'REST1' and 'REST2' tasks."
                 )

--- a/junifer/datagrabber/tests/test_multiple.py
+++ b/junifer/datagrabber/tests/test_multiple.py
@@ -61,7 +61,7 @@ def test_MultipleDataGrabber() -> None:
     ]
 
     with dg:
-        subs = [x for x in dg]
+        subs = list(dg)
         assert set(subs) == set(expected_subs)
 
         elem = dg[("sub-01", "ses-01")]
@@ -109,7 +109,7 @@ def test_MultipleDataGrabber_no_intersection() -> None:
     dg = MultipleDataGrabber([dg1, dg2])
     expected_subs = set()
     with dg:
-        subs = [x for x in dg]
+        subs = list(dg)
         assert set(subs) == set(expected_subs)
 
 

--- a/junifer/datagrabber/tests/test_pattern_datalad.py
+++ b/junifer/datagrabber/tests/test_pattern_datalad.py
@@ -60,7 +60,7 @@ def test_bids_PatternDataladDataGrabber() -> None:
         patterns=patterns,
         replacements=replacements,
     ) as dg:
-        subs = [x for x in dg]
+        subs = list(dg)
         expected_subs = [f"sub-{i:02d}" for i in range(1, 10)]
         assert set(subs) == set(expected_subs)
 
@@ -86,7 +86,7 @@ def test_bids_PatternDataladDataGrabber() -> None:
             assert "datalad_commit_id" in dg_meta
             assert dg_meta["datalad_commit_id"] == repo_commit
 
-            with open(t_sub["T1w"]["path"], "r") as f:
+            with open(t_sub["T1w"]["path"]) as f:
                 assert f.readlines()[0].startswith("placeholder")
 
 
@@ -159,7 +159,7 @@ def test_bids_PatternDataladDataGrabber_session():
         patterns=patterns,
         replacements=replacements,
     ) as dg:
-        subs = [x for x in dg]
+        subs = list(dg)
         expected_subs = [
             (f"sub-{i:02d}", f"ses-{j:02d}")
             for j in range(1, 3)
@@ -179,7 +179,7 @@ def test_bids_PatternDataladDataGrabber_session():
         patterns=patterns,
         replacements=replacements,
     ) as dg:
-        subs = [x for x in dg]
+        subs = list(dg)
         expected_subs = [
             (f"sub-{i:02d}", f"ses-{j:02d}")
             for j in range(1, 4)

--- a/junifer/external/nilearn/junifer_nifti_spheres_masker.py
+++ b/junifer/external/nilearn/junifer_nifti_spheres_masker.py
@@ -91,6 +91,7 @@ def _apply_mask_and_get_affinity(
         Mask to apply to regions before extracting signals. If niimg is None,
         mask_img is used as a reference space in which the spheres 'indices are
         placed.
+
     Returns
     -------
     X : 2D numpy.ndarray
@@ -261,14 +262,14 @@ class _JuniferExtractionFunctor:
 
         Parameters
         ----------
-         imgs : 4D Niimg-like object
-            If ``imgs`` is an iterable, checks if data is really 4D. Then,
-            considering that it is a list of ``img``, load them one by one.
-            If ``img`` is a string, consider it as a path to Nifti image and
-            call :func:`nibabel.load` on it.
-            If it is an object, check if the affine attribute is present and
-            that :func:`nilearn.image.get_data` returns a result, eval raise
-            TypeError.
+        imgs : 4D Niimg-like object
+           If ``imgs`` is an iterable, checks if data is really 4D. Then,
+           considering that it is a list of ``img``, load them one by one.
+           If ``img`` is a string, consider it as a path to Nifti image and
+           call :func:`nibabel.load` on it.
+           If it is an object, check if the affine attribute is present and
+           that :func:`nilearn.image.get_data` returns a result, eval raise
+           TypeError.
 
         Raises
         ------

--- a/junifer/external/nilearn/tests/test_junifer_nifti_spheres_masker.py
+++ b/junifer/external/nilearn/tests/test_junifer_nifti_spheres_masker.py
@@ -155,7 +155,7 @@ def test_nifti_spheres_masker_overlap() -> None:
     affine = np.eye(4)
     shape = (5, 5, 5)
 
-    data = np.random.RandomState(42).random_sample(shape + (5,))
+    data = np.random.RandomState(42).random_sample((*shape, 5))
     fmri_img = nibabel.Nifti1Image(data, affine)
 
     seeds = [(0, 0, 0), (2, 2, 2)]

--- a/junifer/markers/ets_rss.py
+++ b/junifer/markers/ets_rss.py
@@ -6,7 +6,7 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 
 import numpy as np
 
@@ -42,7 +42,7 @@ class RSSETSMarker(BaseMarker):
 
     """
 
-    _DEPENDENCIES = {"nilearn"}
+    _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn"}
 
     def __init__(
         self,

--- a/junifer/markers/falff/falff_base.py
+++ b/junifer/markers/falff/falff_base.py
@@ -155,7 +155,7 @@ class ALFFBase(BaseMarker):
         )
         post_data = falff if self.fractional else alff
 
-        post_input = {k: v for k, v in input.items()}
+        post_input = dict(input.items())
         post_input["data"] = post_data
         post_input["path"] = None
 

--- a/junifer/markers/falff/falff_base.py
+++ b/junifer/markers/falff/falff_base.py
@@ -6,7 +6,7 @@
 # License: AGPL
 
 from abc import abstractmethod
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional, Union
 
 from ...utils.logging import raise_error
 from ..base import BaseMarker
@@ -44,7 +44,9 @@ class ALFFBase(BaseMarker):
 
     """
 
-    _EXT_DEPENDENCIES = [
+    _EXT_DEPENDENCIES: ClassVar[
+        List[Dict[str, Union[str, bool, List[str]]]]
+    ] = [
         {
             "name": "afni",
             "optional": True,

--- a/junifer/markers/falff/falff_estimator.py
+++ b/junifer/markers/falff/falff_estimator.py
@@ -237,7 +237,7 @@ class ALFFEstimator:
         falff_img = nimg.new_img_like(data, python_falff)
         return alff_img, falff_img
 
-    @lru_cache(maxsize=None, typed=True)  # noqa: B019
+    @lru_cache(maxsize=None, typed=True)
     def _compute(
         self,
         use_afni: bool,

--- a/junifer/markers/falff/tests/test_falff_estimator.py
+++ b/junifer/markers/falff/tests/test_falff_estimator.py
@@ -36,7 +36,7 @@ def test_ALFFEstimator_cache_python() -> None:
     logger.info(f"ALFF Estimator First time: {first_time}")
     assert isinstance(alff, Nifti1Image)
     assert isinstance(falff, Nifti1Image)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now fit again, should be faster
@@ -51,7 +51,7 @@ def test_ALFFEstimator_cache_python() -> None:
     second_time = time.time() - start_time
     logger.info(f"ALFF Estimator Second time: {second_time}")
     assert second_time < (first_time / 1000)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now change a parameter, should compute again, without clearing the
@@ -67,7 +67,7 @@ def test_ALFFEstimator_cache_python() -> None:
     third_time = time.time() - start_time
     logger.info(f"ALFF Estimator Third time: {third_time}")
     assert third_time > (first_time / 10)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now fit again with the previous params, should be fast
@@ -82,7 +82,7 @@ def test_ALFFEstimator_cache_python() -> None:
     fourth = time.time() - start_time
     logger.info(f"ALFF Estimator Fourth time: {fourth}")
     assert fourth < (first_time / 1000)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now change the data, it should clear the cache
@@ -102,7 +102,7 @@ def test_ALFFEstimator_cache_python() -> None:
     fifth = time.time() - start_time
     logger.info(f"ALFF Estimator Fifth time: {fifth}")
     assert fifth > (first_time / 10)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
 
@@ -129,7 +129,7 @@ def test_ALFFEstimator_cache_afni() -> None:
     logger.info(f"ALFF Estimator First time: {first_time}")
     assert isinstance(alff, Nifti1Image)
     assert isinstance(falff, Nifti1Image)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 3  # input + alff + falff
 
     # Now fit again, should be faster
@@ -144,7 +144,7 @@ def test_ALFFEstimator_cache_afni() -> None:
     second_time = time.time() - start_time
     logger.info(f"ALFF Estimator Second time: {second_time}")
     assert second_time < (first_time / 1000)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 3  # input + alff + falff
 
     # Now change a parameter, should compute again, without clearing the
@@ -160,7 +160,7 @@ def test_ALFFEstimator_cache_afni() -> None:
     third_time = time.time() - start_time
     logger.info(f"ALFF Estimator Third time: {third_time}")
     assert third_time > (first_time / 10)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 5  # input + 2 * alff + 2 * falff
 
     # Now fit again with the previous params, should be fast
@@ -175,7 +175,7 @@ def test_ALFFEstimator_cache_afni() -> None:
     fourth = time.time() - start_time
     logger.info(f"ALFF Estimator Fourth time: {fourth}")
     assert fourth < (first_time / 1000)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 5  # input + 2 * alff + 2 * falff
 
     # Now change the data, it should clear the cache
@@ -195,7 +195,7 @@ def test_ALFFEstimator_cache_afni() -> None:
     fifth = time.time() - start_time
     logger.info(f"ALFF Estimator Fifth time: {fifth}")
     assert fifth > (first_time / 10)
-    n_files = len([x for x in estimator.temp_dir_path.glob("*")])
+    n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 3  # input + alff + falff
 
 

--- a/junifer/markers/falff/tests/test_falff_parcels.py
+++ b/junifer/markers/falff/tests/test_falff_parcels.py
@@ -89,8 +89,9 @@ def test_ALFFParcels_python_vs_afni(
 
     Parameters
     ----------
-    factional : bool
+    fractional : bool
         Whether to compute fractional ALFF or not.
+
     """
 
     with PartlyCloudyTestingDataGrabber() as dg:

--- a/junifer/markers/functional_connectivity/crossparcellation_functional_connectivity.py
+++ b/junifer/markers/functional_connectivity/crossparcellation_functional_connectivity.py
@@ -4,7 +4,7 @@
 #          Kaustubh R. Patil <k.patil@fz-juelich.de>
 # License: AGPL
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 
 import pandas as pd
 
@@ -39,7 +39,7 @@ class CrossParcellationFC(BaseMarker):
         (default None).
     """
 
-    _DEPENDENCIES = {"nilearn"}
+    _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn"}
 
     def __init__(
         self,

--- a/junifer/markers/functional_connectivity/functional_connectivity_base.py
+++ b/junifer/markers/functional_connectivity/functional_connectivity_base.py
@@ -5,7 +5,7 @@
 
 
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 
 from nilearn.connectome import ConnectivityMeasure
 from sklearn.covariance import EmpiricalCovariance
@@ -42,7 +42,7 @@ class FunctionalConnectivityBase(BaseMarker):
 
     """
 
-    _DEPENDENCIES = {"nilearn", "scikit-learn"}
+    _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn", "scikit-learn"}
 
     def __init__(
         self,

--- a/junifer/markers/functional_connectivity/tests/test_crossparcellation_functional_connectivity.py
+++ b/junifer/markers/functional_connectivity/tests/test_crossparcellation_functional_connectivity.py
@@ -14,8 +14,8 @@ from junifer.storage import SQLiteFeatureStorage
 from junifer.testing.datagrabbers import SPMAuditoryTestingDataGrabber
 
 
-parcellation_ONE = "Schaefer100x17"
-parcellation_TWO = "Schaefer200x17"
+parcellation_one = "Schaefer100x17"
+parcellation_two = "Schaefer200x17"
 
 
 def test_compute() -> None:
@@ -33,8 +33,8 @@ def test_compute() -> None:
         }
 
         crossparcellation = CrossParcellationFC(
-            parcellation_one=parcellation_ONE,
-            parcellation_two=parcellation_TWO,
+            parcellation_one=parcellation_one,
+            parcellation_two=parcellation_two,
             correlation_method="spearman",
         )
         out = crossparcellation.compute(input_dict["BOLD"])
@@ -60,8 +60,8 @@ def test_store(tmp_path: Path) -> None:
         input_dict["BOLD"]["data"] = niimg
 
         crossparcellation = CrossParcellationFC(
-            parcellation_one=parcellation_ONE,
-            parcellation_two=parcellation_TWO,
+            parcellation_one=parcellation_one,
+            parcellation_two=parcellation_two,
             correlation_method="spearman",
         )
         uri = tmp_path / "test_crossparcellation.sqlite"
@@ -77,7 +77,7 @@ def test_get_output_type() -> None:
     """Test CrossParcellationFC get_output_type()."""
 
     crossparcellation = CrossParcellationFC(
-        parcellation_one=parcellation_ONE, parcellation_two=parcellation_TWO
+        parcellation_one=parcellation_one, parcellation_two=parcellation_two
     )
     input_ = "BOLD"
     output = crossparcellation.get_output_type(input_)

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -4,7 +4,7 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 
 import numpy as np
 from nilearn.image import math_img, resample_to_img
@@ -51,7 +51,7 @@ class ParcelAggregation(BaseMarker):
         None).
     """
 
-    _DEPENDENCIES = {"nilearn", "numpy"}
+    _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn", "numpy"}
 
     def __init__(
         self,

--- a/junifer/markers/reho/reho_base.py
+++ b/junifer/markers/reho/reho_base.py
@@ -102,7 +102,7 @@ class ReHoBase(BaseMarker):
         .. [1] Jiang, L., & Zuo, X. N. (2016).
                Regional Homogeneity: A Multimodal, Multiscale Neuroimaging
                Marker of the Human Connectome.
-               The Neuroscientist, Volume 22(5), Pages 486–505.
+               The Neuroscientist, Volume 22(5), Pages 486-505.
                https://doi.org/10.1177/1073858415595004
 
         """

--- a/junifer/markers/reho/reho_base.py
+++ b/junifer/markers/reho/reho_base.py
@@ -4,7 +4,7 @@
 # License: AGPL
 
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
 
 from ...utils import logger, raise_error
 from ..base import BaseMarker
@@ -29,7 +29,9 @@ class ReHoBase(BaseMarker):
 
     """
 
-    _EXT_DEPENDENCIES = [
+    _EXT_DEPENDENCIES: ClassVar[
+        List[Dict[str, Union[str, bool, List[str]]]]
+    ] = [
         {
             "name": "afni",
             "optional": True,

--- a/junifer/markers/reho/reho_estimator.py
+++ b/junifer/markers/reho/reho_estimator.py
@@ -250,6 +250,7 @@ class ReHoEstimator:
             * 125 : for 5x5 cuboidal volume
 
             (default 27).
+
         Returns
         -------
         Niimg-like object
@@ -481,7 +482,7 @@ def _kendall_w_reho(
 
     Parameters
     ----------
-    timeseries_matrix : 2D numpy.ndarray
+    timeseries_ranks : 2D numpy.ndarray
         A matrix of ranks of a subset subject's brain voxels.
     tied_rank_corrections : 3D numpy.ndarray
         A 3D array consisting of the tied rank corrections for the ranks

--- a/junifer/markers/reho/reho_parcels.py
+++ b/junifer/markers/reho/reho_parcels.py
@@ -140,7 +140,7 @@ class ReHoParcels(ReHoBase):
             on="BOLD",
         )
         # Perform aggregation on reho map
-        parcel_aggregation_input = {k: v for k, v in input.items()}
+        parcel_aggregation_input = dict(input.items())
         parcel_aggregation_input["data"] = reho_map
         parcel_aggregation_input["path"] = None
 

--- a/junifer/markers/reho/reho_spheres.py
+++ b/junifer/markers/reho/reho_spheres.py
@@ -154,7 +154,7 @@ class ReHoSpheres(ReHoBase):
             on="BOLD",
         )
         # Perform aggregation on reho map
-        sphere_aggregation_input = {k: v for k, v in input.items()}
+        sphere_aggregation_input = dict(input.items())
         sphere_aggregation_input["data"] = reho_map
         sphere_aggregation_input["path"] = None
         output = sphere_aggregation.compute(

--- a/junifer/markers/reho/tests/test_reho_estimator.py
+++ b/junifer/markers/reho/tests/test_reho_estimator.py
@@ -38,7 +38,7 @@ def test_reho_estimator_cache_python() -> None:
     )
     assert isinstance(reho_map_without_cache, nib.Nifti1Image)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now fit again, should be faster
@@ -56,7 +56,7 @@ def test_reho_estimator_cache_python() -> None:
     # Check that cache is being used
     assert (second_toc - second_tic) < ((first_toc - first_tic) / 1000)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now change a parameter, should compute again, without clearing the
@@ -75,7 +75,7 @@ def test_reho_estimator_cache_python() -> None:
     # Should require more time
     assert (third_toc - third_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now fit again with the previous params, should be fast
@@ -93,7 +93,7 @@ def test_reho_estimator_cache_python() -> None:
     # Should require less time
     assert (fourth_toc - fourth_tic) < ((first_toc - first_tic) / 1000)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
     # Now change the data, it should clear the cache
@@ -117,7 +117,7 @@ def test_reho_estimator_cache_python() -> None:
     # Should take less time
     assert (fifth_toc - fifth_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 0  # no files in python
 
 
@@ -146,7 +146,7 @@ def test_reho_estimator_cache_afni() -> None:
     )
     assert isinstance(reho_map_without_cache, nib.Nifti1Image)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 2  # input + reho
 
     # Now fit again, should be faster
@@ -163,7 +163,7 @@ def test_reho_estimator_cache_afni() -> None:
     assert isinstance(reho_map_with_cache, nib.Nifti1Image)
     assert (second_toc - second_tic) < ((first_toc - first_tic) / 1000)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 2  # input + reho
 
     # Now change a parameter, should compute again, without clearing the
@@ -182,7 +182,7 @@ def test_reho_estimator_cache_afni() -> None:
     # Should require more time
     assert (third_toc - third_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 3  # input + 2 * reho
 
     # Now fit again with the previous params, should be fast
@@ -199,7 +199,7 @@ def test_reho_estimator_cache_afni() -> None:
     assert isinstance(reho_map_with_new_cache, nib.Nifti1Image)
     # Should require less time
     assert (fourth_toc - fourth_tic) < ((first_toc - first_tic) / 1000)
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 3  # input + 2 * reho
 
     # Now change the data, it should clear the cache
@@ -222,7 +222,7 @@ def test_reho_estimator_cache_afni() -> None:
     # Should take less time
     assert (fifth_toc - fifth_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
-    n_files = len([x for x in reho_estimator.temp_dir_path.glob("*")])
+    n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 2  # input + reho
 
 

--- a/junifer/markers/sphere_aggregation.py
+++ b/junifer/markers/sphere_aggregation.py
@@ -4,7 +4,7 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 
 from ..api.decorators import register_marker
 from ..data import get_mask, load_coordinates
@@ -57,7 +57,7 @@ class SphereAggregation(BaseMarker):
 
     """
 
-    _DEPENDENCIES = {"nilearn", "numpy"}
+    _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn", "numpy"}
 
     def __init__(
         self,

--- a/junifer/markers/temporal_snr/temporal_snr_base.py
+++ b/junifer/markers/temporal_snr/temporal_snr_base.py
@@ -5,7 +5,7 @@
 
 
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 
 from nilearn import image as nimg
 
@@ -34,7 +34,7 @@ class TemporalSNRBase(BaseMarker):
 
     """
 
-    _DEPENDENCIES = {"nilearn"}
+    _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn"}
 
     def __init__(
         self,

--- a/junifer/pipeline/registry.py
+++ b/junifer/pipeline/registry.py
@@ -139,7 +139,7 @@ def build(
     try:
         # Create instance of the class
         object_ = klass(**init_params)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
         raise_error(
             msg=f"Failed to create {step} ({name}). Error: {e}",
             klass=RuntimeError,

--- a/junifer/pipeline/registry.py
+++ b/junifer/pipeline/registry.py
@@ -141,7 +141,7 @@ def build(
         object_ = klass(**init_params)
     except ValueError as e:
         raise_error(
-            msg=(f"Failed to create {step} ({name}). " f"Error: {e}"),
+            msg=f"Failed to create {step} ({name}). Error: {e}",
             klass=RuntimeError,
             exception=e,
         )

--- a/junifer/pipeline/registry.py
+++ b/junifer/pipeline/registry.py
@@ -113,7 +113,7 @@ def build(
         Name of the function.
     baseclass : class
         Class to be checked against.
-    init_parms : dict, optional
+    init_params : dict or None, optional
         Parameters to pass to the base class constructor (default None).
 
     Returns
@@ -139,7 +139,7 @@ def build(
     try:
         # Create instance of the class
         object_ = klass(**init_params)
-    except Exception as e:
+    except ValueError as e:
         raise_error(
             msg=(f"Failed to create {step} ({name}). " f"Error: {e}"),
             klass=RuntimeError,

--- a/junifer/pipeline/tests/test_pipeline_step_mixin.py
+++ b/junifer/pipeline/tests/test_pipeline_step_mixin.py
@@ -5,7 +5,7 @@
 # License: AGPL
 
 import warnings
-from typing import Dict, List
+from typing import ClassVar, Dict, List, Set, Union
 
 import pytest
 
@@ -30,7 +30,7 @@ def test_pipeline_step_mixin_validate_correct_dependencies() -> None:
     class CorrectMixer(PipelineStepMixin):
         """Test class for validation."""
 
-        _DEPENDENCIES = {"setuptools"}
+        _DEPENDENCIES: ClassVar[Set[str]] = {"setuptools"}
 
         def validate_input(self, input: List[str]) -> List[str]:
             return input
@@ -51,7 +51,7 @@ def test_pipeline_step_mixin_validate_incorrect_dependencies() -> None:
     class IncorrectMixer(PipelineStepMixin):
         """Test class for validation."""
 
-        _DEPENDENCIES = {"foobar"}
+        _DEPENDENCIES: ClassVar[Set[str]] = {"foobar"}
 
         def validate_input(self, input: List[str]) -> List[str]:
             return input
@@ -76,7 +76,9 @@ def test_pipeline_step_mixin_validate_correct_ext_dependencies() -> None:
     class CorrectMixer(PipelineStepMixin):
         """Test class for validation."""
 
-        _EXT_DEPENDENCIES = [{"name": "afni", "optional": False}]
+        _EXT_DEPENDENCIES: ClassVar[List[Dict[str, Union[str, bool]]]] = [
+            {"name": "afni", "optional": False}
+        ]
 
         def validate_input(self, input: List[str]) -> List[str]:
             return input
@@ -100,9 +102,9 @@ def test_pipeline_step_mixin_validate_ext_deps_correct_commands() -> None:
     class CorrectMixer(PipelineStepMixin):
         """Test class for validation."""
 
-        _EXT_DEPENDENCIES = [
-            {"name": "afni", "optional": False, "commands": ["3dReHo"]}
-        ]
+        _EXT_DEPENDENCIES: ClassVar[
+            List[Dict[str, Union[str, bool, List[str]]]]
+        ] = [{"name": "afni", "optional": False, "commands": ["3dReHo"]}]
 
         def validate_input(self, input: List[str]) -> List[str]:
             return input
@@ -128,9 +130,9 @@ def test_pipeline_step_mixin_validate_ext_deps_incorrect_commands() -> None:
     class CorrectMixer(PipelineStepMixin):
         """Test class for validation."""
 
-        _EXT_DEPENDENCIES = [
-            {"name": "afni", "optional": False, "commands": ["3d"]}
-        ]
+        _EXT_DEPENDENCIES: ClassVar[
+            List[Dict[str, Union[str, bool, List[str]]]]
+        ] = [{"name": "afni", "optional": False, "commands": ["3d"]}]
 
         def validate_input(self, input: List[str]) -> List[str]:
             return input
@@ -152,7 +154,9 @@ def test_pipeline_step_mixin_validate_incorrect_ext_dependencies() -> None:
     class IncorrectMixer(PipelineStepMixin):
         """Test class for validation."""
 
-        _EXT_DEPENDENCIES = [{"name": "foobar", "optional": True}]
+        _EXT_DEPENDENCIES: ClassVar[List[Dict[str, Union[str, bool]]]] = [
+            {"name": "foobar", "optional": True}
+        ]
 
         def validate_input(self, input: List[str]) -> List[str]:
             return input

--- a/junifer/pipeline/tests/test_update_meta_mixin.py
+++ b/junifer/pipeline/tests/test_update_meta_mixin.py
@@ -15,9 +15,9 @@ from junifer.pipeline.update_meta_mixin import UpdateMetaMixin
     "input, step_name, dependencies, expected",
     [
         ({}, "step_name", None, set()),
-        ({}, "step_name", ["numpy"], set(["numpy"])),
-        ({}, "step_name", "numpy", set(["numpy"])),
-        ({}, "step_name", set(["numpy"]), set(["numpy"])),
+        ({}, "step_name", ["numpy"], {"numpy"}),
+        ({}, "step_name", "numpy", {"numpy"}),
+        ({}, "step_name", {"numpy"}, {"numpy"}),
     ],
 )
 def test_UpdateMetaMixin(

--- a/junifer/pipeline/update_meta_mixin.py
+++ b/junifer/pipeline/update_meta_mixin.py
@@ -39,5 +39,5 @@ class UpdateMetaMixin:
         dependencies = getattr(self, "_DEPENDENCIES", set())
         if dependencies is not None:
             if not isinstance(dependencies, (set, list)):
-                dependencies = set([dependencies])
+                dependencies = {dependencies}
             input["meta"]["dependencies"].update(dependencies)

--- a/junifer/preprocess/confounds/fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/fmriprep_confound_remover.py
@@ -5,7 +5,17 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import pandas as pd
@@ -141,7 +151,7 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
 
     """
 
-    _DEPENDENCIES = {"numpy", "nilearn"}
+    _DEPENDENCIES: ClassVar[Set[str]] = {"numpy", "nilearn"}
 
     def __init__(
         self,

--- a/junifer/preprocess/confounds/fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/fmriprep_confound_remover.py
@@ -208,6 +208,7 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
         input : list of str
             The input to the pipeline step. The list must contain the
             available Junifer Data object keys.
+
         Returns
         -------
         list of str
@@ -543,7 +544,7 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
             include the ``BOLD_confounds`` key.
 
         Returns
-        --------
+        -------
         Niimg-like object
             Input image with confounds removed.
 

--- a/junifer/preprocess/confounds/tests/test_fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/tests/test_fmriprep_confound_remover.py
@@ -93,7 +93,7 @@ def test_fMRIPrepConfoundRemover__map_adhoc_to_fmriprep() -> None:
     ]
 
     # Build mappings dictionary
-    mappings = {x: y for x, y in zip(adhoc_names, fmriprep_names)}
+    mappings = dict(zip(adhoc_names, fmriprep_names))
     input = {
         "mappings": {"fmriprep": mappings},
         "data": adhoc_df,
@@ -170,7 +170,7 @@ def test_fMRIPrepConfoundRemover__process_fmriprep_spec() -> None:
 
     confounds_df = pd.DataFrame(
         np.random.randn(7, len(var_names) + 1),
-        columns=var_names + ["framewise_displacement"],
+        columns=[*var_names, "framewise_displacement"],
     )
     out = confound_remover._process_fmriprep_spec({"data": confounds_df})
     to_select, sq_to_compute, der_to_compute, spike_name = out
@@ -248,7 +248,7 @@ def test_fMRIPrepConfoundRemover__pick_confounds_adhoc() -> None:
     ]
 
     # Build mappings dictionary
-    mappings = {x: y for x, y in zip(adhoc_names, fmriprep_names)}
+    mappings = dict(zip(adhoc_names, fmriprep_names))
     input = {
         "mappings": {"fmriprep": mappings},
         "data": adhoc_df,
@@ -281,13 +281,13 @@ def test_FMRIPRepConfoundRemover__pick_confounds_fmriprep() -> None:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
         out1 = confound_remover._pick_confounds(input["BOLD_confounds"])
-        assert set(out1.columns) == set(fmriprep_all_vars + ["spike"])
+        assert set(out1.columns) == {*fmriprep_all_vars, "spike"}
 
     with PartlyCloudyTestingDataGrabber(reduce_confounds=False) as dg:
         input = dg["sub-01"]
         input = reader.fit_transform(input)
         out2 = confound_remover._pick_confounds(input["BOLD_confounds"])
-        assert set(out2.columns) == set(fmriprep_all_vars + ["spike"])
+        assert set(out2.columns) == {*fmriprep_all_vars, "spike"}
 
     assert_frame_equal(out1, out2)
 

--- a/junifer/storage/pandas_base.py
+++ b/junifer/storage/pandas_base.py
@@ -131,10 +131,12 @@ class PandasBaseFeatureStorage(BaseFeatureStorage):
 
         Parameters
         ----------
+        meta_md5 : str
+            The metadata MD5 hash.
+        element : dict
+            The element as a dictionary.
         df : pandas.DataFrame or pandas.Series
             The pandas DataFrame or Series to store.
-        meta : dict
-            The metadata as a dictionary.
 
         Raises
         ------

--- a/junifer/storage/sqlite.py
+++ b/junifer/storage/sqlite.py
@@ -74,7 +74,7 @@ class SQLiteFeatureStorage(PandasBaseFeatureStorage):
         # Create parent directories if not present
         if not uri.parent.exists():
             logger.info(
-                f"Output directory ({str(uri.parent.absolute())}) "
+                f"Output directory ({uri.parent.absolute()!s}) "
                 "does not exist, creating now."
             )
             uri.parent.mkdir(parents=True, exist_ok=True)
@@ -351,10 +351,12 @@ class SQLiteFeatureStorage(PandasBaseFeatureStorage):
 
         Parameters
         ----------
+        meta_md5 : str
+            The metadata MD5 hash.
+        element : dict
+            The element as a dictionary.
         df : pandas.DataFrame or pandas.Series
             The pandas DataFrame or Series to store.
-        meta : dict
-            The metadata as a dictionary.
 
         Raises
         ------
@@ -476,7 +478,7 @@ class SQLiteFeatureStorage(PandasBaseFeatureStorage):
                 "options that will not raise this warning.",
             )
             data_df = data_df.stack()
-            new_names = [x for x in data_df.index.names[:-1]]
+            new_names = list(data_df.index.names[:-1])
             new_names.append("pair")
             data_df.index.names = new_names
 
@@ -506,7 +508,7 @@ class SQLiteFeatureStorage(PandasBaseFeatureStorage):
         # Glob files
         files = self.uri.parent.glob(f"*{self.uri.name}")  # type: ignore
         for elem in tqdm(files, desc="file"):
-            logger.debug(f"Reading from {str(elem.absolute())}")
+            logger.debug(f"Reading from {elem.absolute()!s}")
             in_storage = SQLiteFeatureStorage(uri=elem)
             in_engine = in_storage.get_engine()
             # Open "meta" table

--- a/junifer/storage/tests/test_hdf5.py
+++ b/junifer/storage/tests/test_hdf5.py
@@ -882,6 +882,12 @@ def test_multi_output_store_and_collect(
     ----------
     tmp_path : pathlib.Path
         The path to the test directory.
+    n_elements : int
+        The parametrized element count.
+    chunk_size : int
+        The parametrized chunk size.
+    kind : str
+        The parametrized storage kind.
 
     """
     uri = tmp_path / "test_multi_output_store_and_collect.hdf5"

--- a/junifer/tests/test_stats.py
+++ b/junifer/tests/test_stats.py
@@ -89,15 +89,15 @@ def test_winsorized_mean() -> None:
 def test_count() -> None:
     """Test count."""
     input = np.zeros((10, 3))
-    ax1 = np.ones((10)) * 3
-    ax2 = np.ones((3)) * 10
+    ax1 = np.ones(10) * 3
+    ax2 = np.ones(3) * 10
     assert_array_equal(count(input, axis=-1), ax1)
     assert_array_equal(count(input, axis=1), ax1)
     assert_array_equal(count(input, axis=0), ax2)
 
     input = np.zeros((10, 0))
-    ax1 = np.zeros((10))
-    ax2 = np.zeros((0))
+    ax1 = np.zeros(10)
+    ax2 = np.zeros(0)
 
     assert_array_equal(count(input, axis=-1), ax1)
     assert_array_equal(count(input, axis=1), ax1)

--- a/junifer/utils/logging.py
+++ b/junifer/utils/logging.py
@@ -29,8 +29,7 @@ _logging_types = {
 
 
 class WrapStdOut(logging.StreamHandler):
-    """
-    Dynamically wrap to sys.stdout.
+    """Dynamically wrap to sys.stdout.
 
     This makes packages that monkey-patch sys.stdout (e.g.doctest,
     sphinx-gallery) work properly.
@@ -239,9 +238,10 @@ def configure_logging(
             fname = Path(fname)
         if fname.exists() and overwrite is None:
             warn(
-                f"File ({str(fname.absolute())}) exists. "
+                f"File ({fname.absolute()!s}) exists. "
                 "Messages will be appended. Use overwrite=True to "
-                "overwrite or overwrite=False to avoid this message."
+                "overwrite or overwrite=False to avoid this message.",
+                stacklevel=2,
             )
             overwrite = False
         mode = "w" if overwrite else "a"
@@ -303,4 +303,4 @@ def warn_with_log(
 
     """
     logger.warning(msg)
-    warn(msg, category=category)
+    warn(msg, category=category, stacklevel=2)

--- a/junifer/utils/tests/test_logging.py
+++ b/junifer/utils/tests/test_logging.py
@@ -178,8 +178,8 @@ def test_lib_logging(tmp_path: Path) -> None:
 
     """
     # Import third-party packages
-    import numpy as np  # noqa
-    import pandas  # noqa
+    import numpy  # noqa: F401
+    import pandas  # noqa: F401
 
     log_file_path = tmp_path / "test_lib_logging.log"
     configure_logging(fname=log_file_path, level="INFO")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,87 @@ ignore-words = "ignore_words.txt"
 interactive = 0
 builtin = "clear,rare,informal,names,usage,code"
 
+[tool.ruff]
+line-length = 79
+select = [
+    # flake8-bugbear
+    "B",
+    # flake8-blind-except
+    "BLE",
+    # flake8-comprehensions
+    "C4",
+    # mccabe
+    "C90",
+    # pydocstyle
+    "D",
+    # pycodestyle errors
+    "E",
+    # pyflakes
+    "F",
+    # isort
+    "I",
+    # pep8-naming
+    "N",
+    # pygrep-hooks
+    "PGH",
+    # ruff
+    "RUF",
+    # flake8-type-checking
+    "TCH",
+    # pyupgrade
+    "UP",
+    # pycodestyle warnings
+    "W",
+    # flake8-2020
+    "YTT",
+]
+extend-exclude = [
+    "__init__.py",
+    "junifer/external/h5io",
+    "docs",
+    "examples",
+    "tools",
+]
+extend-ignore = [
+    # Use of `functools.lru_cache` or `functools.cache` on methods can lead to
+    # memory leaks. The cache may retain instance references, preventing garbage
+    # collection.
+    "B019",
+    # abstract class with no abstract methods
+    "B024",
+    "D202",
+    # missing docstring in __init__, incompatible with numpydoc
+    "D107",
+    # use r""" if any backslashes in a docstring
+    "D301",
+    # class names should use CapWords convention
+    "N801",
+    # function name should be lowercase
+    "N802",
+    # variable in function should be lowercase
+    "N806",
+    # use specific rule codes when ignoring type issues
+    "PGH003",
+]
+
+[tool.ruff.isort]
+lines-after-imports = 2
+known-first-party = ["junifer"]
+known-third-party =[
+    "click",
+    "numpy",
+    "datalad",
+    "pandas",
+    "nibabel",
+    "nilearn",
+    "sqlalchemy",
+    "yaml",
+    "pytest",
+]
+
+[tool.ruff.mccabe]
+max-complexity = 20
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "--ignore=junifer/external/h5io -vv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "AGPL-3.0-only"}
 authors = [
-    {name = "Fede Raimondo", email = "f.raimondo@fz-juelich.de"},
-    {name = "Synchon Mandal", email = "s.mandal@fz-juelich.de"},
+    { name = "Fede Raimondo", email = "f.raimondo@fz-juelich.de" },
+    { name = "Synchon Mandal", email = "s.mandal@fz-juelich.de" },
 ]
 maintainers = [
-    {name = "Fede Raimondo", email = "f.raimondo@fz-juelich.de"},
-    {name = "Synchon Mandal", email = "s.mandal@fz-juelich.de"},
+    { name = "Fede Raimondo", email = "f.raimondo@fz-juelich.de" },
+    { name = "Synchon Mandal", email = "s.mandal@fz-juelich.de" },
 ]
 keywords = [
     "neuroimaging",
@@ -88,7 +88,7 @@ write_to = "junifer/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ["py38"]
+target-version = ["py38", "py39", "py310", "py311"]
 extend-exclude = """
 (
   junifer/external/h5io

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = isort, black, flake8, test, coverage, codespell, py3{8,9,10,11}
+envlist = ruff, black, test, coverage, codespell, py3{8,9,10,11}
 isolated_build = true
 
 [gh-actions]
@@ -19,12 +19,12 @@ deps =
 commands =
     pytest
 
-[testenv:isort]
+[testenv:ruff]
 skip_install = true
 deps =
-    isort
+    ruff
 commands =
-    isort --check-only --diff {toxinidir}/junifer {toxinidir}/setup.py
+    ruff {toxinidir}
 
 [testenv:black]
 skip_install = true
@@ -32,15 +32,6 @@ deps =
     black
 commands =
     black --check --diff {toxinidir}/junifer {toxinidir}/setup.py
-
-[testenv:flake8]
-skip_install = true
-deps =
-    flake8
-    flake8-docstrings
-    flake8-bugbear
-commands =
-    flake8 {toxinidir}/junifer {toxinidir}/setup.py
 
 [testenv:test]
 skip_install = false
@@ -70,63 +61,6 @@ commands =
 ################
 # Tool configs #
 ################
-
-[isort]
-skip =
-    __init__.py
-    junifer/external/h5io
-profile = black
-line_length = 79
-lines_after_imports = 2
-known_first_party = junifer
-known_third_party =
-    click
-    numpy
-    datalad
-    pandas
-    nibabel
-    nilearn
-    sqlalchemy
-    yaml
-    pytest
-
-[flake8]
-exclude =
-    __init__.py
-    junifer/external/h5io
-max-line-length = 79
-extend-ignore =
-    ; Use of `functools.lru_cache` or `functools.cache` on methods can lead to
-    ; memory leaks. The cache may retain instance references, preventing garbage
-    ; collection.
-    B019
-    ; abstract class with no abstract methods
-    B024
-    D202
-    ; missing docstring in __init__, incompatible with numpydoc
-    D107
-    ; use r""" if any backslashes in a docstring
-    D301
-    ; whitespace after ‘(’
-    E201
-    ; whitespace before ‘)’
-    E202
-    ; whitespace before ‘,’, ‘;’, or ‘:’
-    E203
-    ; multiple spaces before operator
-    E221
-    ; multiple spaces after operator
-    E222
-    ; multiple spaces after ‘,’
-    E241
-    I100
-    I101
-    I201
-    N806
-    ; line break before binary operator
-    W503
-    ; line break after binary operator
-    W504
 
 [coverage:paths]
 source =

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ skip_install = true
 deps =
     ruff
 commands =
-    ruff {toxinidir}
+    ruff check {toxinidir}
 
 [testenv:black]
 skip_install = true


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds support for `ruff` linter and removes `isort`, `flake8` (and extensions) also improving missing linting checks.