### PR TITLE
[ENH]: Unix path expansion directives support for `PatternDataGrabber`

### DIFF
--- a/docs/changes/newsfragments/345.feature
+++ b/docs/changes/newsfragments/345.feature
@@ -1,0 +1,1 @@
+Allow Unix path expansion directives to be used in :class:`.PatternDataGrabber` ``patterns`` by `Synchon Mandal`_

--- a/docs/extending/datagrabber.rst
+++ b/docs/extending/datagrabber.rst
@@ -314,6 +314,53 @@ This approach can be used directly from the YAML, like so:
      uri: "https://gin.g-node.org/juaml/datalad-example-bids"
      rootdir: example_bids_ses
 
+Advanced: Using Unix-like path expansion directives
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is also possible to use some advanced Unix-like path expansion tricks to
+define our patterns.
+
+A very common thing would be to use ``*`` to match any number of
+characters but we cannot use it right after a replacement like:
+
+.. code-block:: python
+
+    "derivatives/freesurfer/{subject}*"
+
+or if there are multiple files or no files which can be globbed.
+
+We can also use ``[]`` and ``[!]`` to glob certain tricky files like with the
+case of FreeSurfer derivatives. The file structure seen in a typical
+FreeSurfer derivative of a dataset (like ``AOMIC`` ones) is like so:
+
+.. code-block::
+
+      .
+      └── derivatives
+          └── freesurfer
+             ├── fsaverage
+             │   ├── mri
+             │   |   ├── T1.mgz
+             │   |   └── ...
+             │   └── ...
+             ├── sub-01
+             │   ├── mri
+             │   |   ├── T1.mgz
+             │   |   └── ...
+             │   |   └── ...
+             │   └── ...
+             ...
+
+With a structure like this, it would be cumbersome to write custom methods
+for the class and thus we could use a pattern like this:
+
+.. code-block:: python
+
+    "derivatives/freesurfer/[!f]{subject}/mri/T1.mg[z]"
+
+This would ignore the ``fsaverage`` directory as a subject and let ``T1.mgz`` be
+fetched as there can be many files with the same prefix.
+
 .. _extending_datagrabbers_base:
 
 Option B: Extending from BaseDataGrabber

--- a/junifer/datagrabber/pattern.py
+++ b/junifer/datagrabber/pattern.py
@@ -214,18 +214,25 @@ class PatternDataGrabber(BaseDataGrabber):
         t_replacements = [
             x for x in self.replacements if f"{{{x}}}" in pattern
         ]
-
+        # Ops on re_pattern
+        # Remove negated unix glob pattern i.e., [!...] for re_pattern
+        re_pattern = re.sub(r"\[!.?\]", "", re_pattern)
+        # Remove enclosing square brackets from unix glob pattern i.e., [...]
+        # for re_pattern
+        re_pattern = re.sub(r"\[|\]", "", re_pattern)
+        # Iteratively replace the first of each with a named group definition
         for t_r in t_replacements:
-            # Replace the first of each with a named group definition
             re_pattern = re_pattern.replace(f"{{{t_r}}}", f"(?P<{t_r}>.*)", 1)
-
+        # Iteratively replace the second appearance of each with the named
+        # group back reference
         for t_r in t_replacements:
-            # Replace the second appearance of each with the named group
-            # back reference
             re_pattern = re_pattern.replace(f"{{{t_r}}}", f"(?P={t_r})")
-
+        # Ops on glob_pattern
+        # Iteratively replace replacements with wildcard i.e., *
+        # for glob_pattern
         for t_r in t_replacements:
             glob_pattern = glob_pattern.replace(f"{{{t_r}}}", "*")
+
         return re_pattern, glob_pattern, t_replacements
 
     def _replace_patterns_glob(self, element: Dict, pattern: str) -> str:
@@ -254,6 +261,10 @@ class PatternDataGrabber(BaseDataGrabber):
                 f"The element keys must be {self.replacements}, "
                 f"element has {list(element.keys())}."
             )
+        # Remove negated unix glob pattern i.e., [!...]
+        pattern = re.sub(r"\[!.?\]", "", pattern)
+        # Remove enclosing square brackets from unix glob pattern i.e., [...]
+        pattern = re.sub(r"\[|\]", "", pattern)
         return pattern.format(**element)
 
     def _get_path_from_patterns(


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds support for specifying Unix path expansion directives like `[], [!]` for `PatternDataGrabber` patterns. This is an improvement which is needed for supporting `FreeSurfer` data type. For example, `fsaverage` directory is at the same level as subjects like `sub-0001` for AOMIC datasets and `[!f]` allows to not glob the `fsaverage` directory without overriding `get_elements()` method. As the `.mgz` and other outputs of `FreeSurfer` are not unique by subject (and/or task / session) prefix, globbing doesn't work as usual (at least for the AOMIC datasets). This also enables one to have the pattern: `.../T1.mg[z]` to make it work.