### PR TITLE
[BUG]: Fix interpolation scheme for native parcellation and mask

### DIFF
--- a/docs/changes/newsfragments/276.bugfix
+++ b/docs/changes/newsfragments/276.bugfix
@@ -1,0 +1,1 @@
+Change interpolation scheme for parcel and mask native space transformation to nearest neighbour by `Synchon Mandal`_

--- a/junifer/data/masks.py
+++ b/junifer/data/masks.py
@@ -361,7 +361,7 @@ def get_mask(  # noqa: C901
         # Set applywarp command
         applywarp_cmd = [
             "applywarp",
-            "--interp=spline",
+            "--interp=nn",
             f"-i {prewarp_mask_path.resolve()}",
             # use resampled reference
             f"-r {target_data['reference_path'].resolve()}",

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -308,7 +308,7 @@ def get_parcellation(
         # Set applywarp command
         applywarp_cmd = [
             "applywarp",
-            "--interp=spline",
+            "--interp=nn",
             f"-i {prewarp_parcellation_path.resolve()}",
             # use resampled reference
             f"-r {target_data['reference_path'].resolve()}",


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR fixes the interpolation scheme for parcellation and mask transformation to native space, to nearest neighbour instead of spline.