### PR TITLE
[ENH]: Refactor DataGrabber `patterns`

### DIFF
--- a/docs/changes/newsfragments/341.enh
+++ b/docs/changes/newsfragments/341.enh
@@ -1,0 +1,1 @@
+Refactor DataGrabber ``patterns`` to make helper types like ``*_mask`` as "nested types" of the actual data type by `Synchon Mandal`_

--- a/docs/extending/datagrabber.rst
+++ b/docs/extending/datagrabber.rst
@@ -297,22 +297,22 @@ This approach can be used directly from the YAML, like so:
 .. code-block:: yaml
 
    datagrabber:
-     - kind: PatternDataladDataGrabber
-       types:
-         - BOLD
-         - T1w
-       patterns:
-         BOLD:
-           pattern: "{subject}/{session}/func/{subject}_{session}_task-rest_bold.nii.gz"
-           space: MNI152NLin6Asym
-         T1w:
-           pattern: "{subject}/{session}/anat/{subject}_{session}_T1w.nii.gz"
-           space: native
-       replacements:
-         - subject
-         - session
-       uri: "https://gin.g-node.org/juaml/datalad-example-bids"
-       rootdir: example_bids_ses
+     kind: PatternDataladDataGrabber
+     types:
+       - BOLD
+       - T1w
+     patterns:
+       BOLD:
+         pattern: "{subject}/{session}/func/{subject}_{session}_task-rest_bold.nii.gz"
+         space: MNI152NLin6Asym
+       T1w:
+         pattern: "{subject}/{session}/anat/{subject}_{session}_T1w.nii.gz"
+         space: native
+     replacements:
+       - subject
+       - session
+     uri: "https://gin.g-node.org/juaml/datalad-example-bids"
+     rootdir: example_bids_ses
 
 .. _extending_datagrabbers_base:
 
@@ -442,11 +442,11 @@ Step 4: Optional: Adding *BOLD confounds*
 -----------------------------------------
 
 For some analyses, it is useful to have the confounds associated with the BOLD
-data. This corresponds to the ``BOLD_confounds`` item in the
+data. This corresponds to the ``BOLD.confounds`` item in the
 :ref:`Data Object <data_object>` (see :ref:`data_types`). However, the
-``BOLD_confounds`` element does not only consists of a ``path``, but it requires
+``BOLD.confounds`` element does not only consists of a ``path``, but it requires
 more information about the format of the confounds file. Thus, the
-``BOLD_confounds`` element is a dictionary with the following keys:
+``BOLD.confounds`` element is a dictionary with the following keys:
 
 - ``path``: the path to the confounds file.
 - ``format``: the format of the confounds file. Currently, this can be either
