### PR TITLE
[BUG]: Mask "inherit" will be warped twice if working in native space.

### DIFF
--- a/docs/changes/newsfragments/284.bugfix
+++ b/docs/changes/newsfragments/284.bugfix
@@ -1,0 +1,1 @@
+Avoid warping mask preprocessed with :class:`.fMRIPrepConfoundRemover` and used by markers with ``mask="inherit"`` in subject-native template space by `Fede Raimondo`_ and `Synchon Mandal`_

--- a/junifer/data/masks.py
+++ b/junifer/data/masks.py
@@ -280,6 +280,7 @@ def get_mask(  # noqa: C901
                     f"because the item ({inherited_mask_item}) does not exist."
                 )
             mask_img = extra_input[inherited_mask_item]["data"]
+            mask_space = extra_input[inherited_mask_item]["space"]
         # Starting with new mask
         else:
             # Load mask
@@ -306,7 +307,7 @@ def get_mask(  # noqa: C901
                     interpolation="nearest",
                     copy=True,
                 )
-            all_spaces.append(mask_space)
+        all_spaces.append(mask_space)
         all_masks.append(mask_img)
 
     # Multiple masks, need intersection / union
@@ -316,6 +317,8 @@ def get_mask(  # noqa: C901
         # Intersect / union of masks only if all masks are in the same space
         if len(filtered_spaces) == 1:
             mask_img = intersect_masks(all_masks, **intersect_params)
+            # Store the mask space for further checks
+            mask_space = next(iter(filtered_spaces))
         else:
             raise_error(
                 msg=(
@@ -333,9 +336,10 @@ def get_mask(  # noqa: C901
                 "when there is only one mask."
             )
         mask_img = all_masks[0]
+        mask_space = all_spaces[0]
 
-    # Warp mask if target data is native
-    if target_data["space"] == "native":
+    # Warp mask if target data is native and mask space is not native
+    if target_data["space"] == "native" and target_data["space"] != mask_space:
         # Check for extra inputs
         if extra_input is None:
             raise_error(

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -392,7 +392,9 @@ def test_get_mask_inherit() -> None:
 
         # Now get the mask using the inherit functionality, passing the
         # computed mask as extra data
-        extra_input = {"BOLD_MASK": {"data": gm_mask}}
+        extra_input = {
+            "BOLD_MASK": {"data": gm_mask, "space": input["BOLD"]["space"]}
+        }
         input["BOLD"]["mask_item"] = "BOLD_MASK"
         mask2 = get_mask(
             masks="inherit", target_data=input["BOLD"], extra_input=extra_input

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -407,11 +407,9 @@ def test_get_mask_inherit() -> None:
 @pytest.mark.parametrize(
     "masks,params",
     [
-        (["GM_prob0.2", "compute_brain_mask"], {}),
-        (
-            ["GM_prob0.2", "compute_brain_mask"],
-            {"threshold": 0.2},
-        ),
+        (["GM_prob0.2", "GM_prob0.2_cortex"], {}),
+        (["compute_brain_mask", "compute_background_mask"], {}),
+        (["compute_brain_mask", "compute_epi_mask"], {}),
     ],
 )
 def test_get_mask_multiple(

--- a/junifer/preprocess/confounds/fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/fmriprep_confound_remover.py
@@ -574,7 +574,10 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
             # this allows to use "inherit" down the pipeline
             if extra_input is not None:
                 logger.debug("Setting mask_item")
-                extra_input["BOLD_mask"] = {"data": mask_img}
+                extra_input["BOLD_mask"] = {
+                    "data": mask_img,
+                    "space": input["space"],
+                }
                 input["mask_item"] = "BOLD_mask"
 
         logger.info("Cleaning image")


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

I'm running a pipeline in which we use warp data to native space. The second preprocessing step is doing confound removal, while using a GM mask. The markers have `mask="inherit"`, so the same GM mask is used. What I see in the log is that the mask is warped twice, so in the end, it does not fit the subject's images and many voxels are not considered as part of the GM.

### Expected Behavior

I expect the "inherited" mask not to be warped twice, since it's already warped in the preprocessing step.

### Steps To Reproduce

1. Install junifer from main branch.
2. Run something like this:

```
workdir: /tmp

with:
  - ../external/juni-farm/juni_farm/datagrabber/hcp_ya_confounds_cat.py

datagrabber:
    kind: MultipleHCP
    ica_fix: true
    tasks:
      - REST1
      - REST2

preprocess:
  - kind: BOLDWarper
    reference: T1w
  - kind: fMRIPrepConfoundRemover
    detrend: true
    standardize: true
    strategy:
        wm_csf: full
        global_signal: full
    low_pass: 0.08
    high_pass: 0.01
    masks:
      - fetch_icbm152_brain_gm_mask

markers:

  - name: ReHo-SphereSize-5mm_native
    kind: ReHoSpheres
    coords: "Power"
    radius: 5
    use_afni: true
    allow_overlap: true
    agg_method: count
    masks: 
      - inherit
```

3. Run the same, but replace the `inherit` for `fetch_icbm152_brain_gm_mask` in the marker. Check the output, it should be the same.

### Environment

```markdown
junifer:
  version: 0.0.3.dev101
python:
  version: 3.11.3
  implementation: CPython
dependencies:
  click: 8.0.4
  numpy: 1.23.5
  datalad: 0.18.2+59.gc5054cb91
  pandas: 1.5.3
  nibabel: 4.0.2
  nilearn: 0.10.0
  sqlalchemy: 1.4.48
  ruamel.yaml: 0.17.31
system:
  platform: Linux-6.1.0-12-amd64-x86_64-with-glibc2.36
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: 
    /home/fraimondo/miniconda3/envs/junifer/bin:/home/fraimondo/miniconda3/condabin:/home/fraimondo/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games
```


### Relevant log output

```shell
2023-12-13 16:59:59,227 - JUNIFER - INFO - ===== Lib Versions =====                                        
2023-12-13 16:59:59,227 - JUNIFER - INFO - numpy: 1.23.5                                                   
2023-12-13 16:59:59,227 - JUNIFER - INFO - scipy: 1.10.1                                                   
2023-12-13 16:59:59,227 - JUNIFER - INFO - pandas: 1.5.3                                                   
2023-12-13 16:59:59,228 - JUNIFER - INFO - nilearn: 0.10.0                                                 
2023-12-13 16:59:59,228 - JUNIFER - INFO - nibabel: 4.0.2                                                  
2023-12-13 16:59:59,228 - JUNIFER - INFO - junifer: 0.0.3.dev101                                           
2023-12-13 16:59:59,228 - JUNIFER - INFO - ========================                                        
2023-12-13 16:59:59,259 - JUNIFER - INFO - Preprocessing BOLD                                              
2023-12-13 16:59:59,259 - JUNIFER - DEBUG - Extra input for preprocess: dict_keys(['T1w', 'Warp', 'BOLD_con
founds'])                                                                                                  
2023-12-13 17:00:37,317 - JUNIFER - INFO - No `t_r` specified, using t_r from nifti header                 
2023-12-13 17:00:37,317 - JUNIFER - INFO - Read t_r from nifti header: 0.7200000286102295                  
2023-12-13 17:00:37,317 - JUNIFER - DEBUG - Masking with fetch_icbm152_brain_gm_mask                       
2023-12-13 17:00:37,723 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpv1yu9n14                                                                          
2023-12-13 17:00:37,731 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scr
atch/test_junifer_native/temp/tmpz0e9c9gs                                                                  
2023-12-13 17:00:37,734 - JUNIFER - INFO - applywarp command to be executed: applywarp --interp=nn -i /home
/fraimondo/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/masks0f3ar3gu/prewarp_mask.nii.gz -r /home/frai
mondo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8/reference_resampled.nii.gz -w /hom
e/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex/object
s/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz/MD5E-s8671773--cba2afc2eef7b965d83048e1270f0
1a7.nii.gz -o /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskspqismabx/mask_warped.ni
i.gz  
2023-12-13 17:00:40,433 - JUNIFER - INFO - applywarp succeeded with the following output: b'/home/fraimondo
/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/masks0f3ar3gu/prewarp_mask.nii.gz is a file\n/home/fraimo
ndo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8/reference_resampled.nii.gz is a file
\n/home/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex/
objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz/MD5E-s8671773--cba2afc2eef7b965d83048e
1270f01a7.nii.gz is a file\n/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskspqismabx/
mask_warped.nii.gz is a prefix\nSingularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/te
mp/tmpv1yu9n14/masks0f3ar3gu:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmph
9ne4d1v/applywarpwe3rtzw8:/data/mount_2 --bind /home/fraimondo/test_datasets/human-connectome-project-opena
ccess/HCP1200/100307/MNINonLinear/.git/annex/objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.
nii.gz:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskspqismabx:
/data/mount_4\nCorrected args for FSL: applywarp --interp=nn -i /data/mount_1/prewarp_mask.nii.gz -r /data/
mount_2/reference_resampled.nii.gz -w /data/mount_3/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz 
-o /data/mount_4/mask_warped.nii.gz\nRunning command: /data/group/appliedml/tools/fsl_6.0.4-patched2/singul
arity_cmd exec --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/masks0f3ar3gu:/data/
mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8:/data/mou
nt_2 --bind /home/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.
git/annex/objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskspqismabx:/data/mount_4 /data/group/appliedml
/tools/fsl_6.0.4-patched2/fsl_6.0.4-patched2.sif applywarp --interp=nn -i /data/mount_1/prewarp_mask.nii.gz
 -r /data/mount_2/reference_resampled.nii.gz -w /data/mount_3/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01
a7.nii.gz -o /data/mount_4/mask_warped.nii.gz\n'                                                           
2023-12-13 17:00:40,434 - JUNIFER - DEBUG - Deleting temporary directory at /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpv1yu9n14/masks0f3ar3gu                                                            
2023-12-13 17:00:40,434 - JUNIFER - DEBUG - Setting mask_item                                              
2023-12-13 17:00:40,434 - JUNIFER - INFO - Cleaning image                                                  
2023-12-13 17:00:40,434 - JUNIFER - DEBUG -     detrend: True                                              
2023-12-13 17:00:40,434 - JUNIFER - DEBUG -     standardize: True                                          
2023-12-13 17:00:40,434 - JUNIFER - DEBUG -     low_pass: 0.08                                             
2023-12-13 17:00:40,434 - JUNIFER - DEBUG -     high_pass: 0.01                                            
2023-12-13 17:01:06,601 - JUNIFER - DEBUG - Adding BOLD to output                                                                                                    
2023-12-13 17:01:12,059 - JUNIFER - INFO - Computing BOLD                                                  
2023-12-13 17:01:12,059 - JUNIFER - INFO - Calculating ReHo for spheres.                                   
2023-12-13 17:01:12,059 - JUNIFER - INFO - Calculating ReHO map.                                           
2023-12-13 17:01:12,059 - JUNIFER - INFO - Using ReHo map cache at /home/fraimondo/test_datasets/human-conn
ectome-project-openaccess/HCP1200/100307/MNINonLinear/Results/rfMRI_REST1_LR/rfMRI_REST1_LR_hp2000_clean.ni
i.gz.                                                                                                      
2023-12-13 17:01:12,059 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpv1yu9n14                                                                          
2023-12-13 17:01:16,869 - JUNIFER - INFO - 3dReHo command to be executed: 3dReHo -prefix /home/fraimondo/de
v/scratch/test_junifer_native/temp/tmpv1yu9n14/rehodt5otw4m/reho -inset /home/fraimondo/dev/scratch/test_ju
nifer_native/temp/tmpv1yu9n14/rehodt5otw4m/input.nii -nneigh 27                                            
2023-12-13 17:02:02,784 - JUNIFER - INFO - 3dReHo succeeded with the following output: b"/home/fraimondo/de
v/scratch/test_junifer_native/temp/tmpv1yu9n14/rehodt5otw4m/reho is a prefix\n/home/fraimondo/dev/scratch/t
est_junifer_native/temp/tmpv1yu9n14/rehodt5otw4m/input.nii is a file\nSingularity args: --bind /home/fraimo
ndo/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/rehodt5otw4m:/data/mount_1 --bind /home/fraimondo/dev/
scratch/test_junifer_native/temp/tmpv1yu9n14/rehodt5otw4m:/data/mount_2\nCorrected args for AFNI: 3dReHo -p
refix /data/mount_1/reho -inset /data/mount_2/input.nii -nneigh 27\nRunning command: /data/group/appliedml/
tools/afni_23.1.10/singularity_cmd exec --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpv1yu
9n14/rehodt5otw4m:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/reh
odt5otw4m:/data/mount_2 /data/group/appliedml/tools/afni_23.1.10/afni_make_build_AFNI_23.1.10.sif 3dReHo -p
refix /data/mount_1/reho -inset /data/mount_2/input.nii -nneigh 27\n++ Final vox neighborhood: ellipsoid wi
th Nneigh=27 and radii (1.900,1.900,1.900).\n++ ReHo (Kendall's W) calculated.\n"
2023-12-13 17:02:02,786 - JUNIFER - INFO - 3dAFNItoNIFTI command to be executed: 3dAFNItoNIFTI -prefix /hom
e/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss/output_9e864993c8cc53239c292
660732b8932024b2b8c347bc4549620d0f5aec38cd6.nii /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpv1y
u9n14/rehodt5otw4m/reho+tlrc.BRIK                                                                          
2023-12-13 17:02:03,004 - JUNIFER - INFO - 3dAFNItoNIFTI succeeded with the following output: b'/home/fraim
ondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss/output_9e864993c8cc53239c292660732b
8932024b2b8c347bc4549620d0f5aec38cd6.nii is a prefix\n/home/fraimondo/dev/scratch/test_junifer_native/temp/
tmpv1yu9n14/rehodt5otw4m/reho+tlrc.BRIK is a file\nSingularity args: --bind /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_j
unifer_native/temp/tmpv1yu9n14/rehodt5otw4m:/data/mount_2\nCorrected args for AFNI: 3dAFNItoNIFTI -prefix /
data/mount_1/output_9e864993c8cc53239c292660732b8932024b2b8c347bc4549620d0f5aec38cd6.nii /data/mount_2/reho
+tlrc.BRIK\nRunning command: /data/group/appliedml/tools/afni_23.1.10/singularity_cmd exec --bind /home/fra
imondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss:/data/mount_1 --bind /home/fraimo
ndo/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/rehodt5otw4m:/data/mount_2 /data/group/appliedml/tools
/afni_23.1.10/afni_make_build_AFNI_23.1.10.sif 3dAFNItoNIFTI -prefix /data/mount_1/output_9e864993c8cc53239
c292660732b8932024b2b8c347bc4549620d0f5aec38cd6.nii /data/mount_2/reho+tlrc.BRIK\n++ 3dAFNItoNIFTI: AFNI ve
rsion=AFNI_23.1.10 (Jun 30 2023) [64-bit]\n'                                                               
2023-12-13 17:02:03,010 - JUNIFER - DEBUG - Sphere aggregation using count                                 
2023-12-13 17:02:03,010 - JUNIFER - WARNING - `Power` has been replaced with `Power2011` and will be remove
d in the next release. For now, it's available for backward compatibility.                                 
2023-12-13 17:02:03,014 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpv1yu9n14                                                                          
2023-12-13 17:02:03,020 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scr
atch/test_junifer_native/temp/tmpz0e9c9gs                                                                  
2023-12-13 17:02:03,025 - JUNIFER - INFO - img2imgcoord command to be executed: cat /home/fraimondo/dev/scr
atch/test_junifer_native/temp/tmpv1yu9n14/coordinatesj3qdk4wz/pretransform_coordinates.txt | img2imgcoord -
mm -src /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss/output_9e864993c
8cc53239c292660732b8932024b2b8c347bc4549620d0f5aec38cd6.nii -dest /home/fraimondo/dev/scratch/test_junifer_
native/temp/tmph9ne4d1v/applywarpwe3rtzw8/reference_resampled.nii.gz -warp /home/fraimondo/test_datasets/hu
man-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex/objects/8Z/gf/MD5E-s8671773--cba2a
fc2eef7b965d83048e1270f01a7.nii.gz/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz > /home/fraimondo
/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/coordinates1vx7cf_h/coordinates_transformed.txt; sed -i 1
d /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/coordinates1vx7cf_h/coordinates_transfor
med.txt                                                                                                    
2023-12-13 17:02:14,398 - JUNIFER - INFO - img2imgcoord succeeded with the following output: b'/home/fraimo
ndo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss/output_9e864993c8cc53239c292660732b8
932024b2b8c347bc4549620d0f5aec38cd6.nii is a file\n/home/fraimondo/dev/scratch/test_junifer_native/temp/tmp
h9ne4d1v/applywarpwe3rtzw8/reference_resampled.nii.gz is a file\n/home/fraimondo/test_datasets/human-connec
tome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex/objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b96
5d83048e1270f01a7.nii.gz/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz is a file\nSingularity args
: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss:/data/mount_1 -
-bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8:/data/mount_2 --bi
nd /home/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex
/objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz:/data/mount_3\nCorrected args for FSL
: img2imgcoord -mm -src /data/mount_1/output_9e864993c8cc53239c292660732b8932024b2b8c347bc4549620d0f5aec38c
d6.nii -dest /data/mount_2/reference_resampled.nii.gz -warp /data/mount_3/MD5E-s8671773--cba2afc2eef7b965d8
3048e1270f01a7.nii.gz\nRunning command: /data/group/appliedml/tools/fsl_6.0.4-patched2/singularity_cmd exec
 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/reho_afni2sopr5ss:/data/mount_1 --
bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8:/data/mount_2 --bind /home/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex/
objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz:/data/mount_3 /data/group/appliedml/to
ols/fsl_6.0.4-patched2/fsl_6.0.4-patched2.sif img2imgcoord -mm -src /data/mount_1/output_9e864993c8cc53239c
292660732b8932024b2b8c347bc4549620d0f5aec38cd6.nii -dest /data/mount_2/reference_resampled.nii.gz -warp /da
ta/mount_3/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz\n'    
2023-12-13 17:02:14,399 - JUNIFER - DEBUG - Deleting temporary directory at /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpv1yu9n14/coordinatesj3qdk4wz                                                      
2023-12-13 17:02:14,399 - JUNIFER - DEBUG - Masking with inherit                                           
2023-12-13 17:02:14,399 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpv1yu9n14                                                                          
2023-12-13 17:02:14,422 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scr
atch/test_junifer_native/temp/tmpz0e9c9gs                                                                  
2023-12-13 17:02:14,424 - JUNIFER - INFO - applywarp command to be executed: applywarp --interp=nn -i /home
/fraimondo/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/masksxd08mqmd/prewarp_mask.nii.gz -r /home/frai
mondo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8/reference_resampled.nii.gz -w /hom
e/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex/object
s/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz/MD5E-s8671773--cba2afc2eef7b965d83048e1270f0
1a7.nii.gz -o /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskszcxnzh5d/mask_warped.ni
i.gz                                                                                                       
2023-12-13 17:02:17,172 - JUNIFER - INFO - applywarp succeeded with the following output: b'/home/fraimondo
/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/masksxd08mqmd/prewarp_mask.nii.gz is a file\n/home/fraimo
ndo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8/reference_resampled.nii.gz is a file
\n/home/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.git/annex/
objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz/MD5E-s8671773--cba2afc2eef7b965d83048e
1270f01a7.nii.gz is a file\n/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskszcxnzh5d/
mask_warped.nii.gz is a prefix\nSingularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/te
mp/tmpv1yu9n14/masksxd08mqmd:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmph
9ne4d1v/applywarpwe3rtzw8:/data/mount_2 --bind /home/fraimondo/test_datasets/human-connectome-project-opena
ccess/HCP1200/100307/MNINonLinear/.git/annex/objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.
nii.gz:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskszcxnzh5d:
/data/mount_4\nCorrected args for FSL: applywarp --interp=nn -i /data/mount_1/prewarp_mask.nii.gz -r /data/
mount_2/reference_resampled.nii.gz -w /data/mount_3/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz 
-o /data/mount_4/mask_warped.nii.gz\nRunning command: /data/group/appliedml/tools/fsl_6.0.4-patched2/singul
arity_cmd exec --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpv1yu9n14/masksxd08mqmd:/data/
mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmph9ne4d1v/applywarpwe3rtzw8:/data/mou
nt_2 --bind /home/fraimondo/test_datasets/human-connectome-project-openaccess/HCP1200/100307/MNINonLinear/.
git/annex/objects/8Z/gf/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01a7.nii.gz:/data/mount_3 --bind /home/f
raimondo/dev/scratch/test_junifer_native/temp/tmpz0e9c9gs/maskszcxnzh5d:/data/mount_4 /data/group/appliedml
/tools/fsl_6.0.4-patched2/fsl_6.0.4-patched2.sif applywarp --interp=nn -i /data/mount_1/prewarp_mask.nii.gz
 -r /data/mount_2/reference_resampled.nii.gz -w /data/mount_3/MD5E-s8671773--cba2afc2eef7b965d83048e1270f01
a7.nii.gz -o /data/mount_4/mask_warped.nii.gz\n'                                                           
2023-12-13 17:02:17,173 - JUNIFER - DEBUG - Deleting temporary directory at /home/fraimondo/dev/scratch/tes
t_junifer_native/temp/tmpv1yu9n14/masksxd08mqmd                                                            
2023-12-13 17:02:17,174 - JUNIFER - DEBUG - Masking                                                        
2023-12-13 17:02:18,498 - JUNIFER - INFO - No storage specified, returning dictionary
```


### Anything else?

Log at 17:00:40 shows the first warping
Log at 17:02:14 shows the second warping.

Error is here:

https://github.com/juaml/junifer/blob/01055e80cc5a4872e0deae0523800a3ca5a647e5/junifer/data/masks.py#L337-L338

We are basically warping if the target data is in "native" space. We should be warping ONLY if the mask is not in the target data's space.

We also need to set the space here:

https://github.com/juaml/junifer/blob/01055e80cc5a4872e0deae0523800a3ca5a647e5/junifer/preprocess/confounds/fmriprep_confound_remover.py#L577