### PR TITLE
[MAINT]: Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -48,4 +48,4 @@ jobs:
           # Allow coverage upload failure
           fail_ci_if_error: false
           flags: docs
-        if: success() && matrix.python-version == 3.10
+        if: success() && matrix.python-version == 3.11

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -40,7 +40,7 @@ jobs:
           echo '</package>' >> coverage.xml
           echo '</packages>' >> coverage.xml
           echo '</coverage>' >> coverage.xml
-        if: matrix.python-version == 3.10
+        if: matrix.python-version == 3.11
       - name: Upload mock coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - run: 'echo "No build required"'
       - name: Create mock coverage.xml file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Set up system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
         curl -O https://afni.nimh.nih.gov/pub/dist/bin/misc/@update.afni.binaries
         sudo tcsh @update.afni.binaries -package linux_ubuntu_16_64 -bindir /afni
         echo "/afni" >> $GITHUB_PATH
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.11
     - name: Check AFNI
       run: |
         echo "Using AFNI : $(afni --version)"
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.11
     - name: Install ANTs
       run: |
         sudo apt-get install -y -qq unzip
@@ -78,11 +78,11 @@ jobs:
         mv /opt/ants-2.5.1/bin/* /opt/ants-2.5.1
         rm ants.zip
         echo "/opt/ants-2.5.1" >> $GITHUB_PATH
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.11
     - name: Check ANTs
       run: |
         echo "Using ANTs : $(antsRegistration --version)"
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.11
     - name: Install FSL
       run: |
         sudo apt-get install -y -qq python3
@@ -96,13 +96,13 @@ jobs:
         FSLREMOTECALL=""
         FSLGECUDAQ="cuda.q"
         echo "/opt/fsl-6.0.6.4" >> $GITHUB_PATH
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.11
       # Bypass FSL installation failure
       continue-on-error: true
     - name: Check FSL
       run: |
         echo "Using FSL : $(flirt -version)"
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.11
       # Bypass FSL installation failure
       continue-on-error: true
     - name: Test with tox
@@ -114,4 +114,4 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         flags: junifer
-      if: success() && matrix.python-version == 3.10
+      if: success() && matrix.python-version == 3.11

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Check for sudo
       shell: bash
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,10 @@ jobs:
         # require all of history to see all tagged versions' docs
         fetch-depth: 0
         submodules: true
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Check for sudo
       shell: bash
       run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,11 +25,6 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run:
         python -m build --sdist --wheel --outdir dist/ .
-    # - name: Publish distribution 📦 to Test PyPI
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     password: ${{ secrets.testpypi_token }}
-    #     repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,10 +15,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install build
       run:
         pip install build

--- a/docs/changes/newsfragments/270.misc
+++ b/docs/changes/newsfragments/270.misc
@@ -1,0 +1,1 @@
+Add support for Python 3.12 and make Python 3.11 the base for code coverage and CI checks by `Synchon Mandal`_

--- a/junifer/api/tests/test_api_utils.py
+++ b/junifer/api/tests/test_api_utils.py
@@ -46,8 +46,13 @@ def test_get_dependency_information_short() -> None:
         "tqdm",
         "templateflow",
     ]
-    if int(pl.python_version_tuple()[1]) < 10:
+
+    python_minor_version = int(pl.python_version_tuple()[1])
+    if python_minor_version < 10:
         dependency_list.append("importlib_metadata")
+    elif python_minor_version >= 12:
+        dependency_list.append("looseversion")
+
     assert frozenset(dependency_information.keys()) == frozenset(
         dependency_list
     )

--- a/junifer/api/tests/test_api_utils.py
+++ b/junifer/api/tests/test_api_utils.py
@@ -45,13 +45,12 @@ def test_get_dependency_information_short() -> None:
         "httpx",
         "tqdm",
         "templateflow",
+        "looseversion",
     ]
 
     python_minor_version = int(pl.python_version_tuple()[1])
     if python_minor_version < 10:
         dependency_list.append("importlib_metadata")
-    elif python_minor_version >= 12:
-        dependency_list.append("looseversion")
 
     assert frozenset(dependency_information.keys()) == frozenset(
         dependency_list

--- a/junifer/utils/logging.py
+++ b/junifer/utils/logging.py
@@ -4,9 +4,13 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+try:
+    from distutils.version import LooseVersion
+except ImportError:  # pragma: no cover
+    from looseversion import LooseVersion
+
 import logging
 import sys
-from distutils.version import LooseVersion
 from pathlib import Path
 from subprocess import PIPE, Popen, TimeoutExpired
 from typing import Dict, NoReturn, Optional, Type, Union

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "httpx[http2]==0.26.0",
     "tqdm==4.66.1",
     "templateflow>=23.0.0",
+    "looseversion==1.3.0; python_version>='3.12'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "click>=8.1.3,<8.2",
@@ -98,7 +99,7 @@ write_to = "junifer/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 extend-exclude = """
 (
   junifer/external/h5io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,11 @@ dependencies = [
     "nilearn>=0.9.0,<=0.10.2",
     "sqlalchemy>=1.4.27,<=2.1.0",
     "ruamel.yaml>=0.17,<0.18",
-    "importlib_metadata; python_version<'3.10'",
-    "h5py>=3.8.0,<3.10",
+    "h5py>=3.10",
     "httpx[http2]==0.26.0",
     "tqdm==4.66.1",
     "templateflow>=23.0.0",
+    "importlib_metadata; python_version<'3.10'",
     "looseversion==1.3.0; python_version>='3.12'",
 ]
 dynamic = ["version"]

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ isolated_build = true
 python =
     3.8: py38
     3.9: py39
-    3.10: coverage
-    3.11: py311
+    3.10: py310
+    3.11: coverage
     3.12: py312
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = ruff, black, test, coverage, codespell, py3{8,9,10,11}
+envlist = ruff, black, test, coverage, codespell, py3{8,9,10,11,12}
 isolated_build = true
 
 [gh-actions]
@@ -8,6 +8,7 @@ python =
     3.9: py39
     3.10: coverage
     3.11: py311
+    3.12: py312
 
 [testenv]
 skip_install = false


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds support for Python 3.12 by adding tests against it in CI and makes Python 3.11 the base for coverage and CI checks.