### PR TITLE
[ENH]: Allow for using `venv` in queue kind

### DIFF
--- a/docs/changes/newsfragments/249.feature
+++ b/docs/changes/newsfragments/249.feature
@@ -1,0 +1,1 @@
+Support ``venv`` as environment kind for queueing jobs by `Synchon Mandal`_

--- a/docs/using/queueing.rst
+++ b/docs/using/queueing.rst
@@ -57,7 +57,8 @@ The following parameters are available for HTCondor:
 
   * ``name``: This is the name of the environment to use in case a virtual
     environment is used. It should be the name when ``conda`` is used and
-    the absolute path to the virtualenv when ``venv`` is used.
+    the absolute or relative path to the virtualenv when ``venv`` is used.
+    If relative path is used then it should be relative to the YAML.
 
 * ``mem``: Memory to be used by the job. It must be provided as a string with
   the units (e.g. ``2GB``).

--- a/docs/using/queueing.rst
+++ b/docs/using/queueing.rst
@@ -52,11 +52,12 @@ The following parameters are available for HTCondor:
   * ``kind``: This is the kind of virtual environment to use:
 
     * ``conda``
-    * ``virtualenv`` (not yet supported)
+    * ``venv``
     * ``local`` (no virtual environment)
 
   * ``name``: This is the name of the environment to use in case a virtual
-    environment is used.
+    environment is used. It should be the name when ``conda`` is used and
+    the absolute path to the virtualenv when ``venv`` is used.
 
 * ``mem``: Memory to be used by the job. It must be provided as a string with
   the units (e.g. ``2GB``).

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -418,7 +418,10 @@ def _queue_condor(
         env_name = env["name"]
         executable = "run_venv.sh"
         arguments = f"{env_name} junifer"
-        # TODO: Copy run_venv.sh to jobdir
+        exec_path = jobdir / executable
+        logger.info(f"Copying {executable} to {exec_path.absolute()!s}")
+        shutil.copy(Path(__file__).parent / "res" / executable, exec_path)
+        make_executable(exec_path)
     elif env["kind"] == "local":
         executable = "junifer"
         arguments = ""

--- a/junifer/api/parser.py
+++ b/junifer/api/parser.py
@@ -99,4 +99,17 @@ def parse_yaml(filepath: Union[str, Path]) -> Dict:
                 contents["storage"]["uri"] = str(
                     (filepath.parent / uri_path).resolve()
                 )
+
+    # Allow relative path if queue env kind is venv; same motivation as above
+    if "queue" in contents:
+        if "env" in contents["queue"]:
+            if "venv" == contents["queue"]["env"]["kind"]:
+                # Check if the env name is relative
+                venv_path = Path(contents["queue"]["env"]["name"])
+                if not venv_path.is_absolute():
+                    # Compute the absolute path
+                    contents["queue"]["env"]["name"] = str(
+                        (filepath.parent / venv_path).resolve()
+                    )
+
     return contents

--- a/junifer/api/res/run_conda.sh
+++ b/junifer/api/res/run_conda.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 if [ $# -lt 2 ]; then
-    echo "This script is meant to run a command within a python environment"
+    echo "This script is meant to run a command within a conda environment."
     echo "It needs at least 2 parameters."
     echo "The first one must be the environment name."
-    echo "The rest will be the command"
+    echo "The rest will be the command."
     exit 255
 fi
 
 eval "$(conda shell.bash hook)"
 env_name=$1
 echo "Activating ${env_name}"
-conda activate "$1"
+conda activate "${env_name}"
 shift 1
 
 if [ -f "pre_run.sh" ]; then
@@ -19,5 +19,5 @@ if [ -f "pre_run.sh" ]; then
     . ./pre_run.sh
 fi
 
-echo "Running ${*} in virtual environment"
+echo "Running ${*} in conda environment"
 "$@"

--- a/junifer/api/res/run_venv.sh
+++ b/junifer/api/res/run_venv.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 if [ $# -lt 2 ]; then
-    echo "This script is meant to run a command within a python environment"
+    echo "This script is meant to run a command within a Python virtual environment."
     echo "It needs at least 2 parameters."
-    echo "The first one must be the environment name."
-    echo "The rest will be the command"
+    echo "The first one must be the virtualenv path."
+    echo "The rest will be the command."
     exit 255
 fi
 
-env_name=$1
-echo "Activating ${env_name}"
-source "${env_name}"/bin/activate
+env_path=$1
+echo "Activating ${env_path}"
+source "${env_path}"/bin/activate
 shift 1
 
 if [ -f "pre_run.sh" ]; then
@@ -18,5 +18,5 @@ if [ -f "pre_run.sh" ]; then
     . ./pre_run.sh
 fi
 
-echo "Running ${*} in virtual environment"
+echo "Running ${*} in Python virtual environment"
 "$@"

--- a/junifer/api/res/run_venv.sh
+++ b/junifer/api/res/run_venv.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ $# -lt 2 ]; then
+    echo "This script is meant to run a command within a python environment"
+    echo "It needs at least 2 parameters."
+    echo "The first one must be the environment name."
+    echo "The rest will be the command"
+    exit 255
+fi
+
+env_name=$1
+echo "Activating ${env_name}"
+source "${env_name}"/bin/activate
+shift 1
+
+if [ -f "pre_run.sh" ]; then
+    echo "Sourcing pre_run.sh"
+    . ./pre_run.sh
+fi
+
+echo "Running ${*} in virtual environment"
+"$@"


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

Some people do not like to use conda, it would be nice to be able to set the `env` variable to a path of an environment created using [the venv tool](https://docs.python.org/3/library/venv.html) to run a junifer pipeline.

### How do you imagine this integrated in junifer?

Similar to conda, but with venv.

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_