### PR TITLE
[ENH]: Add test for `JuniferNiftiSpheresMasker` against nilearn's version

### DIFF
--- a/docs/changes/newsfragments/136.enh
+++ b/docs/changes/newsfragments/136.enh
@@ -1,0 +1,1 @@
+Add test to be sure that :class:`.JuniferNiftiSpheresMasker` with mean aggregation function behaves exactly as :class:`nilearn.maskers.NiftiSpheresMasker` by `Synchon Mandal`_

--- a/junifer/external/nilearn/__init__.py
+++ b/junifer/external/nilearn/__init__.py
@@ -4,3 +4,6 @@
 # License: AGPL
 
 from .junifer_nifti_spheres_masker import JuniferNiftiSpheresMasker
+
+
+__all__ = ["JuniferNiftiSpheresMasker"]

--- a/junifer/external/nilearn/junifer_nifti_spheres_masker.py
+++ b/junifer/external/nilearn/junifer_nifti_spheres_masker.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 # New BSD License
 
-# Copyright (c) 2007 - 2022 The nilearn developers.
+# Copyright (c) The nilearn developers.
 # All rights reserved.
 
 

--- a/junifer/external/nilearn/junifer_nifti_spheres_masker.py
+++ b/junifer/external/nilearn/junifer_nifti_spheres_masker.py
@@ -99,6 +99,17 @@ def _apply_mask_and_get_affinity(
         Contains the boolean indices for each sphere.
         shape: (number of seeds, number of voxels)
 
+    Raises
+    ------
+    ValueError
+        If ``niimg`` and ``mask_img`` are both provided or
+        if overlap is detected between spheres.
+
+    Warns
+    -----
+    RuntimeWarning
+        If the provided images contain NaN, they will be converted to zeroes.
+
     """
     seeds = list(seeds)
 

--- a/junifer/external/nilearn/junifer_nifti_spheres_masker.py
+++ b/junifer/external/nilearn/junifer_nifti_spheres_masker.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
     from pandas import DataFrame
 
 
+__all__ = ["JuniferNiftiSpheresMasker"]
+
+
 # New BSD License
 
 # Copyright (c) The nilearn developers.

--- a/junifer/external/nilearn/junifer_nifti_spheres_masker.py
+++ b/junifer/external/nilearn/junifer_nifti_spheres_masker.py
@@ -221,7 +221,7 @@ def _iter_signals_from_spheres(
     X, A = _apply_mask_and_get_affinity(
         seeds, niimg, radius, allow_overlap, mask_img=mask_img
     )
-    for _, row in enumerate(A.rows):
+    for row in A.rows:
         yield X[:, row]
 
 

--- a/junifer/external/nilearn/tests/test_junifer_nifti_spheres_masker.py
+++ b/junifer/external/nilearn/tests/test_junifer_nifti_spheres_masker.py
@@ -17,7 +17,7 @@ from junifer.external.nilearn import JuniferNiftiSpheresMasker
 
 # New BSD License
 
-# Copyright (c) 2007 - 2022 The nilearn developers.
+# Copyright (c) The nilearn developers.
 # All rights reserved.
 
 


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

We reimplemented (by copying) a `JuniferNiftiSpheresMasker` that has the same functionality of `NiftiSpheresMasker` but allows to change the aggregation function.

The tests are also a copy of Nilearn's one.

If `agg_function = 'mean'`, then they should both behave equally. I would like to have a test so we can corroborate this. They should be numerically equal.

### How do you imagine this integrated in junifer?

One more test in `junifer.external.nilearn.tests`

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_