### PR TITLE
[ENH]: Add scalar table storage support for `HDF5FeatureStorage`

### DIFF
--- a/docs/changes/newsfragments/343.feature
+++ b/docs/changes/newsfragments/343.feature
@@ -1,0 +1,1 @@
+Introduce new storage type ``scalar_table`` and adapt :class:`.HDF5FeatureStorage` to support it by `Synchon Mandal`_

--- a/docs/understanding/storage.rst
+++ b/docs/understanding/storage.rst
@@ -18,12 +18,12 @@ on them outside the context as long as the processed data is in the memory and
 the Python runtime has not garbage-collected it.
 
 The :ref:`Markers <marker>` are responsible for defining what *storage kind*
-(``matrix``, ``vector``, ``timeseries``) they support for which
-:ref:`data type <data_types>` by overriding its ``get_output_type`` method. The
-storage object in turn declares and provides implementation for specific
-*storage kind*. For example, :class:`.SQLiteFeatureStorage` supports saving
-``matrix``, ``vector`` and ``timeseries`` via ``store_matrix``, ``store_vector``
-and ``store_timeseries`` methods respectively.
+(``matrix``, ``vector``, ``timeseries``, ``scalar_table``) they support for
+which :ref:`data type <data_types>` by overriding its ``get_output_type``
+method. The storage object in turn declares and provides implementation for
+specific *storage kind*. For example, :class:`.SQLiteFeatureStorage` supports
+saving ``matrix``, ``vector`` and ``timeseries`` via ``store_matrix``,
+``store_vector`` and ``store_timeseries`` methods respectively.
 
 For storage interfaces not supported by ``junifer`` yet, you can either make
 your own ``Storage`` by providing a concrete implementation of
@@ -44,17 +44,24 @@ Storage Types
      - Options
      - Reference
    * - ``matrix``
-     - A 2D matrix with row and column names
-     -  ``col_names``, ``row_names``, ``matrix_kind``, ``diagonal``
-     -  :meth:`.BaseFeatureStorage.store_matrix`
+     - A 2D square matrix with row and column names
+     - | ``col_names``, ``row_names``, ``matrix_kind``, ``diagonal``
+       | ``row_header_col_name``
+       | (only for :meth:`.HDF5FeatureStorage.store_matrix`)
+     - :meth:`.BaseFeatureStorage.store_matrix`
    * - ``vector``
      - A 1D row vector of values with column names
      - ``col_names``
-     -  :meth:`.BaseFeatureStorage.store_vector`
+     - :meth:`.BaseFeatureStorage.store_vector`
    * - ``timeseries``
-     - A 2D matrix of values with column names
+     - A 2D square or non-square matrix of scalar values with column names
      - ``col_names``
-     -  :meth:`.BaseFeatureStorage.store_timeseries`
+     - :meth:`.BaseFeatureStorage.store_timeseries`
+   * - ``scalar_table``
+     - | A 2D square or non-square matrix of scalar values with row name, column
+       | name and row header column name
+     - ``col_names``, ``row_names``, ``row_header_col_name``
+     - :meth:`.BaseFeatureStorage.store_scalar_table`
 
 .. _storage_interfaces:
 
@@ -76,4 +83,4 @@ Storage Interfaces
    * - :class:`.HDF5FeatureStorage`
      - ``.hdf5``
      - HDF5
-     - ``matrix``, ``vector``, ``timeseries``
+     - ``matrix``, ``vector``, ``timeseries``, ``scalar_table``

--- a/junifer/storage/base.py
+++ b/junifer/storage/base.py
@@ -189,7 +189,7 @@ class BaseFeatureStorage(ABC):
 
         Parameters
         ----------
-        kind : {"matrix", "timeseries", "vector"}
+        kind : {"matrix", "timeseries", "vector", "scalar_table"}
             The storage kind.
         **kwargs
             The keyword arguments.
@@ -218,6 +218,10 @@ class BaseFeatureStorage(ABC):
             )
         elif kind == "vector":
             self.store_vector(meta_md5=meta_md5, element=t_element, **kwargs)
+        elif kind == "scalar_table":
+            self.store_scalar_table(
+                meta_md5=meta_md5, element=t_element, **kwargs
+            )
 
     def store_matrix(
         self,
@@ -310,6 +314,38 @@ class BaseFeatureStorage(ABC):
         """
         raise_error(
             msg="Concrete classes need to implement store_timeseries().",
+            klass=NotImplementedError,
+        )
+
+    def store_scalar_table(
+        self,
+        meta_md5: str,
+        element: Dict,
+        data: np.ndarray,
+        col_names: Optional[Iterable[str]] = None,
+        row_names: Optional[Iterable[str]] = None,
+        row_header_col_name: Optional[str] = "feature",
+    ) -> None:
+        """Store table with scalar values.
+
+        Parameters
+        ----------
+        meta_md5 : str
+            The metadata MD5 hash.
+        element : dict
+            The element as a dictionary.
+        data : numpy.ndarray
+            The timeseries data to store.
+        col_names : list or tuple of str, optional
+            The column labels (default None).
+        row_names : str, optional
+            The row labels (default None).
+        row_header_col_name : str, optional
+            The column name for the row header column (default "feature").
+
+        """
+        raise_error(
+            msg="Concrete classes need to implement store_scalar_table().",
             klass=NotImplementedError,
         )
 

--- a/junifer/storage/tests/test_hdf5.py
+++ b/junifer/storage/tests/test_hdf5.py
@@ -25,7 +25,12 @@ from junifer.storage.utils import (
 def test_get_valid_inputs() -> None:
     """Test valid inputs."""
     storage = HDF5FeatureStorage(uri="/tmp")
-    assert storage.get_valid_inputs() == ["matrix", "vector", "timeseries"]
+    assert storage.get_valid_inputs() == [
+        "matrix",
+        "vector",
+        "timeseries",
+        "scalar_table",
+    ]
 
 
 def test_single_output(tmp_path: Path) -> None:


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR introduces a new storage type called `scalar_table` which is basically a table with scalar values. The data type is like a mix between `matrix` with user-defined `row_names` and `row_header_col_name` and `timeseries` like internal data storage i.e., non-uniform row and column count but fixed row count across elements. For now, storing `eigenvalues` from `BrainPrint` (#344)  would use this and is only supported by `HDF5FeatureStorage`.