### PR TITLE
[FIX]: Element parsing for HTCondor via `VARS`

### DIFF
--- a/docs/changes/newsfragments/312.bugfix
+++ b/docs/changes/newsfragments/312.bugfix
@@ -1,0 +1,1 @@
+Fix :class:`.HTCondorAdapter`'s script generation to use double quotes instead of single quotes for HTCondor's ``VARS`` by `Synchon Mandal`_

--- a/junifer/api/queue_context/htcondor_adapter.py
+++ b/junifer/api/queue_context/htcondor_adapter.py
@@ -274,8 +274,8 @@ class HTCondorAdapter(QueueContextAdapter):
             )
             fixed += (
                 f"JOB run{idx} {self._submit_run_path}\n"
-                f"VARS run{idx} element='{str_element}' "
-                f"log_element='{log_element}'\n\n"
+                f'VARS run{idx} element="{str_element}" '
+                f'log_element="{log_element}"\n\n'
             )
         var = ""
         if self._collect == "yes":

--- a/junifer/api/queue_context/htcondor_adapter.py
+++ b/junifer/api/queue_context/htcondor_adapter.py
@@ -274,8 +274,8 @@ class HTCondorAdapter(QueueContextAdapter):
             )
             fixed += (
                 f"JOB run{idx} {self._submit_run_path}\n"
-                f'VARS run{idx} element="{str_element}" '
-                f'log_element="{log_element}"\n\n'
+                f'VARS run{idx} element="{str_element}" '  # needs to be
+                f'log_element="{log_element}"\n\n'  # double quoted
             )
         var = ""
         if self._collect == "yes":

--- a/junifer/api/queue_context/tests/test_htcondor_adapter.py
+++ b/junifer/api/queue_context/tests/test_htcondor_adapter.py
@@ -139,13 +139,13 @@ def test_HTCondorAdapter_run_collect(
         (
             [("sub01", "ses01")],
             "yes",
-            "element='sub01,ses01' log_element='sub01-ses01'",
+            'element="sub01,ses01" log_element="sub01-ses01"',
         ),
         (["sub01"], "on_success_only", "JOB collect"),
         (
             [("sub01", "ses01")],
             "on_success_only",
-            "element='sub01,ses01' log_element='sub01-ses01'",
+            'element="sub01,ses01" log_element="sub01-ses01"',
         ),
     ],
 )


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR fixes the script generation of `HTCondorAdapter` to allow proper parsing of HTCondor's `VARS`. In particular, replaces single quote with double quotes for element parsing.