### PR TITLE
[MAINT]: Pin `ruff` and update housekeeping configs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox ruff
+          python -m pip install tox "ruff>=0.1.0"
       - name: Run ruff
-        run: ruff check --format=github .
+        run: ruff check --output-format=github .
       - name: Run codespell
         run: tox -e codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-ast
       - id: check-docstring-first
@@ -17,23 +17,24 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.2
+    rev: v0.15
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
       - id: black
         exclude: ^(docs/|examples/|tools/)
         args: [--check]
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.267
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.0
     hooks:
       - id: ruff
+        types_or: [python, jupyter]
         exclude: ^(__init__.py)
-        args: [--format, grouped, --show-fixes]
+        args: [--output-format, grouped, --show-fixes]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.6
     hooks:
       - id: codespell
         exclude: ^(.github/|docs/)

--- a/docs/changes/newsfragments/261.misc
+++ b/docs/changes/newsfragments/261.misc
@@ -1,0 +1,1 @@
+Pin ``ruff`` to ``0.1.0`` as the lowest version and update ``pre-commit`` config by `Synchon Mandal`_

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
 [testenv:ruff]
 skip_install = true
 deps =
-    ruff
+    ruff>=0.1.0
 commands =
     ruff check {toxinidir}
 


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR pins `ruff` to `0.1.0` as the lowest version to not break workflow and update `tox.ini`, `.pre-commit-config.yaml` and `lint.yml`.