### PR TITLE
[BUG]: WorkDirManager does not accept string as workdir

### DIFF
--- a/docs/changes/newsfragments/283.bugfix
+++ b/docs/changes/newsfragments/283.bugfix
@@ -1,0 +1,1 @@
+Allow :class:`junifer.pipeline.WorkDirManager` to accept str via the ``workdir`` parameter by `Synchon Mandal`_

--- a/junifer/pipeline/workdir_manager.py
+++ b/junifer/pipeline/workdir_manager.py
@@ -42,7 +42,7 @@ class WorkDirManager:
 
     def __init__(self, workdir: Optional[Union[str, Path]] = None) -> None:
         """Initialize the class."""
-        self._workdir = workdir
+        self._workdir = Path(workdir) if isinstance(workdir, str) else workdir
         self._elementdir = None
         self._root_tempdir = None
 

--- a/junifer/storage/tests/test_utils.py
+++ b/junifer/storage/tests/test_utils.py
@@ -23,12 +23,12 @@ from junifer.storage.utils import (
     "dependency, max_version",
     [
         ("click", "8.2"),
-        ("numpy", "1.26"),
-        ("datalad", "0.19"),
-        ("pandas", "1.6"),
-        ("nibabel", "4.1"),
-        ("nilearn", "0.10.0"),
-        ("sqlalchemy", "1.5.0"),
+        ("numpy", "1.27"),
+        ("datalad", "0.20"),
+        ("pandas", "2.2"),
+        ("nibabel", "5.11"),
+        ("nilearn", "0.11.0"),
+        ("sqlalchemy", "2.1.0"),
         ("ruamel.yaml", "0.18.0"),
     ],
 )


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

This fails:
```
WorkDirManager(
    workdir="/home/fraimondo/dev/scratch/test_junifer_native/temp",
)
```

Because workdir is not a Path.

### Expected Behavior

to work

### Steps To Reproduce

1. Plain junifer from main
2. Just run this on ipython:
```
from junifer.pipeline import WorkDirManager

WorkDirManager(
    workdir="/home/fraimondo/dev/scratch/test_junifer_native/temp", cleanup=False
)
```

### Environment

```markdown
junifer:
  version: 0.0.3.dev101
python:
  version: 3.11.3
  implementation: CPython
dependencies:
  click: 8.0.4
  numpy: 1.23.5
  datalad: 0.18.2+59.gc5054cb91
  pandas: 1.5.3
  nibabel: 4.0.2
  nilearn: 0.10.0
  sqlalchemy: 1.4.48
  ruamel.yaml: 0.17.31
system:
  platform: Linux-6.1.0-12-amd64-x86_64-with-glibc2.36
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: 
    /home/fraimondo/miniconda3/envs/junifer/bin:/home/fraimondo/miniconda3/condabin:/home/fraimondo/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games
```


### Relevant log output

_No response_

### Anything else?

_No response_