### PR TITLE
[ENH]: Add `feature_md5` argument to `read_transform()`

### DIFF
--- a/docs/changes/newsfragments/248.change
+++ b/docs/changes/newsfragments/248.change
@@ -1,0 +1,1 @@
+Add ``feature_md5`` argument to :func:`.read_transform()` by `Synchon Mandal`_

--- a/junifer/onthefly/read_transform.py
+++ b/junifer/onthefly/read_transform.py
@@ -17,8 +17,9 @@ if TYPE_CHECKING:
 
 def read_transform(
     storage: Type["BaseFeatureStorage"],
-    feature_name: str,
     transform: str,
+    feature_name: Optional[str] = None,
+    feature_md5: Optional[str] = None,
     transform_args: Optional[Tuple] = None,
     transform_kw_args: Optional[Dict] = None,
 ) -> pd.DataFrame:
@@ -28,11 +29,13 @@ def read_transform(
     ----------
     storage : storage-like
         The storage class, for example, SQLiteFeatureStorage.
-    feature_name : str
-        Name of the feature to read.
     transform : str
         The kind of transform formatted as ``<package>_<function>``,
         for example, ``bctpy_degrees_und``.
+    feature_name : str, optional
+        Name of the feature to read (default None).
+    feature_md5 : str, optional
+        MD5 hash of the feature to read (default None).
     transform_args : tuple, optional
         The positional arguments for the callable of ``transform``
         (default None).
@@ -62,7 +65,9 @@ def read_transform(
     transform_kw_args = transform_kw_args or {}
 
     # Read storage
-    stored_data = storage.read(feature_name=feature_name)  # type: ignore
+    stored_data = storage.read(
+        feature_name=feature_name, feature_md5=feature_md5
+    )  # type: ignore
     # Retrieve package and function
     package, func_str = transform.split("_", 1)
     # Condition for package

--- a/junifer/onthefly/read_transform.py
+++ b/junifer/onthefly/read_transform.py
@@ -110,7 +110,8 @@ def read_transform(
         # Apply function and store subject-wise
         output_list = []
         logger.debug(
-            f"Computing '{package}.{func_str}' for feature {feature_name} ..."
+            f"Computing '{package}.{func_str}' for feature "
+            f"{feature_name or feature_md5} ..."
         )
         for subject in range(stored_data["data"].shape[2]):
             output = func(
@@ -124,7 +125,8 @@ def read_transform(
         idx_df = pd.DataFrame(data=stored_data["element"])
         # Create multiindex from dataframe
         logger.debug(
-            f"Generating pandas.MultiIndex for feature {feature_name} ..."
+            "Generating pandas.MultiIndex for feature "
+            f"{feature_name or feature_md5} ..."
         )
         data_idx = pd.MultiIndex.from_frame(df=idx_df)
 


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds `feature_md5` argument to `junifer.onthefly.read_transform()` to allow accessing storage features by MD5 hashes.