### PR TITLE
[BUG]: Propagate ReHo and fALFF maps' file paths

### DIFF
--- a/docs/changes/newsfragments/282.bugfix
+++ b/docs/changes/newsfragments/282.bugfix
@@ -1,0 +1,1 @@
+Propagate ReHo and fALFF maps, for aggregation to convert to other template spaces when required by `Synchon Mandal`_

--- a/junifer/markers/falff/falff_base.py
+++ b/junifer/markers/falff/falff_base.py
@@ -148,7 +148,7 @@ class ALFFBase(BaseMarker):
 
         estimator = ALFFEstimator()
 
-        alff, falff = estimator.fit_transform(
+        alff, falff, alff_path, falff_path = estimator.fit_transform(
             use_afni=self.use_afni,
             input_data=input,
             highpass=self.highpass,
@@ -156,10 +156,11 @@ class ALFFBase(BaseMarker):
             tr=self.tr,
         )
         post_data = falff if self.fractional else alff
+        post_path = falff_path if self.fractional else alff_path
 
         post_input = dict(input.items())
         post_input["data"] = post_data
-        post_input["path"] = None
+        post_input["path"] = post_path
 
         out = self._postprocess(post_input, extra_input=extra_input)
 

--- a/junifer/markers/falff/falff_estimator.py
+++ b/junifer/markers/falff/falff_estimator.py
@@ -34,11 +34,6 @@ class ALFFEstimator:
     .. warning:: This class can only be used via :class:`.ALFFBase` as it
     serves a specific purpose.
 
-    Parameters
-    ----------
-    use_afni : bool
-        Whether to use afni for computation. If False, will use python.
-
     Attributes
     ----------
     temp_dir_path : pathlib.Path
@@ -71,6 +66,7 @@ class ALFFEstimator:
         ------
         RuntimeError
             If AFNI command fails.
+
         """
         logger.info(f"AFNI command to be executed: {cmd}")
         process = subprocess.run(

--- a/junifer/markers/falff/tests/test_falff_estimator.py
+++ b/junifer/markers/falff/tests/test_falff_estimator.py
@@ -55,7 +55,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
 
     # Compute again with cache, should be faster
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -68,7 +68,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
 
     # Change a parameter and compute again without cache
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -81,7 +81,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
 
     # Compute again with cache, should be faster
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -99,7 +99,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
     subject_data = DefaultDataReader().fit_transform(subject)
 
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -135,7 +135,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
 
     # Compute with cache
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -146,12 +146,14 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     logger.info(f"ALFF Estimator First time: {first_time}")
     assert isinstance(alff, Nifti1Image)
     assert isinstance(falff, Nifti1Image)
+    assert isinstance(alff_path, Path)
+    assert isinstance(falff_path, Path)
     n_files = len(list(estimator.temp_dir_path.glob("*")))
     assert n_files == 3  # input + alff + falff
 
     # Compute again with cache, should be faster
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -166,7 +168,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
 
     # Change a parameter and compute again without cache
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -181,7 +183,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
 
     # Compute with cache, should be faster
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -201,7 +203,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     subject_data = DefaultDataReader().fit_transform(subject)
 
     start_time = time.time()
-    alff, falff, alff_path, falff_path = estimator.fit_transform(
+    alff, falff, _, _ = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,

--- a/junifer/markers/falff/tests/test_falff_estimator.py
+++ b/junifer/markers/falff/tests/test_falff_estimator.py
@@ -149,7 +149,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     assert isinstance(alff_path, Path)
     assert isinstance(falff_path, Path)
     n_files = len(list(estimator.temp_dir_path.glob("*")))
-    assert n_files == 3  # input + alff + falff
+    assert n_files == 1  # only input file
 
     # Compute again with cache, should be faster
     start_time = time.time()
@@ -164,7 +164,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     logger.info(f"ALFF Estimator Second time: {second_time}")
     assert second_time < (first_time / 1000)
     n_files = len(list(estimator.temp_dir_path.glob("*")))
-    assert n_files == 3  # input + alff + falff
+    assert n_files == 1  # only input file
 
     # Change a parameter and compute again without cache
     start_time = time.time()
@@ -179,7 +179,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     logger.info(f"ALFF Estimator Third time: {third_time}")
     assert third_time > (first_time / 10)
     n_files = len(list(estimator.temp_dir_path.glob("*")))
-    assert n_files == 3  # input + alff + falff
+    assert n_files == 1  # only input file
 
     # Compute with cache, should be faster
     start_time = time.time()
@@ -194,7 +194,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     logger.info(f"ALFF Estimator Fourth time: {fourth}")
     assert fourth < (first_time / 1000)
     n_files = len(list(estimator.temp_dir_path.glob("*")))
-    assert n_files == 3  # input + alff + falff
+    assert n_files == 1  # only input file
 
     # Change the data and it should clear the cache
     with PartlyCloudyTestingDataGrabber() as dg:
@@ -214,7 +214,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     logger.info(f"ALFF Estimator Fifth time: {fifth}")
     assert fifth > (first_time / 10)
     n_files = len(list(estimator.temp_dir_path.glob("*")))
-    assert n_files == 3  # input + alff + falff
+    assert n_files == 1  # only input file
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/falff/tests/test_falff_estimator.py
+++ b/junifer/markers/falff/tests/test_falff_estimator.py
@@ -39,7 +39,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
 
     # Compute without cache
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -50,10 +50,12 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
     logger.info(f"ALFF Estimator First time: {first_time}")
     assert isinstance(alff, Nifti1Image)
     assert isinstance(falff, Nifti1Image)
+    assert isinstance(alff_path, Path)
+    assert isinstance(falff_path, Path)
 
     # Compute again with cache, should be faster
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -66,7 +68,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
 
     # Change a parameter and compute again without cache
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -79,7 +81,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
 
     # Compute again with cache, should be faster
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -97,7 +99,7 @@ def test_ALFFEstimator_cache_python(tmp_path: Path) -> None:
     subject_data = DefaultDataReader().fit_transform(subject)
 
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -149,7 +151,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
 
     # Compute again with cache, should be faster
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -164,7 +166,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
 
     # Change a parameter and compute again without cache
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -179,7 +181,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
 
     # Compute with cache, should be faster
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -199,7 +201,7 @@ def test_ALFFEstimator_cache_afni(tmp_path: Path) -> None:
     subject_data = DefaultDataReader().fit_transform(subject)
 
     start_time = time.time()
-    alff, falff = estimator.fit_transform(
+    alff, falff, alff_path, falff_path = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -236,7 +238,7 @@ def test_ALFFEstimator_afni_vs_python(tmp_path: Path) -> None:
     estimator = ALFFEstimator()
 
     # Use an arbitrary TR to test the AFNI vs Python implementation
-    afni_alff, afni_falff = estimator.fit_transform(
+    afni_alff, afni_falff, _, _ = estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         highpass=0.01,
@@ -244,7 +246,7 @@ def test_ALFFEstimator_afni_vs_python(tmp_path: Path) -> None:
         tr=2.5,
     )
 
-    python_alff, python_falff = estimator.fit_transform(
+    python_alff, python_falff, _, _ = estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         highpass=0.01,

--- a/junifer/markers/reho/reho_base.py
+++ b/junifer/markers/reho/reho_base.py
@@ -4,7 +4,17 @@
 # License: AGPL
 
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from ...utils import logger, raise_error
 from ..base import BaseMarker
@@ -78,7 +88,7 @@ class ReHoBase(BaseMarker):
         self,
         input: Dict[str, Any],
         **reho_params: Any,
-    ) -> "Nifti1Image":
+    ) -> Tuple["Nifti1Image", Path]:
         """Compute.
 
         Calculates Kendall's W per voxel using neighborhood voxels.
@@ -98,6 +108,9 @@ class ReHoBase(BaseMarker):
         Returns
         -------
         Niimg-like object
+            The ReHo map as NIfTI.
+        pathlib.Path
+            The path to the ReHo map as NIfTI.
 
         References
         ----------
@@ -120,9 +133,8 @@ class ReHoBase(BaseMarker):
         # Initialize reho estimator
         reho_estimator = ReHoEstimator()
         # Fit-transform reho estimator
-        reho_map = reho_estimator.fit_transform(
+        return reho_estimator.fit_transform(
             use_afni=self.use_afni,
             input_data=input,
             **reho_params,
         )
-        return reho_map

--- a/junifer/markers/reho/reho_parcels.py
+++ b/junifer/markers/reho/reho_parcels.py
@@ -128,9 +128,11 @@ class ReHoParcels(ReHoBase):
         logger.info("Calculating ReHo for parcels.")
         # Calculate reho map
         if self.reho_params is not None:
-            reho_map = self.compute_reho_map(input=input, **self.reho_params)
+            reho_map, reho_file_path = self.compute_reho_map(
+                input=input, **self.reho_params
+            )
         else:
-            reho_map = self.compute_reho_map(input=input)
+            reho_map, reho_file_path = self.compute_reho_map(input=input)
         # Initialize parcel aggregation
         parcel_aggregation = ParcelAggregation(
             parcellation=self.parcellation,
@@ -142,7 +144,7 @@ class ReHoParcels(ReHoBase):
         # Perform aggregation on reho map
         parcel_aggregation_input = dict(input.items())
         parcel_aggregation_input["data"] = reho_map
-        parcel_aggregation_input["path"] = None
+        parcel_aggregation_input["path"] = reho_file_path
 
         output = parcel_aggregation.compute(
             input=parcel_aggregation_input,

--- a/junifer/markers/reho/reho_spheres.py
+++ b/junifer/markers/reho/reho_spheres.py
@@ -140,9 +140,11 @@ class ReHoSpheres(ReHoBase):
         logger.info("Calculating ReHo for spheres.")
         # Calculate reho map
         if self.reho_params is not None:
-            reho_map = self.compute_reho_map(input=input, **self.reho_params)
+            reho_map, reho_file_path = self.compute_reho_map(
+                input=input, **self.reho_params
+            )
         else:
-            reho_map = self.compute_reho_map(input=input)
+            reho_map, reho_file_path = self.compute_reho_map(input=input)
         # Initialize sphere aggregation
         sphere_aggregation = SphereAggregation(
             coords=self.coords,
@@ -156,7 +158,7 @@ class ReHoSpheres(ReHoBase):
         # Perform aggregation on reho map
         sphere_aggregation_input = dict(input.items())
         sphere_aggregation_input["data"] = reho_map
-        sphere_aggregation_input["path"] = None
+        sphere_aggregation_input["path"] = reho_file_path
         output = sphere_aggregation.compute(
             input=sphere_aggregation_input, extra_input=extra_input
         )

--- a/junifer/markers/reho/tests/test_reho_estimator.py
+++ b/junifer/markers/reho/tests/test_reho_estimator.py
@@ -56,7 +56,10 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
 
     # Compute again with cache, should be faster
     second_tic = time.time()
-    reho_map_with_cache, _ = reho_estimator.fit_transform(
+    (
+        reho_map_with_cache,
+        reho_map_with_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         nneigh=27,
@@ -66,6 +69,7 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
         f"ReHo estimator in Python with cache: {second_toc - second_tic}"
     )
     assert isinstance(reho_map_with_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_cache_path, Path)
     # Check that cache is being used
     assert (second_toc - second_tic) < ((first_toc - first_tic) / 1000)
 
@@ -73,7 +77,7 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
     third_tic = time.time()
     (
         reho_map_with_partial_cache,
-        reho_map_with_partial_path,
+        reho_map_with_partial_cache_path,
     ) = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
@@ -84,7 +88,7 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
         f"ReHo estimator in Python with partial cache: {third_toc - third_tic}"
     )
     assert isinstance(reho_map_with_partial_cache, nib.Nifti1Image)
-    assert isinstance(reho_map_with_partial_path, Path)
+    assert isinstance(reho_map_with_partial_cache_path, Path)
     # Should require more time
     assert (third_toc - third_tic) > ((first_toc - first_tic) / 10)
 
@@ -157,7 +161,10 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
 
     # Compute without cache
     first_tic = time.time()
-    reho_map_without_cache = reho_estimator.fit_transform(
+    (
+        reho_map_without_cache,
+        reho_map_without_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         nneigh=19,
@@ -167,13 +174,17 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
         f"ReHo estimator in AFNI without cache: {first_toc - first_tic}"
     )
     assert isinstance(reho_map_without_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_without_cache_path, Path)
     # Count intermediate files
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
     assert n_files == 2  # input + reho
 
     # Compute again with cache, should be faster
     second_tic = time.time()
-    reho_map_with_cache = reho_estimator.fit_transform(
+    (
+        reho_map_with_cache,
+        reho_map_with_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         nneigh=19,
@@ -183,6 +194,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
         f"ReHo estimator in AFNI with cache: {second_toc - second_tic}"
     )
     assert isinstance(reho_map_with_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_cache_path, Path)
     assert (second_toc - second_tic) < ((first_toc - first_tic) / 1000)
     # Count intermediate files
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
@@ -190,7 +202,10 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
 
     # Change a parameter and compute again without cache
     third_tic = time.time()
-    reho_map_with_partial_cache = reho_estimator.fit_transform(
+    (
+        reho_map_with_partial_cache,
+        reho_map_with_partial_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         nneigh=27,
@@ -200,6 +215,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
         f"ReHo estimator in AFNI with partial cache: {third_toc - third_tic}"
     )
     assert isinstance(reho_map_with_partial_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_partial_cache_path, Path)
     # Should require more time
     assert (third_toc - third_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
@@ -208,7 +224,10 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
 
     # Compute with cache, should be faster
     fourth_tic = time.time()
-    reho_map_with_new_cache = reho_estimator.fit_transform(
+    (
+        reho_map_with_new_cache,
+        reho_map_with_new_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         nneigh=27,
@@ -218,6 +237,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
         f"ReHo estimator in AFNI with new cache: {fourth_toc - fourth_tic}"
     )
     assert isinstance(reho_map_with_new_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_new_cache_path, Path)
     # Should require less time
     assert (fourth_toc - fourth_tic) < ((first_toc - first_tic) / 1000)
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
@@ -230,7 +250,10 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
     subject_data = DefaultDataReader().fit_transform(subject)
 
     fifth_tic = time.time()
-    reho_map_with_different_cache = reho_estimator.fit_transform(
+    (
+        reho_map_with_different_cache,
+        reho_map_with_different_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         nneigh=27,
@@ -240,6 +263,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
         f"ReHo estimator in AFNI with different cache: {fifth_toc - fifth_tic}"
     )
     assert isinstance(reho_map_with_different_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_different_cache_path, Path)
     # Should take less time
     assert (fifth_toc - fifth_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
@@ -270,12 +294,12 @@ def test_reho_estimator_afni_vs_python(tmp_path: Path) -> None:
     reho_estimator = ReHoEstimator()
 
     # Compare using 27 neighbours
-    reho_map_afni = reho_estimator.fit_transform(
+    reho_map_afni, _ = reho_estimator.fit_transform(
         use_afni=True,
         input_data=subject_data["BOLD"],
         nneigh=27,
     )
-    reho_map_python = reho_estimator.fit_transform(
+    reho_map_python, _ = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         nneigh=27,

--- a/junifer/markers/reho/tests/test_reho_estimator.py
+++ b/junifer/markers/reho/tests/test_reho_estimator.py
@@ -39,7 +39,10 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
 
     # Compute without cache
     first_tic = time.time()
-    reho_map_without_cache = reho_estimator.fit_transform(
+    (
+        reho_map_without_cache,
+        reho_map_without_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         nneigh=27,
@@ -49,10 +52,11 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
         f"ReHo estimator in Python without cache: {first_toc - first_tic}"
     )
     assert isinstance(reho_map_without_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_without_cache_path, Path)
 
     # Compute again with cache, should be faster
     second_tic = time.time()
-    reho_map_with_cache = reho_estimator.fit_transform(
+    reho_map_with_cache, _ = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         nneigh=27,
@@ -67,7 +71,10 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
 
     # Change a parameter and compute again without cache
     third_tic = time.time()
-    reho_map_with_partial_cache = reho_estimator.fit_transform(
+    (
+        reho_map_with_partial_cache,
+        reho_map_with_partial_path,
+    ) = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         nneigh=125,
@@ -77,12 +84,16 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
         f"ReHo estimator in Python with partial cache: {third_toc - third_tic}"
     )
     assert isinstance(reho_map_with_partial_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_partial_path, Path)
     # Should require more time
     assert (third_toc - third_tic) > ((first_toc - first_tic) / 10)
 
     # Compute again with cache, should be faster
     fourth_tic = time.time()
-    reho_map_with_new_cache = reho_estimator.fit_transform(
+    (
+        reho_map_with_new_cache,
+        reho_map_with_new_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         nneigh=125,
@@ -92,6 +103,7 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
         f"ReHo estimator in Python with new cache: {fourth_toc - fourth_tic}"
     )
     assert isinstance(reho_map_with_new_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_new_cache_path, Path)
     # Should require less time
     assert (fourth_toc - fourth_tic) < ((first_toc - first_tic) / 1000)
 
@@ -102,7 +114,10 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
     subject_data = DefaultDataReader().fit_transform(subject)
 
     fifth_tic = time.time()
-    reho_map_with_different_cache = reho_estimator.fit_transform(
+    (
+        reho_map_with_different_cache,
+        reho_map_with_different_cache_path,
+    ) = reho_estimator.fit_transform(
         use_afni=False,
         input_data=subject_data["BOLD"],
         nneigh=27,
@@ -113,6 +128,7 @@ def test_reho_estimator_cache_python(tmp_path: Path) -> None:
         f"{fifth_toc - fifth_tic}"
     )
     assert isinstance(reho_map_with_different_cache, nib.Nifti1Image)
+    assert isinstance(reho_map_with_different_cache_path, Path)
     # Should take less time
     assert (fifth_toc - fifth_tic) > ((first_toc - first_tic) / 10)
 

--- a/junifer/markers/reho/tests/test_reho_estimator.py
+++ b/junifer/markers/reho/tests/test_reho_estimator.py
@@ -177,7 +177,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
     assert isinstance(reho_map_without_cache_path, Path)
     # Count intermediate files
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
-    assert n_files == 2  # input + reho
+    assert n_files == 1  # only input file
 
     # Compute again with cache, should be faster
     second_tic = time.time()
@@ -198,7 +198,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
     assert (second_toc - second_tic) < ((first_toc - first_tic) / 1000)
     # Count intermediate files
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
-    assert n_files == 2  # input + reho
+    assert n_files == 1  # only input file
 
     # Change a parameter and compute again without cache
     third_tic = time.time()
@@ -220,7 +220,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
     assert (third_toc - third_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
-    assert n_files == 2  # input + reho
+    assert n_files == 1  # only input file
 
     # Compute with cache, should be faster
     fourth_tic = time.time()
@@ -241,7 +241,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
     # Should require less time
     assert (fourth_toc - fourth_tic) < ((first_toc - first_tic) / 1000)
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
-    assert n_files == 2  # input + reho
+    assert n_files == 1  # only input file
 
     # Change the data and it should clear the cache
     with PartlyCloudyTestingDataGrabber() as dg:
@@ -268,7 +268,7 @@ def test_reho_estimator_cache_afni(tmp_path: Path) -> None:
     assert (fifth_toc - fifth_tic) > ((first_toc - first_tic) / 10)
     # Count intermediate files
     n_files = len(list(reho_estimator.temp_dir_path.glob("*")))
-    assert n_files == 2  # input + reho
+    assert n_files == 1  # only input file
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR enables file path propagation for ReHo and fALFF maps from the estimator to the compute step so that aggregation markers can use it for conversion to other template spaces if and when required.