### PR TITLE
[MAINT]: Bump `numpy` version

### DIFF
--- a/docs/changes/newsfragments/241.misc
+++ b/docs/changes/newsfragments/241.misc
@@ -1,0 +1,1 @@
+Bump ``numpy`` version constraint to ``>=1.24,<1.26`` by `Synchon Mandal`_

--- a/junifer/storage/tests/test_utils.py
+++ b/junifer/storage/tests/test_utils.py
@@ -23,7 +23,7 @@ from junifer.storage.utils import (
     "dependency, max_version",
     [
         ("click", "8.2"),
-        ("numpy", "1.24"),
+        ("numpy", "1.26"),
         ("datalad", "0.19"),
         ("pandas", "1.6"),
         ("nibabel", "4.1"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.3,<8.2",
-    "numpy>=1.22,<1.24",
+    "numpy>=1.24,<1.26",
     "datalad>=0.15.4,<0.19",
     "pandas>=1.4.0,<1.6",
     "nibabel>=3.2.0,<4.1",


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR bumps `numpy` version constraints to make `junifer` compatible with `julearn`.