### PR TITLE
[ENH]: Add `read()` method for storage-like objects

### DIFF
--- a/docs/changes/newsfragments/236.change
+++ b/docs/changes/newsfragments/236.change
@@ -1,0 +1,1 @@
+Add :meth:`.BaseFeatureStorage.read` method for storage-like objects by `Synchon Mandal`_

--- a/docs/changes/newsfragments/236.enh
+++ b/docs/changes/newsfragments/236.enh
@@ -1,0 +1,1 @@
+Adapt :meth:`.HDF5FeatureStorage.read_df` due to addition of :meth:`.HDF5FeatureStorage.read` by `Synchon Mandal`_

--- a/junifer/storage/base.py
+++ b/junifer/storage/base.py
@@ -105,6 +105,34 @@ class BaseFeatureStorage(ABC):
         )
 
     @abstractmethod
+    def read(
+        self,
+        feature_name: Optional[str] = None,
+        feature_md5: Optional[str] = None,
+    ) -> Dict[
+        str, Union[str, List[Union[int, str, Dict[str, str]]], np.ndarray]
+    ]:
+        """Read stored feature.
+
+        Parameters
+        ----------
+        feature_name : str, optional
+            Name of the feature to read (default None).
+        feature_md5 : str, optional
+            MD5 hash of the feature to read (default None).
+
+        Returns
+        -------
+        dict
+            The stored feature as a dictionary.
+
+        """
+        raise_error(
+            msg="Concrete classes need to implement read().",
+            klass=NotImplementedError,
+        )
+
+    @abstractmethod
     def read_df(
         self,
         feature_name: Optional[str] = None,

--- a/junifer/storage/sqlite.py
+++ b/junifer/storage/sqlite.py
@@ -258,7 +258,12 @@ class SQLiteFeatureStorage(PandasBaseFeatureStorage):
 
         """
         raise_error(
-            msg="read() is not implemented for SQLiteFeatureStorage.",
+            msg=(
+                "read() for SQLiteFeatureStorage is not currently planned to "
+                "be implemented in the near future. If you need the "
+                "functionality, contact the junifer developers "
+                "(https://juaml.github.io/junifer/main/help.html)."
+            ),
             klass=NotImplementedError,
         )
 

--- a/junifer/storage/sqlite.py
+++ b/junifer/storage/sqlite.py
@@ -235,6 +235,33 @@ class SQLiteFeatureStorage(PandasBaseFeatureStorage):
                 out[md5][k] = json.loads(v)
         return out
 
+    def read(
+        self,
+        feature_name: Optional[str] = None,
+        feature_md5: Optional[str] = None,
+    ) -> Dict[
+        str, Union[str, List[Union[int, str, Dict[str, str]]], np.ndarray]
+    ]:
+        """Read stored feature.
+
+        Parameters
+        ----------
+        feature_name : str, optional
+            Name of the feature to read (default None).
+        feature_md5 : str, optional
+            MD5 hash of the feature to read (default None).
+
+        Returns
+        -------
+        dict
+            The stored feature as a dictionary.
+
+        """
+        raise_error(
+            msg="read() is not implemented for SQLiteFeatureStorage.",
+            klass=NotImplementedError,
+        )
+
     def read_df(
         self,
         feature_name: Optional[str] = None,

--- a/junifer/storage/tests/test_hdf5.py
+++ b/junifer/storage/tests/test_hdf5.py
@@ -220,6 +220,37 @@ def test_store_metadata_ignore_duplicate(tmp_path: Path) -> None:
     assert len(features) == 1
 
 
+def test_read(tmp_path: Path) -> None:
+    """Test read.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    uri = tmp_path / "test_read.hdf5"
+    storage = HDF5FeatureStorage(uri=uri)
+    # Data to store
+    to_store_data = {
+        "meta": {
+            "element": {"subject": "test"},
+            "dependencies": ["numpy"],
+            "marker": {"name": "test"},
+            "type": "BOLD",
+        },
+        "data": np.array([[1, 10]]),
+        "col_names": ["f1", "f2"],
+    }
+    # Store data
+    storage.store(kind="vector", **to_store_data)
+    # Read and check
+    stored_data = storage.read(feature_name="BOLD_test")
+    assert ["column_headers", "data", "element", "kind"] == list(
+        stored_data.keys()
+    )
+
+
 def test_read_df_params_error(tmp_path: Path) -> None:
     """Test parameter validation errors for read_df.
 

--- a/junifer/storage/tests/test_sqlite.py
+++ b/junifer/storage/tests/test_sqlite.py
@@ -253,6 +253,22 @@ def test_upsert_invalid_option(tmp_path: Path) -> None:
         SQLiteFeatureStorage(uri=uri, upsert="wrong")
 
 
+def test_read(tmp_path: Path) -> None:
+    """Test reading of stored feature.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    uri = tmp_path / "test_read.sqlite"
+    storage = SQLiteFeatureStorage(uri=uri, upsert="ignore")
+    # Check error
+    with pytest.raises(NotImplementedError):
+        storage.read()
+
+
 # TODO: can the tests be separated?
 def test_store_df_and_read_df(tmp_path: Path) -> None:
     """Test storing dataframe and reading of stored table into dataframe.

--- a/junifer/storage/tests/test_storage_base.py
+++ b/junifer/storage/tests/test_storage_base.py
@@ -38,6 +38,12 @@ def test_BaseFeatureStorage() -> None:
         def list_features(self):
             super().list_features()
 
+        def read(self, feature_name=None, feature_md5=None):
+            super().read(
+                feature_name=feature_name,
+                feature_md5=feature_md5,
+            )
+
         def read_df(self, feature_name=None, feature_md5=None):
             super().read_df(
                 feature_name=feature_name,
@@ -65,6 +71,9 @@ def test_BaseFeatureStorage() -> None:
 
     with pytest.raises(NotImplementedError):
         st.list_features()
+
+    with pytest.raises(NotImplementedError):
+        st.read(None)
 
     with pytest.raises(NotImplementedError):
         st.read_df(None)


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds a new `read()` method for `storage-like` objects. As of now, only `HDF5FeatureStorage` is implemented and allows to retrieve a feature as it is stored. This will allow users to do post-processing on the stored feature.