### PR TITLE
[BUG]: Fix FSL `std2imgcoord` I/O

### DIFF
--- a/docs/changes/newsfragments/278.bugfix
+++ b/docs/changes/newsfragments/278.bugfix
@@ -1,0 +1,1 @@
+Bypass FSL ``std2imgcoord`` stdin bug and use recommended piped input for coordinates transformation by `Synchon Mandal`_

--- a/junifer/data/coordinates.py
+++ b/junifer/data/coordinates.py
@@ -260,11 +260,12 @@ def get_coordinates(
         std2imgcoord_out_path = element_tempdir / "coordinates_transformed.txt"
         # Set std2imgcoord command
         std2imgcoord_cmd = [
-            "std2imgcoord",
+            "cat",
+            f"{pretransform_coordinates_path.resolve()}",
+            "| std2imgcoord",
             f"-img {target_data['reference_path'].resolve()}",
             f"-warp {extra_input['Warp']['path'].resolve()}",
-            f"{pretransform_coordinates_path.resolve()}",
-            f"> {std2imgcoord_out_path.resolve()}",
+            f"- > {std2imgcoord_out_path.resolve()}",
         ]
         # Call std2imgcoord
         std2imgcoord_cmd_str = " ".join(std2imgcoord_cmd)


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR uses the recommended way to bypass the FSL `std2imgcoord` bug used in coordinates transformation to other template spaces.