### PR TITLE
[ENH]: Enable `Marker`s to extract multiple features

### DIFF
--- a/docs/changes/newsfragments/349.change
+++ b/docs/changes/newsfragments/349.change
@@ -1,0 +1,1 @@
+``fractional`` parameter for ``ALFFBase``, :class:`.ALFFParcels` and :class:`.ALFFSpheres` have been removed in favour of returning both ALFF and fALFF by `Synchon Mandal`_

--- a/docs/changes/newsfragments/349.enh
+++ b/docs/changes/newsfragments/349.enh
@@ -1,0 +1,1 @@
+Enable Markers to output multiple features by `Synchon Mandal`_

--- a/docs/understanding/marker.rst
+++ b/docs/understanding/marker.rst
@@ -26,7 +26,5 @@ on them outside the context as long as the actual data is in the memory and the
 Python runtime has not garbage-collected it.
 
 If you are interested in using already provided Markers, please go to
-:doc:`../builtin`. And, if you want to implement your own Marker, you need to
-provide concrete implementation of :class:`.BaseMarker`. Specifically, you
-need to override ``get_valid_inputs``, ``get_output_type`` and ``compute``
-methods.
+:doc:`../builtin`. And, if you want to implement your own Marker, please check
+out :doc:`../extending/marker`.

--- a/junifer/datagrabber/tests/test_datalad_base.py
+++ b/junifer/datagrabber/tests/test_datalad_base.py
@@ -15,13 +15,13 @@ from junifer.datagrabber import DataladDataGrabber
 _testing_dataset = {
     "example_bids": {
         "uri": "https://gin.g-node.org/juaml/datalad-example-bids",
-        "commit": "522dfb203afcd2cd55799bf347f9b211919a7338",
-        "id": "fec92475-d9c0-4409-92ba-f041b6a12c40",
+        "commit": "b87897cbe51bf0ee5514becaa5c7dd76491db5ad",
+        "id": "8fddff30-6993-420a-9d1e-b5b028c59468",
     },
     "example_bids_ses": {
         "uri": "https://gin.g-node.org/juaml/datalad-example-bids-ses",
-        "commit": "3d08d55d1faad4f12ab64ac9497544a0d924d47a",
-        "id": "c83500d0-532f-45be-baf1-0dab703bdc2a",
+        "commit": "6b163aa98af76a9eac0272273c27e14127850181",
+        "id": "715c17cf-a1b9-42d6-9af8-9f74c1a4a724",
     },
 }
 

--- a/junifer/datagrabber/tests/test_pattern_datalad.py
+++ b/junifer/datagrabber/tests/test_pattern_datalad.py
@@ -15,13 +15,13 @@ from junifer.datagrabber import PatternDataladDataGrabber
 _testing_dataset = {
     "example_bids": {
         "uri": "https://gin.g-node.org/juaml/datalad-example-bids",
-        "commit": "522dfb203afcd2cd55799bf347f9b211919a7338",
-        "id": "fec92475-d9c0-4409-92ba-f041b6a12c40",
+        "commit": "b87897cbe51bf0ee5514becaa5c7dd76491db5ad",
+        "id": "8fddff30-6993-420a-9d1e-b5b028c59468",
     },
     "example_bids_ses": {
         "uri": "https://gin.g-node.org/juaml/datalad-example-bids-ses",
-        "commit": "3d08d55d1faad4f12ab64ac9497544a0d924d47a",
-        "id": "c83500d0-532f-45be-baf1-0dab703bdc2a",
+        "commit": "6b163aa98af76a9eac0272273c27e14127850181",
+        "id": "715c17cf-a1b9-42d6-9af8-9f74c1a4a724",
     },
 }
 

--- a/junifer/markers/complexity/tests/test_hurst_exponent.py
+++ b/junifer/markers/complexity/tests/test_hurst_exponent.py
@@ -40,13 +40,14 @@ def test_compute() -> None:
         # Compute the marker
         feature_map = marker.fit_transform(element_data)
         # Assert the dimension of timeseries
-        assert feature_map["BOLD"]["data"].ndim == 2
+        assert feature_map["BOLD"]["complexity"]["data"].ndim == 2
 
 
 def test_get_output_type() -> None:
     """Test HurstExponent get_output_type()."""
-    marker = HurstExponent(parcellation=PARCELLATION)
-    assert marker.get_output_type("BOLD") == "vector"
+    assert "vector" == HurstExponent(
+        parcellation=PARCELLATION
+    ).get_output_type(input_type="BOLD", output_feature="complexity")
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/complexity/tests/test_multiscale_entropy_auc.py
+++ b/junifer/markers/complexity/tests/test_multiscale_entropy_auc.py
@@ -39,13 +39,14 @@ def test_compute() -> None:
         # Compute the marker
         feature_map = marker.fit_transform(element_data)
         # Assert the dimension of timeseries
-        assert feature_map["BOLD"]["data"].ndim == 2
+        assert feature_map["BOLD"]["complexity"]["data"].ndim == 2
 
 
 def test_get_output_type() -> None:
     """Test MultiscaleEntropyAUC get_output_type()."""
-    marker = MultiscaleEntropyAUC(parcellation=PARCELLATION)
-    assert marker.get_output_type("BOLD") == "vector"
+    assert "vector" == MultiscaleEntropyAUC(
+        parcellation=PARCELLATION
+    ).get_output_type(input_type="BOLD", output_feature="complexity")
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/complexity/tests/test_perm_entropy.py
+++ b/junifer/markers/complexity/tests/test_perm_entropy.py
@@ -39,13 +39,14 @@ def test_compute() -> None:
         # Compute the marker
         feature_map = marker.fit_transform(element_data)
         # Assert the dimension of timeseries
-        assert feature_map["BOLD"]["data"].ndim == 2
+        assert feature_map["BOLD"]["complexity"]["data"].ndim == 2
 
 
 def test_get_output_type() -> None:
     """Test PermEntropy get_output_type()."""
-    marker = PermEntropy(parcellation=PARCELLATION)
-    assert marker.get_output_type("BOLD") == "vector"
+    assert "vector" == PermEntropy(parcellation=PARCELLATION).get_output_type(
+        input_type="BOLD", output_feature="complexity"
+    )
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/complexity/tests/test_range_entropy.py
+++ b/junifer/markers/complexity/tests/test_range_entropy.py
@@ -40,13 +40,14 @@ def test_compute() -> None:
         # Compute the marker
         feature_map = marker.fit_transform(element_data)
         # Assert the dimension of timeseries
-        assert feature_map["BOLD"]["data"].ndim == 2
+        assert feature_map["BOLD"]["complexity"]["data"].ndim == 2
 
 
 def test_get_output_type() -> None:
     """Test RangeEntropy get_output_type()."""
-    marker = RangeEntropy(parcellation=PARCELLATION)
-    assert marker.get_output_type("BOLD") == "vector"
+    assert "vector" == RangeEntropy(parcellation=PARCELLATION).get_output_type(
+        input_type="BOLD", output_feature="complexity"
+    )
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/complexity/tests/test_range_entropy_auc.py
+++ b/junifer/markers/complexity/tests/test_range_entropy_auc.py
@@ -40,13 +40,14 @@ def test_compute() -> None:
         # Compute the marker
         feature_map = marker.fit_transform(element_data)
         # Assert the dimension of timeseries
