### PR TITLE
[DOC]: Change `__init__.py` docstrings to reflect sub-packages

### DIFF
--- a/docs/api/nilearn.rst
+++ b/docs/api/nilearn.rst
@@ -1,8 +1,6 @@
 Nilearn
 =======
 
-This package provides re-implementations of some of the functions in `nilearn`_.
-
 .. automodule:: junifer.external.nilearn
    :members:
    :imported-members:

--- a/docs/api/onthefly.rst
+++ b/docs/api/onthefly.rst
@@ -1,8 +1,6 @@
 On-the-fly
 ==========
 
-This package provides functions for quick transform operations on stored data.
-
 .. automodule:: junifer.onthefly
    :members:
    :imported-members:

--- a/docs/changes/newsfragments/115.doc
+++ b/docs/changes/newsfragments/115.doc
@@ -1,0 +1,1 @@
+Improve sub-package level docstrings to better reflect their purposes by `Synchon Mandal`_

--- a/junifer/api/__init__.py
+++ b/junifer/api/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for api sub-package."""
+"""Public API and CLI components."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/api/queue_context/__init__.py
+++ b/junifer/api/queue_context/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for queue context sub-package."""
+"""Context adapters for queueing."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL

--- a/junifer/configs/__init__.py
+++ b/junifer/configs/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for configs sub-package."""
+"""Custom components for specific platforms."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 # License: AGPL

--- a/junifer/configs/juseless/__init__.py
+++ b/junifer/configs/juseless/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for juseless sub-package."""
+"""Custom components for FZJ INM-7's beloved juseless."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 # License: AGPL

--- a/junifer/configs/juseless/datagrabbers/__init__.py
+++ b/junifer/configs/juseless/datagrabbers/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for datagrabbers sub-package."""
+"""Custom DataGrabbers for FZJ INM-7's beloved juseless."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Leonard Sasse <l.sasse@fz-juelich.de>

--- a/junifer/data/__init__.py
+++ b/junifer/data/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for data sub-package."""
+"""Parcellations, coordinates and masks."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/data/coordinates.py
+++ b/junifer/data/coordinates.py
@@ -1,4 +1,4 @@
-"""Provide functions for list of coordinates."""
+"""Functions for coordinates manipulation."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/data/masks.py
+++ b/junifer/data/masks.py
@@ -1,4 +1,4 @@
-"""Provide functions for masks."""
+"""Functions for mask manipulation."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -1,4 +1,4 @@
-"""Provide functions for parcellation."""
+"""Functions for parcellation manipulation."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Vera Komeyer <v.komeyer@fz-juelich.de>

--- a/junifer/data/template_spaces.py
+++ b/junifer/data/template_spaces.py
@@ -1,4 +1,4 @@
-"""Provide functions for template spaces."""
+"""Functions for template space manipulation."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL

--- a/junifer/datagrabber/__init__.py
+++ b/junifer/datagrabber/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for datagrabber sub-package."""
+"""DataGrabbers for datasets' data description."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Leonard Sasse <l.sasse@fz-juelich.de>

--- a/junifer/datareader/__init__.py
+++ b/junifer/datareader/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for datareader sub-package."""
+"""DataReaders for datasets' data loading."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Leonard Sasse <l.sasse@fz-juelich.de>

--- a/junifer/external/__init__.py
+++ b/junifer/external/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for external sub-package."""
+"""External tools adapted for junifer."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL

--- a/junifer/external/nilearn/__init__.py
+++ b/junifer/external/nilearn/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for custom nilearn objects sub-package."""
+"""Custom objects adapted from nilearn."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL

--- a/junifer/markers/__init__.py
+++ b/junifer/markers/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for markers sub-package."""
+"""Markers for feature extraction."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Leonard Sasse <l.sasse@fz-juelich.de>

--- a/junifer/onthefly/__init__.py
+++ b/junifer/onthefly/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for onthefly sub-package."""
+"""Utilities for on-the-fly analyses."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL

--- a/junifer/pipeline/__init__.py
+++ b/junifer/pipeline/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for pipeline sub-package."""
+"""Pipeline components."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL

--- a/junifer/preprocess/__init__.py
+++ b/junifer/preprocess/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for preprocess sub-package."""
+"""Preprocessors for preprocessing data before feature extraction."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Leonard Sasse <l.sasse@fz-juelich.de>

--- a/junifer/stats.py
+++ b/junifer/stats.py
@@ -1,4 +1,4 @@
-"""Provide functions for statistics."""
+"""Statistical functions and helpers."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/storage/__init__.py
+++ b/junifer/storage/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for storage sub-package."""
+"""Storages for storing extracted features."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/testing/__init__.py
+++ b/junifer/testing/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for testing sub-package."""
+"""Testing components."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/testing/datagrabbers.py
+++ b/junifer/testing/datagrabbers.py
@@ -1,4 +1,4 @@
-"""Provide testing DataGrabbers."""
+"""Testing DataGrabbers."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>

--- a/junifer/utils/__init__.py
+++ b/junifer/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Provide imports for utils sub-package."""
+"""General utilities and helpers."""
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>


### PR DESCRIPTION
### Which element of the documentation do you want to modify and why?

Every `__init__.py` file needs to document the purpose of the package, so it does not render like this in the API doc:

![Screenshot 2022-11-03 at 08 53 42](https://user-images.githubusercontent.com/4493699/199662828-3e69b4d3-a9bf-4f57-aa29-6479dbd011a0.png)


### Anything else to say?

_No response_