### PR TITLE
[FIX]: Element access for `DMCC13Benchmark`

### DIFF
--- a/docs/changes/newsfragments/314.bugfix
+++ b/docs/changes/newsfragments/314.bugfix
@@ -1,0 +1,1 @@
+Fix element access for :class:`.DMCC13Benchmark` DataGrabber by `Synchon Mandal`_

--- a/junifer/datagrabber/dmcc13_benchmark.py
+++ b/junifer/datagrabber/dmcc13_benchmark.py
@@ -293,7 +293,7 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
             "f5004cr",
             "f5407sl",
             "f5416zj",
-            "F8113do",
+            "f8113do",
             "f8570ui",
             "f9057kp",
         ]
@@ -324,6 +324,9 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                 run = "1"
             else:
                 run = "2"
+            # Bypass for f5416zj for not having wave1rea session
+            if subject == "f5416zj" and session == "wave1rea":
+                continue
             elems.append((subject, session, task, phase_encoding, run))
 
         return elems


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR fixes uncaught bugs for correct access of all elements using the `DMCC13Benchmark` DataGrabber.