-        assert feature_map["BOLD"]["data"].ndim == 2
+        assert feature_map["BOLD"]["complexity"]["data"].ndim == 2
 
 
 def test_get_output_type() -> None:
     """Test RangeEntropyAUC get_output_type()."""
-    marker = RangeEntropyAUC(parcellation=PARCELLATION)
-    assert marker.get_output_type("BOLD") == "vector"
+    assert "vector" == RangeEntropyAUC(
+        parcellation=PARCELLATION
+    ).get_output_type(input_type="BOLD", output_feature="complexity")
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/complexity/tests/test_sample_entropy.py
+++ b/junifer/markers/complexity/tests/test_sample_entropy.py
@@ -39,13 +39,14 @@ def test_compute() -> None:
         # Compute the marker
         feature_map = marker.fit_transform(element_data)
         # Assert the dimension of timeseries
-        assert feature_map["BOLD"]["data"].ndim == 2
+        assert feature_map["BOLD"]["complexity"]["data"].ndim == 2
 
 
 def test_get_output_type() -> None:
     """Test SampleEntropy get_output_type()."""
-    marker = SampleEntropy(parcellation=PARCELLATION)
-    assert marker.get_output_type("BOLD") == "vector"
+    assert "vector" == SampleEntropy(
+        parcellation=PARCELLATION
+    ).get_output_type(input_type="BOLD", output_feature="complexity")
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/complexity/tests/test_weighted_perm_entropy.py
+++ b/junifer/markers/complexity/tests/test_weighted_perm_entropy.py
@@ -39,13 +39,14 @@ def test_compute() -> None:
         # Compute the marker
         feature_map = marker.fit_transform(element_data)
         # Assert the dimension of timeseries
-        assert feature_map["BOLD"]["data"].ndim == 2
+        assert feature_map["BOLD"]["complexity"]["data"].ndim == 2
 
 
 def test_get_output_type() -> None:
     """Test WeightedPermEntropy get_output_type()."""
