### PR TITLE
[ENH]: Improve element-specific directory cleanup for `WorkDirManager`

### DIFF
--- a/docs/changes/newsfragments/259.enh
+++ b/docs/changes/newsfragments/259.enh
@@ -1,0 +1,1 @@
+Improve element directory cleanup via ``junifer.pipeline.WorkDirManager.cleanup_elementdir`` method by `Synchon Mandal`_

--- a/junifer/pipeline/tests/test_workdir_manager.py
+++ b/junifer/pipeline/tests/test_workdir_manager.py
@@ -55,6 +55,31 @@ def test_workdir_manager_get_and_delete_element_tempdir(
     assert workdir_mgr.elementdir is None
 
 
+def test_workdir_manager_cleanup_elementdir(
+    tmp_path: Path,
+) -> None:
+    """Test WorkDirManager cleans up element directory correctly.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    workdir_mgr = WorkDirManager()
+    workdir_mgr.workdir = tmp_path
+    # Check no element directory
+    assert workdir_mgr.elementdir is None
+
+    workdir_mgr.get_element_tempdir()
+    # Should create a temporary directory
+    assert workdir_mgr.elementdir is not None
+
+    workdir_mgr.cleanup_elementdir()
+    # Should remove temporary directory
+    assert workdir_mgr.elementdir is None
+
+
 def test_workdir_manager_get_and_delete_tempdir(tmp_path: Path) -> None:
     """Test WorkDirManager gets and deletes temporary directories correctly.
 

--- a/junifer/pipeline/workdir_manager.py
+++ b/junifer/pipeline/workdir_manager.py
@@ -71,13 +71,7 @@ class WorkDirManager:
     def _cleanup(self) -> None:
         """Clean up the element and temporary directories."""
         # Remove element directory
-        if self._elementdir is not None:
-            logger.debug(
-                "Deleting element directory at "
-                f"{self._elementdir.resolve()!s}"
-            )
-            shutil.rmtree(self._elementdir, ignore_errors=True)
-            self._elementdir = None
+        self.cleanup_elementdir()
         # Remove root temporary directory
         if self._root_tempdir is not None:
             logger.debug(
@@ -177,6 +171,22 @@ class WorkDirManager:
         """
         logger.debug(f"Deleting element temporary directory at {tempdir}")
         shutil.rmtree(tempdir, ignore_errors=True)
+
+    def cleanup_elementdir(self) -> None:
+        """Clean up element directory.
+
+        It should preferably be used after fitting a marker or something
+        similar in the element-specific scope. If called between components,
+        can lead to required intermediate files not being found.
+
+        """
+        if self._elementdir is not None:
+            logger.debug(
+                "Deleting element directory at "
+                f"{self._elementdir.resolve()!s}"
+            )
+            shutil.rmtree(self._elementdir, ignore_errors=True)
+            self._elementdir = None
 
     @property
     def root_tempdir(self) -> Optional[Path]:


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds `cleanup_elementdir()` method to `WorkDirManager` to allow easy cleanup of element directory.