### PR TITLE
[BUG]: No error is logged if datalad fails to clone a repository

### DIFF
--- a/docs/changes/newsfragments/235.bugfix
+++ b/docs/changes/newsfragments/235.bugfix
@@ -1,0 +1,1 @@
+Handle ``datalad.IncompleteResultsError`` exception for partial clone in :class:`.DataladDataGrabber` by `Synchon Mandal`_

--- a/junifer/datagrabber/datalad_base.py
+++ b/junifer/datagrabber/datalad_base.py
@@ -241,9 +241,12 @@ class DataladDataGrabber(BaseDataGrabber):
 
         else:
             logger.debug(f"Installing dataset {self.uri} to {self._datadir}")
-            self._dataset: dl.Dataset = dl.clone(  # type: ignore
-                self.uri, self._datadir, result_renderer="disabled"
-            )
+            try:
+                self._dataset: dl.Dataset = dl.clone(  # type: ignore
+                    self.uri, self._datadir, result_renderer="disabled"
+                )
+            except IncompleteResultsError as e:
+                raise_error(f"Failed to clone dataset: {e.failed}")
             logger.debug("Dataset installed")
         self._was_cloned = not isinstalled
 


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

This is the standard error:

```
[INFO] Attempting a clone into /tmp/tmpmms6ilm3/datadir 
[INFO] Attempting to clone from https://github.com/datalad-datasets/human-connectome-project-openaccess.git to /tmp/tmpmms6ilm3/datadir 
[INFO] Attempting to clone from https://github.com/datalad-datasets/human-connectome-project-openaccess.git/.git to /tmp/tmpmms6ilm3/datadir 
[INFO] Completed clone attempts for Dataset(/tmp/tmpmms6ilm3/datadir) 
Traceback (most recent call last):
  File "/home/fraimondo/miniconda3/envs/afni/bin/junifer", line 8, in <module>
    sys.exit(cli())
  File "/home/fraimondo/miniconda3/envs/afni/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/fraimondo/miniconda3/envs/afni/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/fraimondo/miniconda3/envs/afni/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/fraimondo/miniconda3/envs/afni/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/fraimondo/miniconda3/envs/afni/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/fraimondo/dev/tbox/junifer/junifer/api/cli.py", line 160, in run
    api_run(
  File "/home/fraimondo/dev/tbox/junifer/junifer/api/functions.py", line 164, in run
    with datagrabber_object:
  File "/home/fraimondo/dev/tbox/junifer/junifer/datagrabber/multiple.py", line 81, in __enter__
    dg.__enter__()
  File "/home/fraimondo/dev/tbox/junifer/junifer/datagrabber/datalad_base.py", line 293, in __enter__
    self.install()
  File "/home/fraimondo/dev/tbox/junifer/junifer/datagrabber/datalad_base.py", line 244, in install
    self._dataset: dl.Dataset = dl.clone(  # type: ignore
  File "/home/fraimondo/dev/tbox/datalad/datalad/interface/base.py", line 773, in eval_func
    return return_func(*args, **kwargs)
  File "/home/fraimondo/dev/tbox/datalad/datalad/interface/base.py", line 763, in return_func
    results = list(results)
  File "/home/fraimondo/dev/tbox/datalad/datalad/interface/base.py", line 940, in _execute_command_
    raise IncompleteResultsError(
datalad.support.exceptions.IncompleteResultsError: Command did not complete successfully. 1 failed:
[{'action': 'install',
  'message': ('Failed to clone from any candidate source URL. Encountered '
              'errors per each url were:\n'
              '- %s',
              'https://github.com/datalad-datasets/human-connectome-project-openaccess.git\n'
              "  CommandError: 'git -c diff.ignoreSubmodules=none clone "
              '--progress '
              'https://github.com/datalad-datasets/human-connectome-project-openaccess.git '
              "/tmp/tmpmms6ilm3/datadir' failed with exitcode 128 [err: "
              "'Cloning into '/tmp/tmpmms6ilm3/datadir'...\n"
              'fatal: unable to access '
              "'https://github.com/datalad-datasets/human-connectome-project-openaccess.git/': "
              "The requested URL returned error: 403']\n"
              '- '
              'https://github.com/datalad-datasets/human-connectome-project-openaccess.git/.git\n'
              "  CommandError: 'git -c diff.ignoreSubmodules=none clone "
              '--progress '
              'https://github.com/datalad-datasets/human-connectome-project-openaccess.git/.git '
              "/tmp/tmpmms6ilm3/datadir' failed with exitcode 128 [err: "
              "'Cloning into '/tmp/tmpmms6ilm3/datadir'...\n"
              'fatal: unable to access '
              "'https://github.com/datalad-datasets/human-connectome-project-openaccess.git/.git/': "
              "The requested URL returned error: 403']"),
  'path': '/tmp/tmpmms6ilm3/datadir',
  'source': {'default_destpath': 'human-connectome-project-openaccess',
             'giturl': 'https://github.com/datalad-datasets/human-connectome-project-openaccess.git/.git',
             'source': 'https://github.com/datalad-datasets/human-connectome-project-openaccess.git',
             'type': 'giturl',
             'version': None},
  'source_url': 'https://github.com/datalad-datasets/human-connectome-project-openaccess.git',
  'status': 'error',
  'type': 'dataset'}]
  ```

