### PR TITLE
[ENH]: Add `junifer list-elements` for listing out elements of an YAML's  DataGrabber

### DIFF
--- a/docs/changes/newsfragments/323.feature
+++ b/docs/changes/newsfragments/323.feature
@@ -1,0 +1,1 @@
+Add ``junifer list-elements`` to list out available elements for a DataGrabber based on filtering via ``--element`` by `Synchon Mandal`_

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -361,3 +361,44 @@ def reset(config: Dict) -> None:
             shutil.rmtree(job_dir)
             # Remove directory
             job_dir.parent.rmdir()
+
+
+def list_elements(
+    datagrabber: Dict,
+    elements: Union[str, List[Union[str, Tuple]], Tuple, None] = None,
+) -> str:
+    """List elements of the datagrabber filtered using `elements`.
+
+    Parameters
+    ----------
+    datagrabber : dict
+        DataGrabber to index. Must have a key ``kind`` with the kind of
+        DataGrabber to use. All other keys are passed to the DataGrabber
+        constructor.
+    elements : str or tuple or list of str or tuple, optional
+        Element(s) to filter using. Will be used to index the DataGrabber
+        (default None).
+
+    """
+    # Get datagrabber to use
+    datagrabber_object = _get_datagrabber(datagrabber)
+
+    # Fetch elements
+    raw_elements_to_list = []
+    with datagrabber_object:
+        if elements is not None:
+            for element in datagrabber_object.filter(elements):
+                raw_elements_to_list.append(element)
+        else:
+            for element in datagrabber_object:
+                raw_elements_to_list.append(element)
+
+    elements_to_list = []
+    for element in raw_elements_to_list:
+        # Stringify elements if tuple for operation
+        str_element = (
+            ",".join(element) if isinstance(element, tuple) else element
+        )
+        elements_to_list.append(str_element)
+
+    return "\n".join(elements_to_list)

--- a/junifer/api/tests/test_cli.py
+++ b/junifer/api/tests/test_cli.py
@@ -14,6 +14,7 @@ from ruamel.yaml import YAML
 from junifer.api.cli import (
     _parse_elements_file,
     collect,
+    list_elements,
     queue,
     reset,
     run,
@@ -295,6 +296,88 @@ def test_reset(
         reset_result = runner.invoke(reset, reset_args)
         # Check
         assert reset_result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "elements",
+    [
+        ("sub-01", "sub-02"),
+        ("sub-03", "sub-04"),
+    ],
+)
+def test_list_elements_stdout(
+    elements: Tuple[str, ...],
+) -> None:
+    """Test elements listing to stdout.
+
+    Parameters
+    ----------
+    elements : tuple of str
+        The parametrized elements for filtering.
+
+    """
+    # Get test config
+    infile = Path(__file__).parent / "data" / "partly_cloudy_agg_mean_tian.yml"
+    # List elements command arguments
+    list_elements_args = [
+        str(infile.absolute()),
+        "--verbose",
+        "debug",
+        "--element",
+        elements[0],
+        "--element",
+        elements[1],
+    ]
+    # Invoke list elements command
+    list_elements_result = runner.invoke(list_elements, list_elements_args)
+    # Check
+    assert list_elements_result.exit_code == 0
+    assert f"{elements[0]}\n{elements[1]}" in list_elements_result.stdout
+
+
+@pytest.mark.parametrize(
+    "elements",
+    [
+        ("sub-01", "sub-02"),
+        ("sub-03", "sub-04"),
+    ],
+)
+def test_list_elements_output_file(
+    tmp_path: Path,
+    elements: Tuple[str, ...],
+) -> None:
+    """Test elements listing to output file.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+    elements : tuple of str
+        The parametrized elements for filtering.
+
+    """
+    # Get test config
+    infile = Path(__file__).parent / "data" / "partly_cloudy_agg_mean_tian.yml"
+    # Output file
+    output_file = tmp_path / "elements.txt"
+    # List elements command arguments
+    list_elements_args = [
+        str(infile.absolute()),
+        "--verbose",
+        "debug",
+        "--element",
+        elements[0],
+        "--element",
+        elements[1],
+        "--output-file",
+        str(output_file.resolve()),
+    ]
+    # Invoke list elements command
+    list_elements_result = runner.invoke(list_elements, list_elements_args)
+    # Check
+    assert list_elements_result.exit_code == 0
+    with open(output_file) as f:
+        assert f"{elements[0]}\n{elements[1]}" == f.read()
 
 
 def test_wtf_short() -> None:

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -7,13 +7,13 @@
 
 import logging
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import pytest
 from ruamel.yaml import YAML
 
 import junifer.testing.registry  # noqa: F401
-from junifer.api.functions import collect, queue, reset, run
+from junifer.api.functions import collect, list_elements, queue, reset, run
 from junifer.datagrabber.base import BaseDataGrabber
 from junifer.pipeline.registry import build
 
@@ -637,3 +637,28 @@ def test_reset_queue(
 
         assert not Path(storage["uri"]).exists()
         assert not (tmp_path / "junifer_jobs" / job_name).exists()
+
+
+@pytest.mark.parametrize(
+    "elements",
+    [
+        ["sub-01"],
+        None,
+    ],
+)
+def test_list_elements(
+    datagrabber: Dict[str, str],
+    elements: Optional[List[str]],
+) -> None:
+    """Test elements listing.
+
+    Parameters
+    ----------
+    datagrabber : dict
+        Testing datagrabber as dictionary.
+    elements : str of list of str
+        The parametrized elements for filtering.
+
+    """
+    listed_elements = list_elements(datagrabber, elements)
+    assert "sub-01" in listed_elements


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

I think it would be fantastic if junifer had a `list-elements` command line function which can be run on a yaml file with a specific datagrabber, and that will then print out all available elements in the format that junifer likes for subsetting the element keys using the `--element elements.txt` command line option for queue.

The workflow i imagine would have the advantage that i can very easily discover elements and subset them for testing using arbitrary command line filters, and then write them into a file for queing i.e.:

`junifer list-elements <yaml> | tail -2 > elements.txt`


### How do you imagine this integrated in junifer?

as above

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_