### PR TITLE
[ENH]: Implement `junifer reset` to delete job/results file.

### DIFF
--- a/docs/changes/newsfragments/240.feature
+++ b/docs/changes/newsfragments/240.feature
@@ -1,0 +1,1 @@
+Add ``junifer reset`` to reset storage and jobs directory by `Synchon Mandal`_

--- a/junifer/api/cli.py
+++ b/junifer/api/cli.py
@@ -21,6 +21,7 @@ from ..utils.logging import (
 )
 from .functions import collect as api_collect
 from .functions import queue as api_queue
+from .functions import reset as api_reset
 from .functions import run as api_run
 from .parser import parse_yaml
 from .utils import (
@@ -412,6 +413,43 @@ def selftest(subpkg: str) -> None:
         click.secho("Successful.", fg="green")
     else:
         click.secho("Failure.", fg="red")
+
+
+@cli.command()
+@click.argument(
+    "filepath",
+    type=click.Path(
+        exists=True, readable=True, dir_okay=False, path_type=pathlib.Path
+    ),
+)
+@click.option(
+    "-v",
+    "--verbose",
+    type=click.UNPROCESSED,
+    callback=_validate_verbose,
+    default="info",
+)
+def reset(
+    filepath: click.Path,
+    verbose: Union[str, int],
+) -> None:
+    """Reset command for CLI.
+
+    \f
+
+    Parameters
+    ----------
+    filepath : click.Path
+        The filepath to the configuration file.
+    verbose : click.Choice
+        The verbosity level: warning, info or debug (default "info").
+
+    """
+    configure_logging(level=verbose)
+    # Parse YAML
+    config = parse_yaml(filepath)
+    # Perform operation
+    api_reset(config)
 
 
 @cli.group()

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -709,3 +709,40 @@ def _queue_slurm(
     #     logger.info(
     #         f"SLURM job files created, to submit the job, run `{cmd}`"
     #     )
+
+
+def reset(config: Dict) -> None:
+    """Reset the storage and jobs directory.
+
+    Parameters
+    ----------
+    config : dict
+        The configuration to be used for resetting.
+
+    """
+    # Fetch storage
+    storage = config["storage"]
+    storage_uri = Path(storage["uri"])
+    logger.info(f"Deleting {storage_uri.resolve()!s}")
+    # Delete storage; will be str
+    if storage_uri.exists():
+        # Delete files in the directory
+        for file in storage_uri.iterdir():
+            file.unlink(missing_ok=True)
+        # Remove directory
+        storage_uri.parent.rmdir()
+
+    # Fetch job name (if present)
+    if config.get("queue") is not None:
+        queue = config["queue"]
+        job_dir = (
+            Path.cwd()
+            / "junifer_jobs"
+            / (queue.get("jobname") or "junifer_job")
+        )
+        logger.info(f"Deleting job directory at {job_dir.resolve()!s}")
+        if job_dir.exists():
+            # Remove files and directories
+            shutil.rmtree(job_dir)
+            # Remove directory
+            job_dir.parent.rmdir()

--- a/junifer/datagrabber/tests/test_dmcc13_benchmark.py
+++ b/junifer/datagrabber/tests/test_dmcc13_benchmark.py
@@ -81,7 +81,6 @@ def test_DMCC13Benchmark(
     dg.uri = URI
 
     with dg:
-        # breakpoint()
         # Get all elements
         all_elements = dg.get_elements()
         # Get test element

--- a/junifer/pipeline/registry.py
+++ b/junifer/pipeline/registry.py
@@ -41,6 +41,11 @@ def register(step: str, name: str, klass: type) -> None:
     klass : class
         Class to be registered.
 
+    Raises
+    ------
+    ValueError
+        If the ``step`` is invalid.
+
     """
     # Verify step
     if step not in _VALID_STEPS:
@@ -62,6 +67,11 @@ def get_step_names(step: str) -> List[str]:
     -------
     list
         List of registered function names.
+
+    Raises
+    ------
+    ValueError
+        If the ``step`` is invalid.
 
     """
     # Verify step
@@ -85,6 +95,11 @@ def get_class(step: str, name: str) -> type:
     -------
     class
         Registered function class.
+
+    Raises
+    ------
+    ValueError
+        If the ``step`` or ``name`` is invalid.
 
     """
     # Verify step
@@ -123,6 +138,8 @@ def build(
 
     Raises
     ------
+    RuntimeError
+        If there is a problem creating the instance.
     ValueError
         If the created object with the given name is not an instance of the
         base class.


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

Sometimes I make a mistake with one parameter in the YAML. Then I need to go and check where the storage file points to, delete the directory and then finally run `junifer queue` with `--overwrite`.

I would like this process to be part of junifer.

### How do you imagine this integrated in junifer?

`junifer reset /path/to/yaml`

This should delete the storage directory and the job directory.

Although the `reset` argument must not necessary be that one.

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_