### PR TITLE
[MAINT]: Make `BOLDWarper` tool-agnostic

### DIFF
--- a/docs/changes/newsfragments/288.misc
+++ b/docs/changes/newsfragments/288.misc
@@ -1,0 +1,1 @@
+Make :class:`.BOLDWarper` tool-agnostic by moving it from ``junifer.preprocess.fsl`` to :mod:`junifer.preprocess` by `Synchon Mandal`_

--- a/junifer/preprocess/__init__.py
+++ b/junifer/preprocess/__init__.py
@@ -7,4 +7,4 @@
 
 from .base import BasePreprocessor
 from .confounds import fMRIPrepConfoundRemover
-from .fsl import BOLDWarper
+from .bold_warper import BOLDWarper

--- a/junifer/preprocess/bold_warper.py
+++ b/junifer/preprocess/bold_warper.py
@@ -1,4 +1,4 @@
-"""Provide class for warping BOLD via FSL FLIRT."""
+"""Provide class for warping BOLD to other template spaces."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
@@ -13,15 +13,15 @@ from typing import (
     Union,
 )
 
-from ...api.decorators import register_preprocessor
-from ...utils import logger, raise_error
-from ..base import BasePreprocessor
-from .apply_warper import _ApplyWarper
+from ..api.decorators import register_preprocessor
+from ..utils import logger, raise_error
+from .base import BasePreprocessor
+from .fsl.apply_warper import _ApplyWarper
 
 
 @register_preprocessor
 class BOLDWarper(BasePreprocessor):
-    """Class for warping BOLD NIfTI images via FSL FLIRT.
+    """Class for warping BOLD NIfTI images.
 
     Parameters
     ----------

--- a/junifer/preprocess/fsl/__init__.py
+++ b/junifer/preprocess/fsl/__init__.py
@@ -2,5 +2,3 @@
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
-
-from .bold_warper import BOLDWarper

--- a/junifer/preprocess/fsl/apply_warper.py
+++ b/junifer/preprocess/fsl/apply_warper.py
@@ -122,7 +122,7 @@ class _ApplyWarper(BasePreprocessor):
         -------
         Niimg-like object
             The warped input image.
-         pathlib.Path
+        pathlib.Path
             The path to the resampled reference image.
 
         Raises

--- a/junifer/preprocess/tests/test_bold_warper.py
+++ b/junifer/preprocess/tests/test_bold_warper.py
@@ -9,7 +9,7 @@ import pytest
 
 # from junifer.datareader import DefaultDataReader
 # from junifer.pipeline.utils import _check_fsl
-from junifer.preprocess.fsl import BOLDWarper
+from junifer.preprocess import BOLDWarper
 
 
 def test_BOLDWarper_init() -> None:


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR changes the location of `BOLDWarper` from `preprocess.fsl` sub-package to `preprocess` sub-package to make it tool-agnostic and enable support for warping via ANTs in the near future.