This is the standard output:
```
2023-06-28 09:13:07,958 - JUNIFER - INFO - ===== Lib Versions =====
2023-06-28 09:13:07,958 - JUNIFER - INFO - numpy: 1.23.5
2023-06-28 09:13:07,958 - JUNIFER - INFO - scipy: 1.11.0
2023-06-28 09:13:07,958 - JUNIFER - INFO - pandas: 1.5.3
2023-06-28 09:13:07,958 - JUNIFER - INFO - nilearn: 0.10.0
2023-06-28 09:13:07,958 - JUNIFER - INFO - nibabel: 4.0.2
2023-06-28 09:13:07,958 - JUNIFER - INFO - junifer: 0.0.3.dev101
2023-06-28 09:13:07,958 - JUNIFER - INFO - ========================
2023-06-28 09:13:07,958 - JUNIFER - INFO - Parsing yaml file: /home/fraimondo/dev/projects/brain_size/1_compute_features/junifer_jobs/HCP_icbm152_mask_5mmreho/config.yaml
2023-06-28 09:13:07,970 - JUNIFER - INFO - Registering HCPCATConfounds in datagrabber
2023-06-28 09:13:07,970 - JUNIFER - INFO - Registering MultipleHCP in datagrabber
2023-06-28 09:13:07,970 - JUNIFER - INFO - `datadir` is None, creating a temporary directory
2023-06-28 09:13:07,971 - JUNIFER - INFO - `datadir` set to /tmp/tmpmms6ilm3/datadir
2023-06-28 09:13:07,972 - JUNIFER - INFO - `datadir` is None, creating a temporary directory
2023-06-28 09:13:07,972 - JUNIFER - INFO - `datadir` set to /tmp/tmp1bzrmjo4/datadir
```



### Expected Behavior

an error  being logged in the standard output

### Steps To Reproduce

This is hard to tell, maybe the best way to reproduce this is to try to run a test using a datalad dataset while not connected to the internet.

### Environment

```markdown
junifer:
  version: 0.0.3.dev101
python:
  version: 3.10.12
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.23.5
  datalad: 0.18.2+59.gc5054cb91
  pandas: 1.5.3
  nibabel: 4.0.2
  nilearn: 0.10.0
  sqlalchemy: 1.4.46
  ruamel.yaml: 0.17.32
system:
  platform: Linux-6.1.0-9-amd64-x86_64-with-glibc2.36
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: 
    /home/fraimondo/miniconda3/envs/afni/bin:/home/fraimondo/miniconda3/condabin:/home/fraimondo/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games
```


### Relevant log output

_No response_

### Anything else?

_No response_