### PR TITLE
[BUG]: Extra dimension added to mask after warping via ANTs

### DIFF
--- a/docs/changes/newsfragments/340.bugfix
+++ b/docs/changes/newsfragments/340.bugfix
@@ -1,0 +1,1 @@
+Remove extra dimension from masks warped via ANTs by `Synchon Mandal`_

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -208,7 +208,7 @@ class ParcelAggregation(BaseMarker):
             )
             # Get "logical and" version of parcellation and mask
             parcellation_bin = math_img(
-                "np.logical_and(img, mask)",
+                "np.logical_and(img, np.squeeze(mask))",
                 img=parcellation_bin,
                 mask=mask_img,
             )


### PR DESCRIPTION
This PR fixes extra dimension addition to mask after warping via ANTs.

* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes