### PR TITLE
[FIX]: Correct command for `mri_binarize` in `BrainPrint`

### DIFF
--- a/docs/changes/newsfragments/356.bugfix
+++ b/docs/changes/newsfragments/356.bugfix
@@ -1,0 +1,1 @@
+Fix ``mri_binarize`` command preparation for structures with multiple indices in :class:`.BrainPrint` by `Fede Raimondo`_

--- a/junifer/markers/brainprint.py
+++ b/junifer/markers/brainprint.py
@@ -143,7 +143,7 @@ class BrainPrint(BaseMarker):
         mri_binarize_cmd = [
             "mri_binarize",
             f"--i {aseg_path.resolve()}",
-            f"--match {''.join(indices)}",
+            f"--match {' '.join(indices)}",
             f"--o {mri_binarize_output_path.resolve()}",
         ]
         # Call mri_binarize command


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR fixes a bug in the `mri_binarize` command preparation for structures with multiple indices in `BrainPrint`.