### PR TITLE
[BUG]: Correct path propagation logic for `ReHoEstimator` and `ALFFEstimator`

### DIFF
--- a/docs/changes/newsfragments/286.bugfix
+++ b/docs/changes/newsfragments/286.bugfix
@@ -1,0 +1,1 @@
+Pass down input path if input space is "native" for ``ReHoEstimator`` and ``ALFFEstimator``, else use respective compute maps by `Fede Raimondo`_ and `Synchon Mandal`_

--- a/junifer/markers/falff/falff_base.py
+++ b/junifer/markers/falff/falff_base.py
@@ -148,6 +148,9 @@ class ALFFBase(BaseMarker):
 
         estimator = ALFFEstimator()
 
+        # If the input data space is "native", then alff_path and falff_path
+        # both point to the input data path as it might be required to use
+        # in get_corrdinates() for transforming coordinates to native space.
         alff, falff, alff_path, falff_path = estimator.fit_transform(
             use_afni=self.use_afni,
             input_data=input,

--- a/junifer/markers/falff/falff_estimator.py
+++ b/junifer/markers/falff/falff_estimator.py
@@ -360,7 +360,7 @@ class ALFFEstimator:
         bold_data = input_data["data"]
         # Clear cache if file path is different from when caching was done
         if self._file_path != bold_path:
-            logger.info(f"Removing fALFF map cache at {self._file_path}.")
+            logger.info(f"Removing fALFF map cache for {self._file_path}.")
             # Clear the cache
             self._compute.cache_clear()
             # Clear temporary directory files
@@ -369,7 +369,7 @@ class ALFFEstimator:
             # Set the new file path
             self._file_path = bold_path
         else:
-            logger.info(f"Using fALFF map cache at {self._file_path}.")
+            logger.info(f"Using fALFF map cache for {self._file_path}.")
         # Compute
         alff_map, falff_map, alff_map_path, falff_map_path = self._compute(
             use_afni=use_afni,

--- a/junifer/markers/falff/falff_estimator.py
+++ b/junifer/markers/falff/falff_estimator.py
@@ -308,17 +308,16 @@ class ALFFEstimator:
         if use_afni:
             # Create new temporary directory before using AFNI
             self.temp_dir_path = WorkDirManager().get_tempdir(prefix="falff")
-            output = self._compute_alff_afni(
+            return self._compute_alff_afni(
                 data=data,
                 highpass=highpass,
                 lowpass=lowpass,
                 tr=tr,
             )
-        else:
-            output = self._compute_alff_python(
-                data, highpass=highpass, lowpass=lowpass, tr=tr
-            )
-        return output
+
+        return self._compute_alff_python(
+            data, highpass=highpass, lowpass=lowpass, tr=tr
+        )
 
     def fit_transform(
         self,

--- a/junifer/markers/falff/falff_estimator.py
+++ b/junifer/markers/falff/falff_estimator.py
@@ -349,9 +349,11 @@ class ALFFEstimator:
         Niimg-like object
             fALFF map.
         pathlib.Path
-            The path to the ALFF map as NIfTI.
+            The path to the ALFF map as NIfTI or the input data path if the
+            input data space is "native".
         pathlib.Path
-            The path to the fALFF map as NIfTI.
+            The path to the fALFF map as NIfTI or the input data path if the
+            input data space is "native".
 
         """
         bold_path = input_data["path"]
@@ -369,10 +371,18 @@ class ALFFEstimator:
         else:
             logger.info(f"Using fALFF map cache at {self._file_path}.")
         # Compute
-        return self._compute(
+        alff_map, falff_map, alff_map_path, falff_map_path = self._compute(
             use_afni=use_afni,
             data=bold_data,
             highpass=highpass,
             lowpass=lowpass,
             tr=tr,
         )
+        # If the input data space is native already, the original path should
+        # be propagated down as it might be required for transforming
+        # coordinates to native space via get_coordinates(), else the alff
+        # / falff map path should be passed for use later if required.
+        if input_data["space"] == "native":
+            return alff_map, falff_map, input_data["path"], input_data["path"]
+
+        return alff_map, falff_map, alff_map_path, falff_map_path

--- a/junifer/markers/reho/reho_base.py
+++ b/junifer/markers/reho/reho_base.py
@@ -110,7 +110,8 @@ class ReHoBase(BaseMarker):
         Niimg-like object
             The ReHo map as NIfTI.
         pathlib.Path
-            The path to the ReHo map as NIfTI.
+            The path to the ReHo map as NIfTI or the input data path if the
+            input data space is "native".
 
         References
         ----------

--- a/junifer/markers/reho/reho_estimator.py
+++ b/junifer/markers/reho/reho_estimator.py
@@ -462,12 +462,9 @@ class ReHoEstimator:
         if use_afni:
             # Create new temporary directory before using AFNI
             self.temp_dir_path = WorkDirManager().get_tempdir(prefix="reho")
-            output, output_path = self._compute_reho_afni(data, **reho_params)
-        else:
-            output, output_path = self._compute_reho_python(
-                data, **reho_params
-            )
-        return output, output_path
+            return self._compute_reho_afni(data, **reho_params)
+
+        return self._compute_reho_python(data, **reho_params)
 
     def fit_transform(
         self,

--- a/junifer/markers/reho/reho_estimator.py
+++ b/junifer/markers/reho/reho_estimator.py
@@ -496,7 +496,7 @@ class ReHoEstimator:
         bold_data = input_data["data"]
         # Clear cache if file path is different from when caching was done
         if self._file_path != bold_path:
-            logger.info(f"Removing ReHo map cache at {self._file_path}.")
+            logger.info(f"Removing ReHo map cache for {self._file_path}.")
             # Clear the cache
             self._compute.cache_clear()
             # Clear temporary directory files
@@ -505,7 +505,7 @@ class ReHoEstimator:
             # Set the new file path
             self._file_path = bold_path
         else:
-            logger.info(f"Using ReHo map cache at {self._file_path}.")
+            logger.info(f"Using ReHo map cache for {self._file_path}.")
         # Compute
         reho_map, reho_map_path = self._compute(
             use_afni, bold_data, **reho_params

--- a/junifer/markers/reho/reho_estimator.py
+++ b/junifer/markers/reho/reho_estimator.py
@@ -488,7 +488,8 @@ class ReHoEstimator:
         Niimg-like object
             The ReHo map as NIfTI.
         pathlib.Path
-            The path to the ReHo map as NIfTI.
+            The path to the ReHo map as NIfTI or the input data path if the
+            input data space is "native".
 
         """
         bold_path = input_data["path"]
@@ -506,7 +507,17 @@ class ReHoEstimator:
         else:
             logger.info(f"Using ReHo map cache at {self._file_path}.")
         # Compute
-        return self._compute(use_afni, bold_data, **reho_params)
+        reho_map, reho_map_path = self._compute(
+            use_afni, bold_data, **reho_params
+        )
+        # If the input data space is native already, the original path should
+        # be propagated down as it might be required for transforming
+        # coordinates to native space via get_coordinates(), else the reho map
+        # path should be passed for use later if required.
+        if input_data["space"] == "native":
+            return reho_map, input_data["path"]
+
+        return reho_map, reho_map_path
 
 
 def _kendall_w_reho(

--- a/junifer/markers/reho/reho_parcels.py
+++ b/junifer/markers/reho/reho_parcels.py
@@ -127,6 +127,9 @@ class ReHoParcels(ReHoBase):
         """
         logger.info("Calculating ReHo for parcels.")
         # Calculate reho map
+        # If the input data space is "native", then reho_file_path points to
+        # the input data path as it might be required to use in
+        # get_coordinates() for transforming coordinates to native space.
         if self.reho_params is not None:
             reho_map, reho_file_path = self.compute_reho_map(
                 input=input, **self.reho_params

--- a/junifer/markers/reho/reho_spheres.py
+++ b/junifer/markers/reho/reho_spheres.py
@@ -139,6 +139,9 @@ class ReHoSpheres(ReHoBase):
         """
         logger.info("Calculating ReHo for spheres.")
         # Calculate reho map
+        # If the input data space is "native", then reho_file_path points to
+        # the input data path as it might be required to use in
+        # get_coordinates() for transforming coordinates to native space.
         if self.reho_params is not None:
             reho_map, reho_file_path = self.compute_reho_map(
                 input=input, **self.reho_params


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR fixes the path propagation logic for `ReHoEstimator` and `ALFFEstimator` based on the input data space. If the input data space is "native", the original input data path is passed down for further use in `get_coordinates()` (as of now) for transforming coordinates to subject-"native" template space, else the actual ReHo and (f)ALFF map paths are passed down.