### PR TITLE
[DOC]: Add missing types in DataGrabber `types` docstrings

### DIFF
--- a/docs/changes/newsfragments/330.doc
+++ b/docs/changes/newsfragments/330.doc
@@ -1,0 +1,1 @@
+Add missing DataGrabber ``types`` options in respective docstrings of :class:`.DataladAOMICID1000`, :class:`.DataladAOMICPIOP1`, :class:`.DataladAOMICPIOP2` and :class:`.DMCC13Benchmark` by `Synchon Mandal`_

--- a/junifer/datagrabber/aomic/id1000.py
+++ b/junifer/datagrabber/aomic/id1000.py
@@ -24,8 +24,9 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "T1w", "VBM_CSF", "VBM_GM", \
-           "VBM_WM", "DWI"} or a list of the options, optional
+    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
+           "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
+           a list of the options, optional
         AOMIC data types. If None, all available data types are selected.
         (default None).
     native_t1w : bool, optional

--- a/junifer/datagrabber/aomic/piop1.py
+++ b/junifer/datagrabber/aomic/piop1.py
@@ -26,8 +26,9 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "T1w", "VBM_CSF", "VBM_GM", \
-           "VBM_WM", "DWI"} or a list of the options, optional
+    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
+           "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
+           a list of the options, optional
         AOMIC data types. If None, all available data types are selected.
         (default None).
     tasks : {"restingstate", "anticipation", "emomatching", "faces", \

--- a/junifer/datagrabber/aomic/piop2.py
+++ b/junifer/datagrabber/aomic/piop2.py
@@ -26,8 +26,9 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "T1w", "VBM_CSF", "VBM_GM", \
-           "VBM_WM", "DWI"} or a list of the options, optional
+    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
+           "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
+           a list of the options, optional
         AOMIC data types. If None, all available data types are selected.
         (default None).
     tasks : {"restingstate", "stopsignal", "workingmemory"} \

--- a/junifer/datagrabber/dmcc13_benchmark.py
+++ b/junifer/datagrabber/dmcc13_benchmark.py
@@ -25,8 +25,9 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "T1w", "VBM_CSF", "VBM_GM", \
-           "VBM_WM"} or a list of the options, optional
+    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
+           "VBM_CSF", "VBM_GM", "VBM_WM", "Warp" (only if \
+           "native_t1w = True")} or a list of the options, optional
         DMCC data types. If None, all available data types are selected.
         (default None).
     sessions: {"ses-wave1bas", "ses-wave1pro", "ses-wave1rea"} or list of \


### PR DESCRIPTION
### Which element of the documentation do you want to modify and why?

https://github.com/juaml/junifer/blob/08ac0d9872664f39ae75537c0c4636accc33ef79/junifer/datagrabber/aomic/id1000.py#L27-L28

vs

https://github.com/juaml/junifer/blob/08ac0d9872664f39ae75537c0c4636accc33ef79/junifer/datagrabber/aomic/id1000.py#L53-L70

### Anything else to say?

_No response_