### PR TITLE
[FIX]: Make native warped components persist

### DIFF
--- a/docs/changes/newsfragments/274.bugfix
+++ b/docs/changes/newsfragments/274.bugfix
@@ -1,0 +1,1 @@
+Store native warped parcellations, coordinates and masks in element-scoped tempdirs for the pipeline to work by `Synchon Mandal`_

--- a/junifer/data/masks.py
+++ b/junifer/data/masks.py
@@ -344,15 +344,20 @@ def get_mask(  # noqa: C901
                 f"{target_data['space']} space for further computation."
             )
 
-        # Create tempdir
+        # Create component-scoped tempdir
         tempdir = WorkDirManager().get_tempdir(prefix="masks")
 
-        # Save mask image
+        # Save mask image to a component-scoped tempfile
         prewarp_mask_path = tempdir / "prewarp_mask.nii.gz"
         nib.save(mask_img, prewarp_mask_path)
 
-        # Create a tempfile for warped output
-        applywarp_out_path = tempdir / "mask_warped.nii.gz"
+        # Create element-scoped tempdir so that warped mask is
+        # available later as nibabel stores file path reference for
+        # loading on computation
+        element_tempdir = WorkDirManager().get_element_tempdir(prefix="masks")
+
+        # Create an element-scoped tempfile for warped output
+        applywarp_out_path = element_tempdir / "mask_warped.nii.gz"
         # Set applywarp command
         applywarp_cmd = [
             "applywarp",

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -289,15 +289,22 @@ def get_parcellation(
                 f"{target_data['space']} space for further computation."
             )
 
-        # Create tempdir
+        # Create component-scoped tempdir
         tempdir = WorkDirManager().get_tempdir(prefix="parcellations")
 
-        # Save parcellation image
+        # Save parcellation image to a component-scoped tempfile
         prewarp_parcellation_path = tempdir / "prewarp_parcellation.nii.gz"
         nib.save(resampled_parcellation_img, prewarp_parcellation_path)
 
-        # Create a tempfile for warped output
-        applywarp_out_path = tempdir / "parcellation_warped.nii.gz"
+        # Create element-scoped tempdir so that warped parcellation is
+        # available later as nibabel stores file path reference for
+        # loading on computation
+        element_tempdir = WorkDirManager().get_element_tempdir(
+            prefix="parcellations"
+        )
+
+        # Create an element-scoped tempfile for warped output
+        applywarp_out_path = element_tempdir / "parcellation_warped.nii.gz"
         # Set applywarp command
         applywarp_cmd = [
             "applywarp",

--- a/junifer/preprocess/fsl/bold_warper.py
+++ b/junifer/preprocess/fsl/bold_warper.py
@@ -35,7 +35,7 @@ class BOLDWarper(BasePreprocessor):
     ] = [
         {
             "name": "fsl",
-            "optional": True,
+            "optional": False,
             "commands": ["applywarp"],
         },
     ]


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR makes native warped components (parcellations, coordinates and masks) persist after the warping is complete via element-scoped tempdirs and tempfiles. This is needed due to nibabel and numpy caching file paths for computation later.