### PR TITLE
[BUG]: `extMDN` coordinates are falsely registered as `extDMN` coordinates in `junifer`

### DIFF
--- a/docs/builtin.rst
+++ b/docs/builtin.rst
@@ -437,7 +437,7 @@ Available
        | (2008).
        | https://doi.org/10.1196/annals.1440.011
    * - Missing formal name
-     - ``eMDN``
+     - ``extDMN``
      - 0.0.1
      - Missing publication details
    * - Empathic processing
@@ -457,7 +457,7 @@ Available
        | Brain structure & function, Volume 220, Pages 1031–1049 (2015).
        | https://doi.org/10.1007/s00429-013-0698-0
    * - Extended multiple-demand network
-     - ``extMDN``
+     - ``eMDN``
      - 0.0.1
      - | Camilleri, J.A., Müller, V.I., Fox, P. et al.
        | Definition and characterization of an extended multiple-demand network.

--- a/docs/changes/newsfragments/251.doc
+++ b/docs/changes/newsfragments/251.doc
@@ -1,0 +1,1 @@
+Rename ``extMDN`` to ``extDMN`` (extended default mode network) and fix listing for ``eMDN`` (extended multiple-demand network) by `Synchon Mandal`_


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

[In this table](https://juaml.github.io/junifer/main/builtin.html#id6) the extended multiple-demand network is correctly listed as `extMDN`, but when using the following marker:
```
  - name: extMDN
    kind: SphereAggregation
    coords: extMDN
    radius: 5
    method: mean
```

one gets the following error:
```
ValueError: Coordinates extMDN not found.
```

Using the `list_coordinates()` function, it seems clear why:
The naming is incorrect in junifer (`extDMN`)

```
>>> from junifer.data.coordinates import list_coordinates
>>> list_coordinates()
['CogAC', 'CogAR', 'DMNBuckner', 'Dosenbach', 'Empathy', 'Motor', 'MultiTask', 'PhysioStress', 'Power', 'Rew', 'Somatosensory', 'ToM', 'VigAtt', 'WM', 'eMDN', 'eSAD', 'extDMN']
```

### Expected Behavior

It should have the correct name and the marker should work.

### Steps To Reproduce

described above

### Environment

```markdown
❱ junifer wtf                                                                                                                              130 !
junifer:
  version: 0.0.2
python:
  version: 3.11.4
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.23.5
  datalad: 0.18.4
  pandas: 1.5.3
  nibabel: 4.0.2
  nilearn: 0.10.0
  sqlalchemy: 1.4.48
  yaml: '6.0'
system:
  platform: Linux-6.2.0-27-generic-x86_64-with-glibc2.37
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: /home/leonard/.venvs/base/bin:/home/leonard/.local/bin/pypy3.9-v7.3.11-linux64/bin:/usr/local/MRIcroGL:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/leonard/.cargo/bin:/home/leonard/.local/bin/pypy3.9-v7.3.11-linux64/bin:/usr/local/MRIcroGL:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

```
```


### Relevant log output

_No response_

### Anything else?

_No response_