@@ -482,15 +482,15 @@ this:
          "BOLD": {
              "path": f"{subject}/{session}/func/{subject}_{session}_task-rest_bold.nii.gz",
              "space": "MNI152NLin6Asym",
-         },
-         "BOLD_confounds": {
-             "path": f"{subject}/{session}/func/{subject}_{session}_confounds.tsv",
-             "format": "adhoc",
-             "mappings": {
-                 "fmriprep": {
-                    "variable1": "rot_x",
-                    "variable2": "rot_z",
-                    "variable3": "rot_y",
+             "confounds": {
+                 "path": f"{subject}/{session}/func/{subject}_{session}_confounds.tsv",
+                 "format": "adhoc",
+                 "mappings": {
+                     "fmriprep": {
+                        "variable1": "rot_x",
+                        "variable2": "rot_z",
+                        "variable3": "rot_y",
+                     },
                  },
              },
          },

--- a/docs/extending/marker.rst
+++ b/docs/extending/marker.rst
@@ -114,8 +114,7 @@ arguments:
   path to the data. The dictionary can also contain other keys, depending on the
   data type.
 * ``extra_input``: the rest of the :ref:`Data Object<data_object>`. This is
-  useful if you want to use other data to compute the Marker
-  (e.g.: ``BOLD_confounds`` can be used to de-confound the ``BOLD`` data).
+  useful if you want to use other data to compute the Marker.
 
 Following the example, we will compute the mean of the data in each parcel using
 :class:`nilearn.maskers.NiftiLabelsMasker`. Importantly, the output of the

--- a/docs/understanding/data.rst
+++ b/docs/understanding/data.rst
@@ -109,9 +109,6 @@ Data Types
    * - ``BOLD``
      - BOLD image (4D)
      - Preprocessed or Denoised BOLD image (fMRIPrep output)
-   * - ``BOLD_confounds``
-     - BOLD image confounds (CSV/TSV file)
-     - Confounds that can be applied to the BOLD image.
    * - ``VBM_GM``
      - VBM Gray Matter segmentation (3D)
      - CAT output (`m0wp1` images)

--- a/docs/understanding/preprocess.rst
+++ b/docs/understanding/preprocess.rst
@@ -23,7 +23,7 @@ Confound Removal
 ----------------
 
 This step is meant to remove *confounds* from the ``BOLD`` data. The confounds
-are extracted from the ``BOLD_confounds`` data (must be provided by the
+are extracted from the ``BOLD.confounds`` data (must be provided by the
 :ref:`Data Grabber <datagrabber>`). The confounds are then regressed out from
 the ``BOLD`` data using :func:`nilearn.image.clean_img`.
 
@@ -36,7 +36,7 @@ Strategy
 
 This confound remover uses the `nilearn`_ API from
 :func:`nilearn.interfaces.fmriprep.load_confounds`. That is, define a *strategy*
-to extract the confounds from the ``BOLD_confounds`` data. The *strategy* is
+to extract the confounds from the ``BOLD.confounds`` data. The *strategy* is
 defined by choosing the *noise components* to be used and the *confounds* to be
 extracted from each noise components. The *noise components* currently supported
 are:

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -362,7 +362,7 @@ def reset(config: Dict) -> None:
             shutil.rmtree(job_dir)
             # Remove parent directory (if empty)
             if not next(os.scandir(job_dir.parent), None):
-                job_dir.parent.rmdir()        
+                job_dir.parent.rmdir()
 
 
 def list_elements(

--- a/junifer/configs/juseless/datagrabbers/tests/test_ucla.py
+++ b/junifer/configs/juseless/datagrabbers/tests/test_ucla.py
@@ -27,7 +27,6 @@ def test_JuselessUCLA() -> None:
 
         types = [
             "BOLD",
-            "BOLD_confounds",
             "T1w",
             "VBM_CSF",
             "VBM_GM",
@@ -43,12 +42,11 @@ def test_JuselessUCLA() -> None:
     "types",
     [
         "BOLD",
-        "BOLD_confounds",
         "T1w",
         "VBM_CSF",
         "VBM_GM",
         "VBM_WM",
-        ["BOLD", "BOLD_confounds"],
+        ["BOLD", "VBM_CSF"],
         ["T1w", "VBM_CSF"],
         ["VBM_GM", "VBM_WM"],
         ["BOLD", "T1w"],

--- a/junifer/configs/juseless/datagrabbers/ucla.py
+++ b/junifer/configs/juseless/datagrabbers/ucla.py
@@ -23,8 +23,8 @@ class JuselessUCLA(PatternDataGrabber):
     datadir : str or Path, optional
         The directory where the dataset is stored.
         (default "/data/project/psychosis_thalamus/data/fmriprep").
-    types: {"BOLD", "BOLD_confounds", "T1w", "VBM_CSF", "VBM_GM", \
-           "VBM_WM"} or a list of the options, optional
+    types: {"BOLD", "T1w", "VBM_CSF", "VBM_GM", "VBM_WM"} or \
+           list of the options, optional
         UCLA data types. If None, all available data types are selected.
         (default None).
     tasks : {"rest", "bart", "bht", "pamenc", "pamret", \
@@ -76,13 +76,13 @@ class JuselessUCLA(PatternDataGrabber):
                     "MNI152NLin2009cAsym_preproc.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-            },
-            "BOLD_confounds": {
-                "pattern": (
-                    "{subject}/func/{subject}_"
-                    "task-{task}_bold_confounds.tsv"
-                ),
-                "space": "fmriprep",
+                "confounds": {
+                    "pattern": (
+                        "{subject}/func/{subject}_"
+                        "task-{task}_bold_confounds.tsv"
+                    ),
+                    "space": "fmriprep",
+                },
             },
             "T1w": {
                 "pattern": (

--- a/junifer/data/parcellations.py
+++ b/junifer/data/parcellations.py
@@ -889,7 +889,7 @@ def _retrieve_tian(
         )
         with open(parcellation_lname, "w") as filehandle:
             for listitem in labels:
-                filehandle.write("%s\n" % listitem)
+                filehandle.write(f"{listitem}\n")
         logger.info(
             "Currently there are no labels provided for the 7T Tian "
             "parcellation. A simple numbering scheme for distinction was "

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -369,13 +369,6 @@ def test_get_mask_errors() -> None:
         with pytest.raises(ValueError, match=r"provide `mask`"):
             get_mask(masks="inherit", target_data=vbm_gm)
 
-        # Block fetch_icbm152_brain_gm_mask space transformation
-        with pytest.raises(RuntimeError, match="prohibited"):
-            get_mask(
-                masks="fetch_icbm152_brain_gm_mask",
-                target_data=vbm_gm,
-            )
-
 
 @pytest.mark.parametrize(
     "mask_name,function,params,resample",

--- a/junifer/data/tests/test_masks.py
+++ b/junifer/data/tests/test_masks.py
@@ -365,25 +365,15 @@ def test_get_mask_errors() -> None:
                 target_data=vbm_gm,
             )
 
-        # Test "inherited" masks errors
-
-        # 1) No extra_data parameter
-        with pytest.raises(ValueError, match=r"no extra data was passed"):
+        # Test "inherited" masks error
+        with pytest.raises(ValueError, match=r"provide `mask`"):
             get_mask(masks="inherit", target_data=vbm_gm)
 
-        extra_input = {"VBM_MASK": {}}
-
-        # 2) No mask_item key in target_data
-        with pytest.raises(ValueError, match=r"no mask item was specified"):
+        # Block fetch_icbm152_brain_gm_mask space transformation
+        with pytest.raises(RuntimeError, match="prohibited"):
             get_mask(
-                masks="inherit", target_data=vbm_gm, extra_input=extra_input
-            )
-
-        # 3) mask_item not in extra data
-        with pytest.raises(ValueError, match=r"does not exist"):
-            vbm_gm["mask_item"] = "wrong"
-            get_mask(
-                masks="inherit", target_data=vbm_gm, extra_input=extra_input
+                masks="fetch_icbm152_brain_gm_mask",
+                target_data=vbm_gm,
             )
 
 
@@ -457,18 +447,15 @@ def test_get_mask_inherit() -> None:
         )
 
         # Now get the mask using the inherit functionality, passing the
-        # computed mask as extra data
-        extra_input = {
-            "BOLD_MASK": {
-                "data": gm_mask,
-                "space": element_data["BOLD"]["space"],
-            }
+        # computed mask as the data
+        bold_dict = element_data["BOLD"]
+        bold_dict["mask"] = {
+            "data": gm_mask,
+            "space": element_data["BOLD"]["space"],
         }
-        element_data["BOLD"]["mask_item"] = "BOLD_MASK"
         mask2 = get_mask(
             masks="inherit",
-            target_data=element_data["BOLD"],
-            extra_input=extra_input,
+            target_data=bold_dict,
         )
 
         # Both masks should be equal

--- a/junifer/datagrabber/aomic/id1000.py
+++ b/junifer/datagrabber/aomic/id1000.py
@@ -24,9 +24,8 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
-           "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
-           a list of the options, optional
+    types: {"BOLD", "T1w", "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
+           list of the options, optional
         AOMIC data types. If None, all available data types are selected.
         (default None).
     native_t1w : bool, optional
@@ -49,24 +48,23 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
                     "space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "BOLD_mask",
-            },
-            "BOLD_confounds": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/func/"
-                    "{subject}_task-moviewatching_"
-                    "desc-confounds_regressors.tsv"
-                ),
-                "format": "fmriprep",
-            },
-            "BOLD_mask": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/func/"
-                    "{subject}_task-moviewatching_"
-                    "space-MNI152NLin2009cAsym_"
-                    "desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/func/"
+                        "{subject}_task-moviewatching_"
+                        "space-MNI152NLin2009cAsym_"
+                        "desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
+                "confounds": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/func/"
+                        "{subject}_task-moviewatching_"
+                        "desc-confounds_regressors.tsv"
+                    ),
+                    "format": "fmriprep",
+                },
             },
             "T1w": {
                 "pattern": (
@@ -75,15 +73,14 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
                     "desc-preproc_T1w.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "T1w_mask",
-            },
-            "T1w_mask": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/anat/"
-                    "{subject}_space-MNI152NLin2009cAsym_"
-                    "desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/anat/"
+                        "{subject}_space-MNI152NLin2009cAsym_"
+                        "desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
             },
             "VBM_CSF": {
                 "pattern": (
@@ -128,14 +125,13 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
                             "{subject}_desc-preproc_T1w.nii.gz"
                         ),
                         "space": "native",
-                        "mask_item": "T1w_mask",
-                    },
-                    "T1w_mask": {
-                        "pattern": (
-                            "derivatives/fmriprep/{subject}/anat/"
-                            "{subject}_desc-brain_mask.nii.gz"
-                        ),
-                        "space": "native",
+                        "mask": {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_desc-brain_mask.nii.gz"
+                            ),
+                            "space": "native",
+                        },
                     },
                     "Warp": {
                         "pattern": (

--- a/junifer/datagrabber/aomic/piop1.py
+++ b/junifer/datagrabber/aomic/piop1.py
@@ -26,9 +26,8 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
-           "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
-           a list of the options, optional
+    types: {"BOLD", "T1w", "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
+           list of the options, optional
         AOMIC data types. If None, all available data types are selected.
         (default None).
     tasks : {"restingstate", "anticipation", "emomatching", "faces", \
@@ -85,23 +84,22 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
                     "space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "BOLD_mask",
-            },
-            "BOLD_confounds": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/func/"
-                    "{subject}_task-{task}_"
-                    "desc-confounds_regressors.tsv"
-                ),
-                "format": "fmriprep",
-            },
-            "BOLD_mask": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/func/"
-                    "{subject}_task-{task}_"
-                    "space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/func/"
+                        "{subject}_task-{task}_"
+                        "space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
+                "confounds": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/func/"
+                        "{subject}_task-{task}_"
+                        "desc-confounds_regressors.tsv"
+                    ),
+                    "format": "fmriprep",
+                },
             },
             "T1w": {
                 "pattern": (
@@ -110,15 +108,14 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
                     "desc-preproc_T1w.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "T1w_mask",
-            },
-            "T1w_mask": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/anat/"
-                    "{subject}_space-MNI152NLin2009cAsym_"
-                    "desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/anat/"
+                        "{subject}_space-MNI152NLin2009cAsym_"
+                        "desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
             },
             "VBM_CSF": {
                 "pattern": (
@@ -163,14 +160,13 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
                             "{subject}_desc-preproc_T1w.nii.gz"
                         ),
                         "space": "native",
-                        "mask_item": "T1w_mask",
-                    },
-                    "T1w_mask": {
-                        "pattern": (
-                            "derivatives/fmriprep/{subject}/anat/"
-                            "{subject}_desc-brain_mask.nii.gz"
-                        ),
-                        "space": "native",
+                        "mask": {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_desc-brain_mask.nii.gz"
+                            ),
+                            "space": "native",
+                        },
                     },
                     "Warp": {
                         "pattern": (

--- a/junifer/datagrabber/aomic/piop2.py
+++ b/junifer/datagrabber/aomic/piop2.py
@@ -26,13 +26,12 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
-           "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
-           a list of the options, optional
+    types: {"BOLD", "T1w", "VBM_CSF", "VBM_GM", "VBM_WM", "DWI"} or \
+           list of the options, optional
         AOMIC data types. If None, all available data types are selected.
         (default None).
-    tasks : {"restingstate", "stopsignal", "workingmemory"} \
-            or list of the options, optional
+    tasks : {"restingstate", "stopsignal", "workingmemory"} or \
+            list of the options, optional
         AOMIC PIOP2 task sessions. If None, all available task sessions are
         selected (default None).
     native_t1w : bool, optional
@@ -82,23 +81,22 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
                     "space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "BOLD_mask",
-            },
-            "BOLD_confounds": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/func/"
-                    "{subject}_task-{task}_"
-                    "desc-confounds_regressors.tsv"
-                ),
-                "format": "fmriprep",
-            },
-            "BOLD_mask": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/func/"
-                    "{subject}_task-{task}_"
-                    "space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/func/"
+                        "{subject}_task-{task}_"
+                        "space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
+                "confounds": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/func/"
+                        "{subject}_task-{task}_"
+                        "desc-confounds_regressors.tsv"
+                    ),
+                    "format": "fmriprep",
+                },
             },
             "T1w": {
                 "pattern": (
@@ -107,15 +105,14 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
                     "desc-preproc_T1w.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "T1w_mask",
-            },
-            "T1w_mask": {
-                "pattern": (
-                    "derivatives/fmriprep/{subject}/anat/"
-                    "{subject}_space-MNI152NLin2009cAsym_"
-                    "desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep/{subject}/anat/"
+                        "{subject}_space-MNI152NLin2009cAsym_"
+                        "desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
             },
             "VBM_CSF": {
                 "pattern": (
@@ -160,14 +157,13 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
                             "{subject}_desc-preproc_T1w.nii.gz"
                         ),
                         "space": "native",
-                        "mask_item": "T1w_mask",
-                    },
-                    "T1w_mask": {
-                        "pattern": (
-                            "derivatives/fmriprep/{subject}/anat/"
-                            "{subject}_desc-brain_mask.nii.gz"
-                        ),
-                        "space": "native",
+                        "mask": {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_desc-brain_mask.nii.gz"
+                            ),
+                            "space": "native",
+                        },
                     },
                     "Warp": {
                         "pattern": (

--- a/junifer/datagrabber/aomic/tests/test_id1000.py
+++ b/junifer/datagrabber/aomic/tests/test_id1000.py
@@ -40,20 +40,20 @@ def test_DataladAOMICID1000() -> None:
         assert out["BOLD"]["path"].exists()
         assert out["BOLD"]["path"].is_file()
 
-        # asserts type "BOLD_confounds"
-        assert "BOLD_confounds" in out
+        # asserts type BOLD.confounds
+        assert "confounds" in out["BOLD"]
 
         assert (
-            out["BOLD_confounds"]["path"].name
+            out["BOLD"]["confounds"]["path"].name
             == f"{test_element}_task-moviewatching_"
             "desc-confounds_regressors.tsv"
         )
 
-        assert out["BOLD_confounds"]["path"].exists()
-        assert out["BOLD_confounds"]["path"].is_file()
+        assert out["BOLD"]["confounds"]["path"].exists()
+        assert out["BOLD"]["confounds"]["path"].is_file()
 
-        # assert BOLD_mask
-        assert out["BOLD_mask"]["path"].exists()
+        # assert BOLD.mask
+        assert out["BOLD"]["mask"]["path"].exists()
 
         # asserts type "T1w"
         assert "T1w" in out
@@ -67,8 +67,8 @@ def test_DataladAOMICID1000() -> None:
         assert out["T1w"]["path"].exists()
         assert out["T1w"]["path"].is_file()
 
-        # asserts T1w_mask
-        assert out["T1w_mask"]["path"].exists()
+        # asserts T1w.mask
+        assert out["T1w"]["mask"]["path"].exists()
 
         # asserts type "VBM_CSF"
         assert "VBM_CSF" in out
@@ -129,13 +129,12 @@ def test_DataladAOMICID1000() -> None:
     "types",
     [
         "BOLD",
-        "BOLD_confounds",
         "T1w",
         "VBM_CSF",
         "VBM_GM",
         "VBM_WM",
         "DWI",
-        ["BOLD", "BOLD_confounds"],
+        ["BOLD", "VBM_CSF"],
         ["T1w", "VBM_CSF"],
         ["VBM_GM", "VBM_WM"],
         ["DWI", "BOLD"],

--- a/junifer/datagrabber/aomic/tests/test_piop1.py
+++ b/junifer/datagrabber/aomic/tests/test_piop1.py
@@ -63,19 +63,19 @@ def test_DataladAOMICPIOP1(tasks: Optional[str]) -> None:
         assert out["BOLD"]["path"].exists()
         assert out["BOLD"]["path"].is_file()
 
-        # asserts type "BOLD_confounds"
-        assert "BOLD_confounds" in out
+        # asserts type BOLD.confounds
+        assert "confounds" in out["BOLD"]
 
         assert (
-            out["BOLD_confounds"]["path"].name == f"{sub}_task-{new_task}_"
+            out["BOLD"]["confounds"]["path"].name == f"{sub}_task-{new_task}_"
             "desc-confounds_regressors.tsv"
         )
 
-        assert out["BOLD_confounds"]["path"].exists()
-        assert out["BOLD_confounds"]["path"].is_file()
+        assert out["BOLD"]["confounds"]["path"].exists()
+        assert out["BOLD"]["confounds"]["path"].is_file()
 
-        # assert BOLD_mask
-        assert out["BOLD_mask"]["path"].exists()
+        # assert BOLD.mask
+        assert out["BOLD"]["mask"]["path"].exists()
 
         # asserts type "T1w"
         assert "T1w" in out
@@ -88,8 +88,8 @@ def test_DataladAOMICPIOP1(tasks: Optional[str]) -> None:
         assert out["T1w"]["path"].exists()
         assert out["T1w"]["path"].is_file()
 
-        # asserts T1w_mask
-        assert out["T1w_mask"]["path"].exists()
+        # asserts T1w.mask
+        assert out["T1w"]["mask"]["path"].exists()
 
         # asserts type "VBM_CSF"
         assert "VBM_CSF" in out
@@ -147,13 +147,12 @@ def test_DataladAOMICPIOP1(tasks: Optional[str]) -> None:
     "types",
     [
         "BOLD",
-        "BOLD_confounds",
         "T1w",
         "VBM_CSF",
         "VBM_GM",
         "VBM_WM",
         "DWI",
-        ["BOLD", "BOLD_confounds"],
+        ["BOLD", "VBM_CSF"],
         ["T1w", "VBM_CSF"],
         ["VBM_GM", "VBM_WM"],
         ["DWI", "BOLD"],

--- a/junifer/datagrabber/aomic/tests/test_piop2.py
+++ b/junifer/datagrabber/aomic/tests/test_piop2.py
@@ -57,19 +57,19 @@ def test_DataladAOMICPIOP2(tasks: Optional[str]) -> None:
         assert out["BOLD"]["path"].exists()
         assert out["BOLD"]["path"].is_file()
 
-        # asserts type "BOLD_confounds"
-        assert "BOLD_confounds" in out
+        # asserts type BOLD.confounds
+        assert "confounds" in out["BOLD"]
 
         assert (
-            out["BOLD_confounds"]["path"].name == f"{sub}_task-{new_task}_"
+            out["BOLD"]["confounds"]["path"].name == f"{sub}_task-{new_task}_"
             "desc-confounds_regressors.tsv"
         )
 
-        assert out["BOLD_confounds"]["path"].exists()
-        assert out["BOLD_confounds"]["path"].is_file()
+        assert out["BOLD"]["confounds"]["path"].exists()
+        assert out["BOLD"]["confounds"]["path"].is_file()
 
-        # assert BOLD_mask
-        assert out["BOLD_mask"]["path"].exists()
+        # assert BOLD.mask
+        assert out["BOLD"]["mask"]["path"].exists()
 
         # asserts type "T1w"
         assert "T1w" in out
@@ -82,8 +82,8 @@ def test_DataladAOMICPIOP2(tasks: Optional[str]) -> None:
         assert out["T1w"]["path"].exists()
         assert out["T1w"]["path"].is_file()
 
-        # asserts T1w_mask
-        assert out["T1w_mask"]["path"].exists()
+        # asserts T1w.mask
+        assert out["T1w"]["mask"]["path"].exists()
 
         # asserts type "VBM_CSF"
         assert "VBM_CSF" in out
@@ -141,13 +141,12 @@ def test_DataladAOMICPIOP2(tasks: Optional[str]) -> None:
     "types",
     [
         "BOLD",
-        "BOLD_confounds",
         "T1w",
         "VBM_CSF",
         "VBM_GM",
         "VBM_WM",
         "DWI",
-        ["BOLD", "BOLD_confounds"],
+        ["BOLD", "VBM_CSF"],
         ["T1w", "VBM_CSF"],
         ["VBM_GM", "VBM_WM"],
         ["DWI", "BOLD"],

--- a/junifer/datagrabber/datalad_base.py
+++ b/junifer/datagrabber/datalad_base.py
@@ -176,7 +176,16 @@ class DataladDataGrabber(BaseDataGrabber):
             The unmodified input dictionary.
 
         """
-        to_get = [v["path"] for v in out.values() if "path" in v]
+        to_get = []
+        for type_val in out.values():
+            # Iterate to check for nested "types" like mask
+            for k, v in type_val.items():
+                # Add base data type path
+                if k == "path":
+                    to_get.append(v)
+                # Add nested data type path
+                if isinstance(v, dict) and "path" in v:
+                    to_get.append(v["path"])
 
         if len(to_get) > 0:
             logger.debug(f"Getting {len(to_get)} files using datalad:")

--- a/junifer/datagrabber/dmcc13_benchmark.py
+++ b/junifer/datagrabber/dmcc13_benchmark.py
@@ -25,17 +25,16 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
         The directory where the datalad dataset will be cloned. If None,
         the datalad dataset will be cloned into a temporary directory
         (default None).
-    types: {"BOLD", "BOLD_confounds", "BOLD_mask", "T1w", "T1w_mask", \
-           "VBM_CSF", "VBM_GM", "VBM_WM", "Warp" (only if \
-           "native_t1w = True")} or a list of the options, optional
+    types: {"BOLD", "T1w", "VBM_CSF", "VBM_GM", "VBM_WM"} or \
+           list of the options, optional
         DMCC data types. If None, all available data types are selected.
         (default None).
-    sessions: {"ses-wave1bas", "ses-wave1pro", "ses-wave1rea"} or list of \
-            the options, optional
+    sessions: {"ses-wave1bas", "ses-wave1pro", "ses-wave1rea"} or \
+              list of the options, optional
         DMCC sessions. If None, all available sessions are selected
         (default None).
     tasks: {"Rest", "Axcpt", "Cuedts", "Stern", "Stroop"} or \
-            list of the options, optional
+           list of the options, optional
         DMCC task sessions. If None, all available task sessions are selected
         (default None).
     phase_encodings : {"AP", "PA"} or list of the options, optional
@@ -148,24 +147,23 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                     "space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "BOLD_mask",
-            },
-            "BOLD_confounds": {
-                "pattern": (
-                    "derivatives/fmriprep-1.3.2/{subject}/{session}/"
-                    "func/{subject}_{session}_task-{task}_acq-mb4"
-                    "{phase_encoding}_run-{run}_desc-confounds_regressors.tsv"
-                ),
-                "format": "fmriprep",
-            },
-            "BOLD_mask": {
-                "pattern": (
-                    "derivatives/fmriprep-1.3.2/{subject}/{session}/"
-                    "/func/{subject}_{session}_task-{task}_acq-mb4"
-                    "{phase_encoding}_run-{run}_"
-                    "space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep-1.3.2/{subject}/{session}/"
+                        "/func/{subject}_{session}_task-{task}_acq-mb4"
+                        "{phase_encoding}_run-{run}_"
+                        "space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
+                "confounds": {
+                    "pattern": (
+                        "derivatives/fmriprep-1.3.2/{subject}/{session}/"
+                        "func/{subject}_{session}_task-{task}_acq-mb4"
+                        "{phase_encoding}_run-{run}_desc-confounds_regressors.tsv"
+                    ),
+                    "format": "fmriprep",
+                },
             },
             "T1w": {
                 "pattern": (
@@ -173,14 +171,13 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                     "{subject}_space-MNI152NLin2009cAsym_desc-preproc_T1w.nii.gz"
                 ),
                 "space": "MNI152NLin2009cAsym",
-                "mask_item": "T1w_mask",
-            },
-            "T1w_mask": {
-                "pattern": (
-                    "derivatives/fmriprep-1.3.2/{subject}/anat/"
-                    "{subject}_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
-                ),
-                "space": "MNI152NLin2009cAsym",
+                "mask": {
+                    "pattern": (
+                        "derivatives/fmriprep-1.3.2/{subject}/anat/"
+                        "{subject}_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
+                    ),
+                    "space": "MNI152NLin2009cAsym",
+                },
             },
             "VBM_CSF": {
                 "pattern": (
@@ -216,14 +213,13 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                             "{subject}_desc-preproc_T1w.nii.gz"
                         ),
                         "space": "native",
-                        "mask_item": "T1w_mask",
-                    },
-                    "T1w_mask": {
-                        "pattern": (
-                            "derivatives/fmriprep-1.3.2/{subject}/anat/"
-                            "{subject}_desc-brain_mask.nii.gz"
-                        ),
-                        "space": "native",
+                        "mask": {
+                            "pattern": (
+                                "derivatives/fmriprep-1.3.2/{subject}/anat/"
+                                "{subject}_desc-brain_mask.nii.gz"
+                            ),
+                            "space": "native",
+                        },
                     },
                     "Warp": {
                         "pattern": (
@@ -298,20 +294,6 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
             phase_encoding=phase_encoding,
             run=run,
         )
-        if out.get("BOLD"):
-            out["BOLD"]["mask_item"] = "BOLD_mask"
-            # Add space information
-            out["BOLD"].update({"space": "MNI152NLin2009cAsym"})
-        if out.get("T1w"):
-            out["T1w"]["mask_item"] = "T1w_mask"
-            # Add space information
-            if self.native_t1w:
-                out["T1w"].update({"space": "native"})
-            else:
-                out["T1w"].update({"space": "MNI152NLin2009cAsym"})
-        if out.get("Warp"):
-            # Add source space information
-            out["Warp"].update({"src": "MNI152NLin2009cAsym"})
         return out
 
     def get_elements(self) -> List:

--- a/junifer/datagrabber/pattern_datalad.py
+++ b/junifer/datagrabber/pattern_datalad.py
@@ -32,7 +32,12 @@ class PatternDataladDataGrabber(DataladDataGrabber, PatternDataGrabber):
 
             {
               "mandatory": ["pattern", "space"],
-              "optional": []
+              "optional": {
+                  "mask": {
+                      "mandatory": ["pattern", "space"],
+                      "optional": []
+                  }
+              }
             }
 
         * ``"T2w"`` :
@@ -41,7 +46,12 @@ class PatternDataladDataGrabber(DataladDataGrabber, PatternDataGrabber):
 
             {
               "mandatory": ["pattern", "space"],
-              "optional": []
+              "optional": {
+                  "mask": {
+                      "mandatory": ["pattern", "space"],
+                      "optional": []
+                  }
+              }
             }
 
         * ``"BOLD"`` :
@@ -50,7 +60,16 @@ class PatternDataladDataGrabber(DataladDataGrabber, PatternDataGrabber):
 
             {
               "mandatory": ["pattern", "space"],
-              "optional": ["mask_item"]
+              "optional": {
+                  "mask": {
+                      "mandatory": ["pattern", "space"],
+                      "optional": []
+                  }
+                  "confounds": {
+                      "mandatory": ["pattern", "format"],
+                      "optional": []
+                  }
+              }
             }
 
         * ``"Warp"`` :
@@ -59,15 +78,6 @@ class PatternDataladDataGrabber(DataladDataGrabber, PatternDataGrabber):
 
             {
               "mandatory": ["pattern", "src", "dst"],
-              "optional": []
-            }
-
-        * ``"BOLD_confounds"`` :
-
-          .. code-block:: none
-
-            {
-              "mandatory": ["pattern", "format"],
               "optional": []
             }
 

--- a/junifer/datagrabber/tests/test_datagrabber_utils.py
+++ b/junifer/datagrabber/tests/test_datagrabber_utils.py
@@ -151,12 +151,18 @@ def test_validate_replacements(
             pytest.raises(KeyError, match="Mandatory key"),
         ),
         (
-            ["BOLD_confounds"],
+            ["BOLD"],
             {
-                "BOLD_confounds": {
-                    "pattern": "{subject}/func/{subject}_confounds.tsv",
-                    "format": "fmriprep",
+                "BOLD": {
+                    "pattern": (
+                        "{subject}/func/{subject}_task-rest_bold.nii.gz"
+                    ),
                     "space": "MNINLin6Asym",
+                    "confounds": {
+                        "pattern": "{subject}/func/{subject}_confounds.tsv",
+                        "format": "fmriprep",
+                    },
+                    "zip": "zap",
                 },
             },
             pytest.raises(RuntimeError, match="not accepted"),
@@ -172,7 +178,7 @@ def test_validate_replacements(
             pytest.raises(ValueError, match="following a replacement"),
         ),
         (
-            ["T1w", "T2w", "BOLD", "BOLD_confounds"],
+            ["T1w", "T2w", "BOLD"],
             {
                 "T1w": {
                     "pattern": "{subject}/anat/{subject}_T1w.nii.gz",
@@ -187,10 +193,10 @@ def test_validate_replacements(
                         "{subject}/func/{subject}_task-rest_bold.nii.gz"
                     ),
                     "space": "MNI152NLin6Asym",
-                },
-                "BOLD_confounds": {
-                    "pattern": "{subject}/func/{subject}_confounds.tsv",
-                    "format": "fmriprep",
+                    "confounds": {
+                        "pattern": "{subject}/func/{subject}_confounds.tsv",
+                        "format": "fmriprep",
+                    },
                 },
             },
             nullcontext(),

--- a/junifer/preprocess/base.py
+++ b/junifer/preprocess/base.py
@@ -146,8 +146,8 @@ class BasePreprocessor(ABC, PipelineStepMixin, UpdateMetaMixin):
             The computed result as dictionary.
         dict or None
             Extra "helper" data types as dictionary to add to the Junifer Data
-            object. For example, computed BOLD mask can be passed via this.
-            If no new "helper" data types is created, None is to be passed.
+            object. If no new "helper" data type(s) is(are) created, None is to
+            be passed.
 
         """
         raise_error(

--- a/junifer/testing/datagrabbers.py
+++ b/junifer/testing/datagrabbers.py
@@ -181,7 +181,7 @@ class PartlyCloudyTestingDataGrabber(BaseDataGrabber):
         """Initialize the class."""
         datadir = tempfile.mkdtemp()
         # Define types
-        types = ["BOLD", "BOLD_confounds"]
+        types = ["BOLD"]
         self.reduce_confounds = reduce_confounds
         self.age_group = age_group
         super().__init__(types=types, datadir=datadir)
@@ -242,10 +242,10 @@ class PartlyCloudyTestingDataGrabber(BaseDataGrabber):
         out["BOLD"] = {
             "path": Path(self._dataset["func"][i_sub]),
             "space": "MNI152NLin2009cAsym",
-        }
-        out["BOLD_confounds"] = {
-            "path": Path(self._dataset["confounds"][i_sub]),
-            "format": "fmriprep",
+            "confounds": {
+                "path": Path(self._dataset["confounds"][i_sub]),
+                "format": "fmriprep",
+            },
         }
 
         return out

--- a/junifer/testing/tests/test_partlycloudytesting_datagrabber.py
+++ b/junifer/testing/tests/test_partlycloudytesting_datagrabber.py
@@ -28,13 +28,13 @@ def test_PartlyCloudyTestingDataGrabber() -> None:
         assert out["BOLD"]["path"].exists()
         assert out["BOLD"]["path"].is_file()
 
-        assert "BOLD_confounds" in out
-        assert out["BOLD_confounds"]["path"].exists()
-        assert out["BOLD_confounds"]["path"].is_file()
-        assert "format" in out["BOLD_confounds"]
-        assert "fmriprep" == out["BOLD_confounds"]["format"]
+        assert "confounds" in out["BOLD"]
+        assert out["BOLD"]["confounds"]["path"].exists()
+        assert out["BOLD"]["confounds"]["path"].is_file()
+        assert "format" in out["BOLD"]["confounds"]
+        assert "fmriprep" == out["BOLD"]["confounds"]["format"]
 
     with PartlyCloudyTestingDataGrabber(reduce_confounds=False) as dg:
         out = dg["sub-01"]
-        assert "format" in out["BOLD_confounds"]
-        assert "fmriprep" == out["BOLD_confounds"]["format"]
+        assert "format" in out["BOLD"]["confounds"]
+        assert "fmriprep" == out["BOLD"]["confounds"]["format"]


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR refactors the `patterns` for DataGrabbers by introducing "nested data types" like `mask` for particular data type like `BOLD` instead of `BOLD_mask`. This cleans up the interface and logically groups the available data while reducing the chances of silly errors like not specifying `BOLD_mask` in DataGrabber `types` when mask is desired from the dataset.