### PR TITLE
[BUG]: Fix FSL `std2imgcoord` source image

### DIFF
--- a/docs/changes/newsfragments/280.bugfix
+++ b/docs/changes/newsfragments/280.bugfix
@@ -1,0 +1,1 @@
+Add ``-std`` to FSL ``std2imgcoord`` for coordinates transformation by `Synchon Mandal`_

--- a/junifer/data/coordinates.py
+++ b/junifer/data/coordinates.py
@@ -262,8 +262,9 @@ def get_coordinates(
         std2imgcoord_cmd = [
             "cat",
             f"{pretransform_coordinates_path.resolve()}",
-            "| std2imgcoord",
+            "| std2imgcoord -mm",
             f"-img {target_data['reference_path'].resolve()}",
+            f"-std {target_data['path'].resolve()}",
             f"-warp {extra_input['Warp']['path'].resolve()}",
             f"- > {std2imgcoord_out_path.resolve()}",
         ]


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds `-std` to FSL `std2imgcoord` for coordinates warping to subject-native template space.