### PR TITLE
[ENH]: Enable `stdout` and `stderr` capturing for `AFNI` commands

### DIFF
--- a/docs/changes/newsfragments/234.enh
+++ b/docs/changes/newsfragments/234.enh
@@ -1,0 +1,1 @@
+Enable ``stdout`` and ``stderr`` capture for AFNI commands by `Synchon Mandal`_

--- a/junifer/markers/falff/falff_estimator.py
+++ b/junifer/markers/falff/falff_estimator.py
@@ -70,12 +70,11 @@ class ALFFEstimator:
             If AFNI command fails.
         """
         logger.info(f"AFNI command to be executed: {cmd}")
-        # TODO: Figure out how to capture stdout and stderr
         process = subprocess.run(
             cmd,
             stdin=subprocess.DEVNULL,
-            # stdout=subprocess.STDOUT,
-            # stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             shell=True,
             check=False,
         )

--- a/junifer/markers/reho/reho_estimator.py
+++ b/junifer/markers/reho/reho_estimator.py
@@ -173,6 +173,8 @@ class ReHoEstimator:
         reho_process = subprocess.run(
             reho_cmd_str,  # string needed with shell=True
             stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             shell=True,  # needed for respecting $PATH
             check=False,
         )
@@ -205,6 +207,8 @@ class ReHoEstimator:
         convert_process = subprocess.run(
             convert_cmd_str,  # string needed with shell=True
             stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             shell=True,  # needed for respecting $PATH
             check=False,
         )


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR enables support for `stdout` and `stderr` capturing for `AFNI` commands run via `subprocess`, specifically for `ReHo` and `fALFF`. This should allow us to understand #233 better.