-    marker = WeightedPermEntropy(parcellation=PARCELLATION)
-    assert marker.get_output_type("BOLD") == "vector"
+    assert "vector" == WeightedPermEntropy(
+        parcellation=PARCELLATION
+    ).get_output_type(input_type="BOLD", output_feature="complexity")
 
 
 @pytest.mark.skipif(

--- a/junifer/markers/falff/tests/test_falff_parcels.py
+++ b/junifer/markers/falff/tests/test_falff_parcels.py
@@ -21,6 +21,28 @@ from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
 PARCELLATION = "TianxS1x3TxMNInonlinear2009cAsym"
 
 
+@pytest.mark.parametrize(
+    "feature",
+    [
+        "alff",
+        "falff",
+    ],
+)
+def test_ALFFParcels_get_output_type(feature: str) -> None:
+    """Test ALFFParcels get_output_type().
+
+    Parameters
+    ----------
+    feature : str
+        The parametrized feature name.
+
+    """
+    assert "vector" == ALFFParcels(
+        parcellation=PARCELLATION,
+        using="junifer",
+    ).get_output_type(input_type="BOLD", output_feature=feature)
+
+
 def test_ALFFParcels(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
     """Test ALFFParcels.
 
@@ -41,7 +63,6 @@ def test_ALFFParcels(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
             # Initialize marker
             marker = ALFFParcels(
                 parcellation=PARCELLATION,
-                fractional=False,
                 using="junifer",
             )
             # Fit transform marker on data
@@ -51,15 +72,16 @@ def test_ALFFParcels(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
 
             # Get BOLD output
             assert "BOLD" in output
-            output_bold = output["BOLD"]
-            # Assert BOLD output keys
-            assert "data" in output_bold
-            assert "col_names" in output_bold
+            for feature in output["BOLD"].keys():
+                output_bold = output["BOLD"][feature]
+                # Assert BOLD output keys
+                assert "data" in output_bold
+                assert "col_names" in output_bold
 
-            output_bold_data = output_bold["data"]
-            # Assert BOLD output data dimension
-            assert output_bold_data.ndim == 2
-            assert output_bold_data.shape == (1, 16)
+                output_bold_data = output_bold["data"]
+                # Assert BOLD output data dimension
+                assert output_bold_data.ndim == 2
+                assert output_bold_data.shape == (1, 16)
 
             # Reset log capture
             caplog.clear()
@@ -77,18 +99,13 @@ def test_ALFFParcels(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
 @pytest.mark.skipif(
     _check_afni() is False, reason="requires AFNI to be in PATH"
 )
-@pytest.mark.parametrize(
-    "fractional", [True, False], ids=["fractional", "non-fractional"]
-)
-def test_ALFFParcels_comparison(tmp_path: Path, fractional: bool) -> None:
+def test_ALFFParcels_comparison(tmp_path: Path) -> None:
     """Test ALFFParcels implementation comparison.
 
     Parameters
     ----------
     tmp_path : pathlib.Path
         The path to the test directory.
-    fractional : bool
-        Whether to compute fractional ALFF or not.
 
     """
     with PartlyCloudyTestingDataGrabber() as dg:
@@ -99,7 +116,6 @@ def test_ALFFParcels_comparison(tmp_path: Path, fractional: bool) -> None:
         # Initialize marker
         junifer_marker = ALFFParcels(
             parcellation=PARCELLATION,
-            fractional=fractional,
             using="junifer",
         )
         # Fit transform marker on data
@@ -110,7 +126,6 @@ def test_ALFFParcels_comparison(tmp_path: Path, fractional: bool) -> None:
         # Initialize marker
         afni_marker = ALFFParcels(
             parcellation=PARCELLATION,
-            fractional=fractional,
             using="afni",
         )
         # Fit transform marker on data
@@ -118,9 +133,10 @@ def test_ALFFParcels_comparison(tmp_path: Path, fractional: bool) -> None:
         # Get BOLD output
         afni_output_bold = afni_output["BOLD"]
 
-        # Check for Pearson correlation coefficient
-        r, _ = sp.stats.pearsonr(
-            junifer_output_bold["data"][0],
-            afni_output_bold["data"][0],
-        )
-        assert r > 0.97
+        for feature in afni_output_bold.keys():
+            # Check for Pearson correlation coefficient
+            r, _ = sp.stats.pearsonr(
+                junifer_output_bold[feature]["data"][0],
+                afni_output_bold[feature]["data"][0],
+            )
+            assert r > 0.97

--- a/junifer/markers/functional_connectivity/edge_functional_connectivity_parcels.py
+++ b/junifer/markers/functional_connectivity/edge_functional_connectivity_parcels.py
@@ -98,23 +98,29 @@ class EdgeCentricFCParcels(FunctionalConnectivityBase):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the actual computed values as a numpy.ndarray
-            * ``col_names`` : the column labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         """
-        parcel_aggregation = ParcelAggregation(
+        # Perform aggregation
+        aggregation = ParcelAggregation(
             parcellation=self.parcellation,
             method=self.agg_method,
             method_params=self.agg_method_params,
             masks=self.masks,
             on="BOLD",
-        )
-
-        bold_aggregated = parcel_aggregation.compute(
-            input, extra_input=extra_input
-        )
+        ).compute(input, extra_input=extra_input)
+        # Compute edgewise timeseries
         ets, edge_names = _ets(
-            bold_aggregated["data"], bold_aggregated["col_names"]
+            bold_ts=aggregation["aggregation"]["data"],
+            roi_names=aggregation["aggregation"]["col_names"],
         )
 
-        return {"data": ets, "col_names": edge_names}
+        return {
+            "aggregation": {
+                "data": ets,
+                "col_names": edge_names,
+            },
+        }

--- a/junifer/markers/functional_connectivity/edge_functional_connectivity_spheres.py
+++ b/junifer/markers/functional_connectivity/edge_functional_connectivity_spheres.py
@@ -110,11 +110,14 @@ class EdgeCentricFCSpheres(FunctionalConnectivityBase):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the actual computed values as a numpy.ndarray
-            * ``col_names`` : the column labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         """
-        sphere_aggregation = SphereAggregation(
+        # Perform aggregation
+        aggregation = SphereAggregation(
             coords=self.coords,
             radius=self.radius,
             allow_overlap=self.allow_overlap,
@@ -122,12 +125,13 @@ class EdgeCentricFCSpheres(FunctionalConnectivityBase):
             method_params=self.agg_method_params,
             masks=self.masks,
             on="BOLD",
-        )
-        bold_aggregated = sphere_aggregation.compute(
-            input, extra_input=extra_input
-        )
+        ).compute(input, extra_input=extra_input)
+        # Compute edgewise timeseries
         ets, edge_names = _ets(
-            bold_aggregated["data"], bold_aggregated["col_names"]
+            bold_ts=aggregation["aggregation"]["data"],
+            roi_names=aggregation["aggregation"]["col_names"],
         )
 
-        return {"data": ets, "col_names": edge_names}
+        return {
+            "aggregation": {"data": ets, "col_names": edge_names},
+        }

--- a/junifer/markers/functional_connectivity/functional_connectivity_parcels.py
+++ b/junifer/markers/functional_connectivity/functional_connectivity_parcels.py
@@ -90,16 +90,16 @@ class FunctionalConnectivityParcels(FunctionalConnectivityBase):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the actual computed values as a numpy.ndarray
-            * ``col_names`` : the column labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         """
-        parcel_aggregation = ParcelAggregation(
+        return ParcelAggregation(
             parcellation=self.parcellation,
             method=self.agg_method,
             method_params=self.agg_method_params,
             masks=self.masks,
             on="BOLD",
-        )
-        # Return the 2D timeseries after parcel aggregation
-        return parcel_aggregation.compute(input, extra_input=extra_input)
+        ).compute(input=input, extra_input=extra_input)

--- a/junifer/markers/functional_connectivity/functional_connectivity_spheres.py
+++ b/junifer/markers/functional_connectivity/functional_connectivity_spheres.py
@@ -104,11 +104,13 @@ class FunctionalConnectivitySpheres(FunctionalConnectivityBase):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the actual computed values as a numpy.ndarray
-            * ``col_names`` : the column labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         """
-        sphere_aggregation = SphereAggregation(
+        return SphereAggregation(
             coords=self.coords,
             radius=self.radius,
             allow_overlap=self.allow_overlap,
@@ -116,6 +118,4 @@ class FunctionalConnectivitySpheres(FunctionalConnectivityBase):
             method_params=self.agg_method_params,
             masks=self.masks,
             on="BOLD",
-        )
-        # Return the 2D timeseries after sphere aggregation
-        return sphere_aggregation.compute(input, extra_input=extra_input)
+        ).compute(input=input, extra_input=extra_input)

--- a/junifer/markers/functional_connectivity/tests/test_crossparcellation_functional_connectivity.py
+++ b/junifer/markers/functional_connectivity/tests/test_crossparcellation_functional_connectivity.py
@@ -33,10 +33,11 @@ def test_init() -> None:
 
 def test_get_output_type() -> None:
     """Test CrossParcellationFC get_output_type()."""
-    crossparcellation = CrossParcellationFC(
+    assert "matrix" == CrossParcellationFC(
         parcellation_one=parcellation_one, parcellation_two=parcellation_two
+    ).get_output_type(
+        input_type="BOLD", output_feature="functional_connectivity"
     )
-    assert "matrix" == crossparcellation.get_output_type("BOLD")
 
 
 @pytest.mark.skipif(
@@ -59,7 +60,9 @@ def test_compute(tmp_path: Path) -> None:
             parcellation_two=parcellation_two,
             correlation_method="spearman",
         )
-        out = crossparcellation.compute(element_data["BOLD"])
+        out = crossparcellation.compute(element_data["BOLD"])[
+            "functional_connectivity"
+        ]
         assert out["data"].shape == (200, 100)
         assert len(out["col_names"]) == 100
         assert len(out["row_names"]) == 200
@@ -92,5 +95,6 @@ def test_store(tmp_path: Path) -> None:
         crossparcellation.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_CrossParcellationFC" for x in features.values()
+            x["name"] == "BOLD_CrossParcellationFC_functional_connectivity"
+            for x in features.values()
         )

--- a/junifer/markers/functional_connectivity/tests/test_edge_functional_connectivity_parcels.py
+++ b/junifer/markers/functional_connectivity/tests/test_edge_functional_connectivity_parcels.py
@@ -28,11 +28,13 @@ def test_EdgeCentricFCParcels(tmp_path: Path) -> None:
             cor_method_params={"empirical": True},
         )
         # Check correct output
-        assert marker.get_output_type("BOLD") == "matrix"
+        assert "matrix" == marker.get_output_type(
+            input_type="BOLD", output_feature="functional_connectivity"
+        )
 
         # Fit-transform the data
         edge_fc = marker.fit_transform(element_data)
-        edge_fc_bold = edge_fc["BOLD"]
+        edge_fc_bold = edge_fc["BOLD"]["functional_connectivity"]
 
         # For 16 ROIs we should get (16 * (16 -1) / 2) edges in the ETS
         n_edges = int(16 * (16 - 1) / 2)
@@ -51,5 +53,6 @@ def test_EdgeCentricFCParcels(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_EdgeCentricFCParcels" for x in features.values()
+            x["name"] == "BOLD_EdgeCentricFCParcels_functional_connectivity"
+            for x in features.values()
         )

--- a/junifer/markers/functional_connectivity/tests/test_edge_functional_connectivity_spheres.py
+++ b/junifer/markers/functional_connectivity/tests/test_edge_functional_connectivity_spheres.py
@@ -27,11 +27,13 @@ def test_EdgeCentricFCSpheres(tmp_path: Path) -> None:
             coords="DMNBuckner", radius=5.0, cor_method="correlation"
         )
         # Check correct output
-        assert marker.get_output_type("BOLD") == "matrix"
+        assert "matrix" == marker.get_output_type(
+            input_type="BOLD", output_feature="functional_connectivity"
+        )
 
         # Fit-transform the data
         edge_fc = marker.fit_transform(element_data)
-        edge_fc_bold = edge_fc["BOLD"]
+        edge_fc_bold = edge_fc["BOLD"]["functional_connectivity"]
 
         # There are six DMNBuckner coordinates, so
         # for 6 ROIs we should get (6 * (6 -1) / 2) edges in the ETS
@@ -57,5 +59,6 @@ def test_EdgeCentricFCSpheres(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_EdgeCentricFCSpheres" for x in features.values()
+            x["name"] == "BOLD_EdgeCentricFCSpheres_functional_connectivity"
+            for x in features.values()
         )

--- a/junifer/markers/functional_connectivity/tests/test_functional_connectivity_parcels.py
+++ b/junifer/markers/functional_connectivity/tests/test_functional_connectivity_parcels.py
@@ -35,11 +35,13 @@ def test_FunctionalConnectivityParcels(tmp_path: Path) -> None:
             parcellation="TianxS1x3TxMNInonlinear2009cAsym"
         )
         # Check correct output
-        assert marker.get_output_type("BOLD") == "matrix"
+        assert "matrix" == marker.get_output_type(
+            input_type="BOLD", output_feature="functional_connectivity"
+        )
 
         # Fit-transform the data
         fc = marker.fit_transform(element_data)
-        fc_bold = fc["BOLD"]
+        fc_bold = fc["BOLD"]["functional_connectivity"]
 
         assert "data" in fc_bold
         assert "row_names" in fc_bold
@@ -83,6 +85,7 @@ def test_FunctionalConnectivityParcels(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_FunctionalConnectivityParcels"
+            x["name"]
+            == "BOLD_FunctionalConnectivityParcels_functional_connectivity"
             for x in features.values()
         )

--- a/junifer/markers/functional_connectivity/tests/test_functional_connectivity_spheres.py
+++ b/junifer/markers/functional_connectivity/tests/test_functional_connectivity_spheres.py
@@ -38,11 +38,13 @@ def test_FunctionalConnectivitySpheres(tmp_path: Path) -> None:
             coords="DMNBuckner", radius=5.0, cor_method="correlation"
         )
         # Check correct output
-        assert marker.get_output_type("BOLD") == "matrix"
+        assert "matrix" == marker.get_output_type(
+            input_type="BOLD", output_feature="functional_connectivity"
+        )
 
         # Fit-transform the data
         fc = marker.fit_transform(element_data)
-        fc_bold = fc["BOLD"]
+        fc_bold = fc["BOLD"]["functional_connectivity"]
 
         assert "data" in fc_bold
         assert "row_names" in fc_bold
@@ -80,7 +82,8 @@ def test_FunctionalConnectivitySpheres(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_FunctionalConnectivitySpheres"
+            x["name"]
+            == "BOLD_FunctionalConnectivitySpheres_functional_connectivity"
             for x in features.values()
         )
 
@@ -103,11 +106,13 @@ def test_FunctionalConnectivitySpheres_empirical(tmp_path: Path) -> None:
             cor_method_params={"empirical": True},
         )
         # Check correct output
-        assert marker.get_output_type("BOLD") == "matrix"
+        assert "matrix" == marker.get_output_type(
+            input_type="BOLD", output_feature="functional_connectivity"
+        )
 
         # Fit-transform the data
         fc = marker.fit_transform(element_data)
-        fc_bold = fc["BOLD"]
+        fc_bold = fc["BOLD"]["functional_connectivity"]
 
         assert "data" in fc_bold
         assert "row_names" in fc_bold

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -63,6 +63,36 @@ class ParcelAggregation(BaseMarker):
 
     _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn", "numpy"}
 
+    _MARKER_INOUT_MAPPINGS: ClassVar[Dict[str, Dict[str, str]]] = {
+        "T1w": {
+            "aggregation": "vector",
+        },
+        "T2w": {
+            "aggregation": "vector",
+        },
+        "BOLD": {
+            "aggregation": "timeseries",
+        },
+        "VBM_GM": {
+            "aggregation": "vector",
+        },
+        "VBM_WM": {
+            "aggregation": "vector",
+        },
+        "VBM_CSF": {
+            "aggregation": "vector",
+        },
+        "fALFF": {
+            "aggregation": "vector",
+        },
+        "GCOR": {
+            "aggregation": "vector",
+        },
+        "LCOR": {
+            "aggregation": "vector",
+        },
+    }
+
     def __init__(
         self,
         parcellation: Union[str, List[str]],
@@ -96,61 +126,6 @@ class ParcelAggregation(BaseMarker):
         self.time_method = time_method
         self.time_method_params = time_method_params or {}
 
-    def get_valid_inputs(self) -> List[str]:
-        """Get valid data types for input.
-
-        Returns
-        -------
-        list of str
-            The list of data types that can be used as input for this marker.
-
-        """
-        return [
-            "T1w",
-            "T2w",
-            "BOLD",
-            "VBM_GM",
-            "VBM_WM",
-            "VBM_CSF",
-            "fALFF",
-            "GCOR",
-            "LCOR",
-        ]
-
-    def get_output_type(self, input_type: str) -> str:
-        """Get output type.
-
-        Parameters
-        ----------
-        input_type : str
-            The data type input to the marker.
-
-        Returns
-        -------
-        str
-            The storage type output by the marker.
-
-        Raises
-        ------
-        ValueError
-            If the ``input_type`` is invalid.
-
-        """
-
-        if input_type in [
-            "VBM_GM",
-            "VBM_WM",
-            "VBM_CSF",
-            "fALFF",
-            "GCOR",
-            "LCOR",
-        ]:
-            return "vector"
-        elif input_type == "BOLD":
-            return "timeseries"
-        else:
-            raise_error(f"Unknown input kind for {input_type}")
-
     def compute(
         self, input: Dict[str, Any], extra_input: Optional[Dict] = None
     ) -> Dict:
@@ -174,8 +149,10 @@ class ParcelAggregation(BaseMarker):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the actual computed values as a numpy.ndarray
-            * ``col_names`` : the column labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         Warns
         -----
@@ -253,5 +230,9 @@ class ParcelAggregation(BaseMarker):
                     "available."
                 )
         # Format the output
-        out = {"data": out_values, "col_names": labels}
-        return out
+        return {
+            "aggregation": {
+                "data": out_values,
+                "col_names": labels,
+            },
+        }

--- a/junifer/markers/reho/reho_base.py
+++ b/junifer/markers/reho/reho_base.py
@@ -62,6 +62,12 @@ class ReHoBase(BaseMarker):
         },
     ]
 
+    _MARKER_INOUT_MAPPINGS: ClassVar[Dict[str, Dict[str, str]]] = {
+        "BOLD": {
+            "reho": "vector",
+        },
+    }
+
     def __init__(
         self,
         using: str,
@@ -75,33 +81,6 @@ class ReHoBase(BaseMarker):
             )
         self.using = using
         super().__init__(on="BOLD", name=name)
-
-    def get_valid_inputs(self) -> List[str]:
-        """Get valid data types for input.
-
-        Returns
-        -------
-        list of str
-            The list of data types that can be used as input for this marker.
-
-        """
-        return ["BOLD"]
-
-    def get_output_type(self, input_type: str) -> str:
-        """Get output type.
-
-        Parameters
-        ----------
-        input_type : str
-            The data type input to the marker.
-
-        Returns
-        -------
-        str
-            The storage type output by the marker.
-
-        """
-        return "vector"
 
     def _compute(
         self,

--- a/junifer/markers/reho/reho_parcels.py
+++ b/junifer/markers/reho/reho_parcels.py
@@ -125,11 +125,14 @@ class ReHoParcels(ReHoBase):
         Returns
         -------
         dict
-            The computed result as dictionary. The dictionary has the following
-            keys:
+            The computed result as dictionary. This will be either returned
+            to the user or stored in the storage by calling the store method
+            with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the actual computed values as a 1D numpy.ndarray
-            * ``col_names`` : the column labels for the parcels as a list
+            * ``reho`` : dictionary with the following keys:
+
+              - ``data`` : ROI values as ``numpy.ndarray``
+              - ``col_names`` : ROI labels as list of str
 
         """
         logger.info("Calculating ReHo for parcels")
@@ -145,22 +148,27 @@ class ReHoParcels(ReHoBase):
         else:
             reho_map, reho_file_path = self._compute(input_data=input)
 
-        # Initialize parcel aggregation
+        # Perform aggregation on reho map
+        aggregation_input = dict(input.items())
+        aggregation_input["data"] = reho_map
+        aggregation_input["path"] = reho_file_path
         parcel_aggregation = ParcelAggregation(
             parcellation=self.parcellation,
             method=self.agg_method,
             method_params=self.agg_method_params,
             masks=self.masks,
             on="BOLD",
-        )
-        # Perform aggregation on reho map
-        parcel_aggregation_input = dict(input.items())
-        parcel_aggregation_input["data"] = reho_map
-        parcel_aggregation_input["path"] = reho_file_path
-        output = parcel_aggregation.compute(
-            input=parcel_aggregation_input,
+        ).compute(
+            input=aggregation_input,
             extra_input=extra_input,
         )
-        # Only use the first row and expand row dimension
-        output["data"] = output["data"][0][np.newaxis, :]
-        return output
+
+        return {
+            "reho": {
+                # Only use the first row and expand row dimension
+                "data": parcel_aggregation["aggregation"]["data"][0][
+                    np.newaxis, :
+                ],
+                "col_names": parcel_aggregation["aggregation"]["col_names"],
+            }
+        }

--- a/junifer/markers/reho/tests/test_reho_parcels.py
+++ b/junifer/markers/reho/tests/test_reho_parcels.py
@@ -42,6 +42,11 @@ def test_ReHoParcels(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
                 parcellation="TianxS1x3TxMNInonlinear2009cAsym",
                 using="junifer",
             )
+            # Check correct output
+            assert "vector" == marker.get_output_type(
+                input_type="BOLD", output_feature="reho"
+            )
+
             # Fit transform marker on data
             output = marker.fit_transform(element_data)
 
@@ -49,7 +54,7 @@ def test_ReHoParcels(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
 
             # Get BOLD output
             assert "BOLD" in output
-            output_bold = output["BOLD"]
+            output_bold = output["BOLD"]["reho"]
             # Assert BOLD output keys
             assert "data" in output_bold
             assert "col_names" in output_bold
@@ -102,14 +107,14 @@ def test_ReHoParcels_comparison(tmp_path: Path) -> None:
         # Fit transform marker on data
         junifer_output = junifer_marker.fit_transform(element_data)
         # Get BOLD output
-        junifer_output_bold = junifer_output["BOLD"]
+        junifer_output_bold = junifer_output["BOLD"]["reho"]
 
         # Initialize marker
         afni_marker = ReHoParcels(parcellation="Schaefer100x7", using="afni")
         # Fit transform marker on data
         afni_output = afni_marker.fit_transform(element_data)
         # Get BOLD output
-        afni_output_bold = afni_output["BOLD"]
+        afni_output_bold = afni_output["BOLD"]["reho"]
 
         # Check for Pearson correlation coefficient
         r, _ = sp.stats.pearsonr(

--- a/junifer/markers/reho/tests/test_reho_spheres.py
+++ b/junifer/markers/reho/tests/test_reho_spheres.py
@@ -40,6 +40,11 @@ def test_ReHoSpheres(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
             marker = ReHoSpheres(
                 coords=COORDINATES, using="junifer", radius=10.0
             )
+            # Check correct output
+            assert "vector" == marker.get_output_type(
+                input_type="BOLD", output_feature="reho"
+            )
+
             # Fit transform marker on data
             output = marker.fit_transform(element_data)
 
@@ -47,7 +52,7 @@ def test_ReHoSpheres(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
 
             # Get BOLD output
             assert "BOLD" in output
-            output_bold = output["BOLD"]
+            output_bold = output["BOLD"]["reho"]
             # Assert BOLD output keys
             assert "data" in output_bold
             assert "col_names" in output_bold
@@ -99,7 +104,7 @@ def test_ReHoSpheres_comparison(tmp_path: Path) -> None:
         # Fit transform marker on data
         junifer_output = junifer_marker.fit_transform(element_data)
         # Get BOLD output
-        junifer_output_bold = junifer_output["BOLD"]
+        junifer_output_bold = junifer_output["BOLD"]["reho"]
 
         # Initialize marker
         afni_marker = ReHoSpheres(
@@ -110,7 +115,7 @@ def test_ReHoSpheres_comparison(tmp_path: Path) -> None:
         # Fit transform marker on data
         afni_output = afni_marker.fit_transform(element_data)
         # Get BOLD output
-        afni_output_bold = afni_output["BOLD"]
+        afni_output_bold = afni_output["BOLD"]["reho"]
 
         # Check for Pearson correlation coefficient
         r, _ = sp.stats.pearsonr(

--- a/junifer/markers/sphere_aggregation.py
+++ b/junifer/markers/sphere_aggregation.py
@@ -68,6 +68,36 @@ class SphereAggregation(BaseMarker):
 
     _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn", "numpy"}
 
+    _MARKER_INOUT_MAPPINGS: ClassVar[Dict[str, Dict[str, str]]] = {
+        "T1w": {
+            "aggregation": "vector",
+        },
+        "T2w": {
+            "aggregation": "vector",
+        },
+        "BOLD": {
+            "aggregation": "timeseries",
+        },
+        "VBM_GM": {
+            "aggregation": "vector",
+        },
+        "VBM_WM": {
+            "aggregation": "vector",
+        },
+        "VBM_CSF": {
+            "aggregation": "vector",
+        },
+        "fALFF": {
+            "aggregation": "vector",
+        },
+        "GCOR": {
+            "aggregation": "vector",
+        },
+        "LCOR": {
+            "aggregation": "vector",
+        },
+    }
+
     def __init__(
         self,
         coords: str,
@@ -103,61 +133,6 @@ class SphereAggregation(BaseMarker):
         self.time_method = time_method
         self.time_method_params = time_method_params or {}
 
-    def get_valid_inputs(self) -> List[str]:
-        """Get valid data types for input.
-
-        Returns
-        -------
-        list of str
-            The list of data types that can be used as input for this marker.
-
-        """
-        return [
-            "T1w",
-            "T2w",
-            "BOLD",
-            "VBM_GM",
-            "VBM_WM",
-            "VBM_CSF",
-            "fALFF",
-            "GCOR",
-            "LCOR",
-        ]
-
-    def get_output_type(self, input_type: str) -> str:
-        """Get output type.
-
-        Parameters
-        ----------
-        input_type : str
-            The data type input to the marker.
-
-        Returns
-        -------
-        str
-            The storage type output by the marker.
-
-        Raises
-        ------
-        ValueError
-            If the ``input_type`` is invalid.
-
-        """
-
-        if input_type in [
-            "VBM_GM",
-            "VBM_WM",
-            "VBM_CSF",
-            "fALFF",
-            "GCOR",
-            "LCOR",
-        ]:
-            return "vector"
-        elif input_type == "BOLD":
-            return "timeseries"
-        else:
-            raise_error(f"Unknown input kind for {input_type}")
-
     def compute(
         self,
         input: Dict[str, Any],
@@ -183,8 +158,10 @@ class SphereAggregation(BaseMarker):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the actual computed values as a numpy.ndarray
-            * ``col_names`` : the column labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         Warns
         -----
@@ -241,5 +218,9 @@ class SphereAggregation(BaseMarker):
                     "available."
                 )
         # Format the output
-        out = {"data": out_values, "col_names": labels}
-        return out
+        return {
+            "aggregation": {
+                "data": out_values,
+                "col_names": labels,
+            },
+        }

--- a/junifer/markers/temporal_snr/temporal_snr_base.py
+++ b/junifer/markers/temporal_snr/temporal_snr_base.py
@@ -39,6 +39,12 @@ class TemporalSNRBase(BaseMarker):
 
     _DEPENDENCIES: ClassVar[Set[str]] = {"nilearn"}
 
+    _MARKER_INOUT_MAPPINGS: ClassVar[Dict[str, Dict[str, str]]] = {
+        "BOLD": {
+            "tsnr": "vector",
+        },
+    }
+
     def __init__(
         self,
         agg_method: str = "mean",
@@ -61,33 +67,6 @@ class TemporalSNRBase(BaseMarker):
             klass=NotImplementedError,
         )
 
-    def get_valid_inputs(self) -> List[str]:
-        """Get valid data types for input.
-
-        Returns
-        -------
-        list of str
-            The list of data types that can be used as input for this marker.
-
-        """
-        return ["BOLD"]
-
-    def get_output_type(self, input_type: str) -> str:
-        """Get output type.
-
-        Parameters
-        ----------
-        input_type : str
-            The data type input to the marker.
-
-        Returns
-        -------
-        str
-            The storage type output by the marker.
-
-        """
-        return "vector"
-
     def compute(
         self,
         input: Dict[str, Any],
@@ -107,11 +86,14 @@ class TemporalSNRBase(BaseMarker):
         Returns
         -------
         dict
-            The computed result as dictionary. The following keys will be
-            included in the dictionary:
+            The computed result as dictionary. This will be either returned
+            to the user or stored in the storage by calling the store method
+            with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : the computed values as a ``numpy.ndarray``
-            * ``col_names`` : the column labels for the computed values as list
+            * ``tsnr`` : dictionary with the following keys:
+
+              - ``data`` : computed tSNR as ``numpy.ndarray``
+              - ``col_names`` : ROI labels as list of str
 
         """
         # Calculate voxelwise temporal signal-to-noise ratio in an image
@@ -129,4 +111,10 @@ class TemporalSNRBase(BaseMarker):
             mask_img=mask_img,
         )
         # Perform necessary aggregation and return
-        return self.aggregate(input=input, extra_input=extra_input)
+        return {
+            "tsnr": {
+                **self.aggregate(input=input, extra_input=extra_input)[
+                    "aggregation"
+                ]
+            }
+        }

--- a/junifer/markers/temporal_snr/temporal_snr_parcels.py
+++ b/junifer/markers/temporal_snr/temporal_snr_parcels.py
@@ -77,16 +77,16 @@ class TemporalSNRParcels(TemporalSNRBase):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : ROI-wise temporal SNR as a ``numpy.ndarray``
-            * ``col_names`` : the ROI labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI-wise tSNR values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         """
-        parcel_aggregation = ParcelAggregation(
+        return ParcelAggregation(
             parcellation=self.parcellation,
             method=self.agg_method,
             method_params=self.agg_method_params,
             masks=self.masks,
             on="BOLD",
-        )
-        # Return the 2D timeseries after parcel aggregation
-        return parcel_aggregation.compute(input=input, extra_input=extra_input)
+        ).compute(input=input, extra_input=extra_input)

--- a/junifer/markers/temporal_snr/temporal_snr_spheres.py
+++ b/junifer/markers/temporal_snr/temporal_snr_spheres.py
@@ -92,11 +92,13 @@ class TemporalSNRSpheres(TemporalSNRBase):
             to the user or stored in the storage by calling the store method
             with this as a parameter. The dictionary has the following keys:
 
-            * ``data`` : VOI-wise temporal SNR as a ``numpy.ndarray``
-            * ``col_names`` : the VOI labels for the computed values as list
+            * ``aggregation`` : dictionary with the following keys:
+
+                - ``data`` : ROI-wise tSNR values as ``numpy.ndarray``
+                - ``col_names`` : ROI labels as list of str
 
         """
-        sphere_aggregation = SphereAggregation(
+        return SphereAggregation(
             coords=self.coords,
             radius=self.radius,
             allow_overlap=self.allow_overlap,
@@ -104,6 +106,4 @@ class TemporalSNRSpheres(TemporalSNRBase):
             method_params=self.agg_method_params,
             masks=self.masks,
             on="BOLD",
-        )
-        # Return the 2D timeseries after sphere aggregation
-        return sphere_aggregation.compute(input=input, extra_input=extra_input)
+        ).compute(input=input, extra_input=extra_input)

--- a/junifer/markers/temporal_snr/tests/test_temporal_snr_parcels.py
+++ b/junifer/markers/temporal_snr/tests/test_temporal_snr_parcels.py
@@ -20,11 +20,13 @@ def test_TemporalSNRParcels_computation() -> None:
             parcellation="TianxS1x3TxMNInonlinear2009cAsym"
         )
         # Check correct output
-        assert marker.get_output_type("BOLD") == "vector"
+        assert "vector" == marker.get_output_type(
+            input_type="BOLD", output_feature="tsnr"
+        )
 
         # Fit-transform the data
         tsnr_parcels = marker.fit_transform(element_data)
-        tsnr_parcels_bold = tsnr_parcels["BOLD"]
+        tsnr_parcels_bold = tsnr_parcels["BOLD"]["tsnr"]
 
         assert "data" in tsnr_parcels_bold
         assert "col_names" in tsnr_parcels_bold
@@ -51,5 +53,6 @@ def test_TemporalSNRParcels_storage(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_TemporalSNRParcels" for x in features.values()
+            x["name"] == "BOLD_TemporalSNRParcels_tsnr"
+            for x in features.values()
         )

--- a/junifer/markers/temporal_snr/tests/test_temporal_snr_spheres.py
+++ b/junifer/markers/temporal_snr/tests/test_temporal_snr_spheres.py
@@ -20,11 +20,13 @@ def test_TemporalSNRSpheres_computation() -> None:
         element_data = DefaultDataReader().fit_transform(dg["sub001"])
         marker = TemporalSNRSpheres(coords="DMNBuckner", radius=5.0)
         # Check correct output
-        assert marker.get_output_type("BOLD") == "vector"
+        assert "vector" == marker.get_output_type(
+            input_type="BOLD", output_feature="tsnr"
+        )
 
         # Fit-transform the data
         tsnr_spheres = marker.fit_transform(element_data)
-        tsnr_spheres_bold = tsnr_spheres["BOLD"]
+        tsnr_spheres_bold = tsnr_spheres["BOLD"]["tsnr"]
 
         assert "data" in tsnr_spheres_bold
         assert "col_names" in tsnr_spheres_bold
@@ -49,7 +51,8 @@ def test_TemporalSNRSpheres_storage(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_TemporalSNRSpheres" for x in features.values()
+            x["name"] == "BOLD_TemporalSNRSpheres_tsnr"
+            for x in features.values()
         )
 
 

--- a/junifer/markers/tests/test_brainprint.py
+++ b/junifer/markers/tests/test_brainprint.py
@@ -13,16 +13,29 @@ from junifer.markers import BrainPrint
 from junifer.pipeline.utils import _check_freesurfer
 
 
-def test_get_output_type() -> None:
-    """Test BrainPrint get_output_type()."""
-    marker = BrainPrint()
-    assert marker.get_output_type("FreeSurfer") == "vector"
+@pytest.mark.parametrize(
+    "feature, storage_type",
+    [
+        ("eigenvalues", "scalar_table"),
+        ("areas", "vector"),
+        ("volumes", "vector"),
+        ("distances", "vector"),
+    ],
+)
+def test_get_output_type(feature: str, storage_type: str) -> None:
+    """Test BrainPrint get_output_type().
 
+    Parameters
+    ----------
+    feature : str
+        The parametrized feature name.
+    storage_type : str
+        The parametrized storage type.
 
-def test_validate() -> None:
-    """Test BrainPrint validate()."""
-    marker = BrainPrint()
-    assert set(marker.validate(["FreeSurfer"])) == {"scalar_table", "vector"}
+    """
+    assert storage_type == BrainPrint().get_output_type(
+        input_type="FreeSurfer", output_feature=feature
+    )
 
 
 @pytest.mark.skipif(
@@ -39,9 +52,7 @@ def test_compute() -> None:
         element = dg["sub-0001"]
         # Fetch element data
         element_data = DefaultDataReader().fit_transform(element)
-        # Initialize the marker
-        marker = BrainPrint()
-        # Compute the marker
-        feature_map = marker.fit_transform(element_data)
+        # Compute marker
+        feature_map = BrainPrint().fit_transform(element_data)
         # Assert the output keys
         assert {"eigenvalues", "areas", "volumes"} == set(feature_map.keys())

--- a/junifer/markers/tests/test_collection.py
+++ b/junifer/markers/tests/test_collection.py
@@ -84,7 +84,7 @@ def test_marker_collection() -> None:
         for t_marker in markers:
             t_name = t_marker.name
             assert "BOLD" in out[t_name]
-            t_bold = out[t_name]["BOLD"]
+            t_bold = out[t_name]["BOLD"]["aggregation"]
             assert "data" in t_bold
             assert "col_names" in t_bold
             assert "meta" in t_bold
@@ -107,7 +107,8 @@ def test_marker_collection() -> None:
         for t_marker in markers:
             t_name = t_marker.name
             assert_array_equal(
-                out[t_name]["BOLD"]["data"], out2[t_name]["BOLD"]["data"]
+                out[t_name]["BOLD"]["aggregation"]["data"],
+                out2[t_name]["BOLD"]["aggregation"]["data"],
             )
 
 
@@ -201,20 +202,20 @@ def test_marker_collection_storage(tmp_path: Path) -> None:
     feature_md5 = next(iter(features.keys()))
     t_feature = storage.read_df(feature_md5=feature_md5)
     fname = "tian_mean"
-    t_data = out[fname]["BOLD"]["data"]  # type: ignore
-    cols = out[fname]["BOLD"]["col_names"]  # type: ignore
+    t_data = out[fname]["BOLD"]["aggregation"]["data"]  # type: ignore
+    cols = out[fname]["BOLD"]["aggregation"]["col_names"]  # type: ignore
     assert_array_equal(t_feature[cols].values, t_data)  # type: ignore
 
     feature_md5 = list(features.keys())[1]
     t_feature = storage.read_df(feature_md5=feature_md5)
     fname = "tian_std"
-    t_data = out[fname]["BOLD"]["data"]  # type: ignore
-    cols = out[fname]["BOLD"]["col_names"]  # type: ignore
+    t_data = out[fname]["BOLD"]["aggregation"]["data"]  # type: ignore
+    cols = out[fname]["BOLD"]["aggregation"]["col_names"]  # type: ignore
     assert_array_equal(t_feature[cols].values, t_data)  # type: ignore
 
     feature_md5 = list(features.keys())[2]
     t_feature = storage.read_df(feature_md5=feature_md5)
     fname = "tian_trim_mean90"
-    t_data = out[fname]["BOLD"]["data"]  # type: ignore
-    cols = out[fname]["BOLD"]["col_names"]  # type: ignore
+    t_data = out[fname]["BOLD"]["aggregation"]["data"]  # type: ignore
+    cols = out[fname]["BOLD"]["aggregation"]["col_names"]  # type: ignore
     assert_array_equal(t_feature[cols].values, t_data)  # type: ignore

--- a/junifer/markers/tests/test_markers_base.py
+++ b/junifer/markers/tests/test_markers_base.py
@@ -20,27 +20,27 @@ def test_base_marker_subclassing() -> None:
 
     # Create concrete class
     class MyBaseMarker(BaseMarker):
+
+        _MARKER_INOUT_MAPPINGS = {  # noqa: RUF012
+            "BOLD": {
+                "feat_1": "timeseries",
+            },
+        }
+
         def __init__(self, on, name=None) -> None:
             self.parameter = 1
             super().__init__(on, name)
 
-        def get_valid_inputs(self):
-            return ["BOLD", "T1w"]
-
-        def get_output_type(self, input):
-            if input == "BOLD":
-                return "timeseries"
-            raise ValueError(f"Cannot compute output type for {input}")
-
         def compute(self, input, extra_input):
             return {
-                "data": "data",
-                "columns": "columns",
-                "row_names": "row_names",
+                "feat_1": {
+                    "data": "data",
+                    "col_names": ["columns"],
+                },
             }
 
-    with pytest.raises(ValueError, match=r"cannot be computed on \['T2w'\]"):
-        MyBaseMarker(on=["BOLD", "T2w"])
+    with pytest.raises(ValueError, match=r"cannot be computed on \['T1w'\]"):
+        MyBaseMarker(on=["BOLD", "T1w"])
 
     # Create input for marker
     input_ = {
@@ -64,12 +64,11 @@ def test_base_marker_subclassing() -> None:
     output = marker.fit_transform(input=input_)  # process
     # Check output
     assert "BOLD" in output
-    assert "data" in output["BOLD"]
-    assert "columns" in output["BOLD"]
-    assert "row_names" in output["BOLD"]
+    assert "data" in output["BOLD"]["feat_1"]
+    assert "col_names" in output["BOLD"]["feat_1"]
 
-    assert "meta" in output["BOLD"]
-    meta = output["BOLD"]["meta"]
+    assert "meta" in output["BOLD"]["feat_1"]
+    meta = output["BOLD"]["feat_1"]["meta"]
     assert "datagrabber" in meta
     assert "element" in meta
     assert "datareader" in meta

--- a/junifer/markers/tests/test_sphere_aggregation.py
+++ b/junifer/markers/tests/test_sphere_aggregation.py
@@ -25,14 +25,65 @@ COORDS = "DMNBuckner"
 RADIUS = 8
 
 
-def test_SphereAggregation_input_output() -> None:
-    """Test SphereAggregation input and output types."""
-    marker = SphereAggregation(coords="DMNBuckner", method="mean", on="VBM_GM")
-    for in_, out_ in [("VBM_GM", "vector"), ("BOLD", "timeseries")]:
-        assert marker.get_output_type(in_) == out_
+@pytest.mark.parametrize(
+    "input_type, storage_type",
+    [
+        (
+            "T1w",
+            "vector",
+        ),
+        (
+            "T2w",
+            "vector",
+        ),
+        (
+            "BOLD",
+            "timeseries",
+        ),
+        (
+            "VBM_GM",
+            "vector",
+        ),
+        (
+            "VBM_WM",
+            "vector",
+        ),
+        (
+            "VBM_CSF",
+            "vector",
+        ),
+        (
+            "fALFF",
+            "vector",
+        ),
+        (
+            "GCOR",
+            "vector",
+        ),
+        (
+            "LCOR",
+            "vector",
+        ),
+    ],
+)
+def test_SphereAggregation_input_output(
+    input_type: str, storage_type: str
+) -> None:
+    """Test SphereAggregation input and output types.
 
-    with pytest.raises(ValueError, match="Unknown input"):
-        marker.get_output_type("unknown")
+    Parameters
+    ----------
+    input_type : str
+        The parametrized input type.
+    storage_type : str
+        The parametrized storage type.
+
+    """
+    assert storage_type == SphereAggregation(
+        coords="DMNBuckner",
+        method="mean",
+        on=input_type,
+    ).get_output_type(input_type=input_type, output_feature="aggregation")
 
 
 def test_SphereAggregation_3D() -> None:
@@ -44,8 +95,8 @@ def test_SphereAggregation_3D() -> None:
             coords=COORDS, method="mean", radius=RADIUS, on="VBM_GM"
         )
         sphere_agg_vbm_gm_data = marker.fit_transform(element_data)["VBM_GM"][
-            "data"
-        ]
+            "aggregation"
+        ]["data"]
 
         # Compare with nilearn
         # Load testing coordinates
@@ -76,8 +127,8 @@ def test_SphereAggregation_4D() -> None:
             coords=COORDS, method="mean", radius=RADIUS, on="BOLD"
         )
         sphere_agg_bold_data = marker.fit_transform(element_data)["BOLD"][
-            "data"
-        ]
+            "aggregation"
+        ]["data"]
 
         # Compare with nilearn
         # Load testing coordinates
@@ -120,7 +171,8 @@ def test_SphereAggregation_storage(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "VBM_GM_SphereAggregation" for x in features.values()
+            x["name"] == "VBM_GM_SphereAggregation_aggregation"
+            for x in features.values()
         )
 
     # Store 4D
@@ -135,7 +187,8 @@ def test_SphereAggregation_storage(tmp_path: Path) -> None:
         marker.fit_transform(input=element_data, storage=storage)
         features = storage.list_features()
         assert any(
-            x["name"] == "BOLD_SphereAggregation" for x in features.values()
+            x["name"] == "BOLD_SphereAggregation_aggregation"
+            for x in features.values()
         )
 
 
@@ -152,8 +205,8 @@ def test_SphereAggregation_3D_mask() -> None:
             masks="compute_brain_mask",
         )
         sphere_agg_vbm_gm_data = marker.fit_transform(element_data)["VBM_GM"][
-            "data"
-        ]
+            "aggregation"
+        ]["data"]
 
         # Compare with nilearn
         # Load testing coordinates
@@ -195,8 +248,8 @@ def test_SphereAggregation_4D_agg_time() -> None:
             on="BOLD",
         )
         sphere_agg_bold_data = marker.fit_transform(element_data)["BOLD"][
-            "data"
-        ]
+            "aggregation"
+        ]["data"]
 
         # Compare with nilearn
         # Load testing coordinates
@@ -231,8 +284,8 @@ def test_SphereAggregation_4D_agg_time() -> None:
             on="BOLD",
         )
         sphere_agg_bold_data = marker.fit_transform(element_data)["BOLD"][
-            "data"
-        ]
+            "aggregation"
+        ]["data"]
 
         assert sphere_agg_bold_data.ndim == 2
         assert_array_equal(

--- a/junifer/pipeline/pipeline_step_mixin.py
+++ b/junifer/pipeline/pipeline_step_mixin.py
@@ -210,7 +210,17 @@ class PipelineStepMixin:
         # Validate input
         fit_input = self.validate_input(input=input)
         # Validate output type
-        outputs = [self.get_output_type(t_input) for t_input in fit_input]
+        # Nested output type for marker
+        if hasattr(self, "_MARKER_INOUT_MAPPINGS"):
+            outputs = list(
+                {
+                    val
+                    for t_input in fit_input
+                    for val in self._MARKER_INOUT_MAPPINGS[t_input].values()
+                }
+            )
+        else:
+            outputs = [self.get_output_type(t_input) for t_input in fit_input]
         return outputs
 
     def fit_transform(

--- a/junifer/pipeline/tests/test_registry.py
+++ b/junifer/pipeline/tests/test_registry.py
@@ -101,7 +101,7 @@ def test_get_class():
     register(step="datagrabber", name="bar", klass=str)
     # Get class
     obj = get_class(step="datagrabber", name="bar")
-    assert obj == str
+    assert isinstance(obj, str)
 
 
 # TODO: possible parametrization?

--- a/junifer/pipeline/tests/test_registry.py
+++ b/junifer/pipeline/tests/test_registry.py
@@ -101,7 +101,7 @@ def test_get_class():
     register(step="datagrabber", name="bar", klass=str)
     # Get class
     obj = get_class(step="datagrabber", name="bar")
-    assert isinstance(obj, str)
+    assert isinstance(obj, type(str))
 
 
 # TODO: possible parametrization?


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR refactors the internals of `BaseMarker` to allow for multiple features to be extracted from one marker. It also simplifies creating new markers by replacing multiple methods with a class attribute. For now, `ALFF`-family and `BrainPrint` are specifically getting benefited from this.