### PR TITLE
[ENH]: Set proper stdout encoding for `run_ext_cmd`

### DIFF
--- a/docs/changes/newsfragments/357.enh
+++ b/docs/changes/newsfragments/357.enh
@@ -1,0 +1,1 @@
+Set proper stdout encoding for :func:`.run_ext_cmd` to ease human readability by `Fede Raimondo`_

--- a/junifer/utils/helpers.py
+++ b/junifer/utils/helpers.py
@@ -5,6 +5,7 @@
 
 import collections.abc
 import subprocess
+import sys
 from typing import Dict, List
 
 from .logging import logger, raise_error
@@ -45,13 +46,13 @@ def run_ext_cmd(name: str, cmd: List[str]) -> None:
     if process.returncode == 0:
         logger.info(
             f"{name} command succeeded with the following output:\n"
-            f"{process.stdout}"
+            f"{process.stdout.decode(sys.stdout.encoding)}"
         )
     else:
         raise_error(
             msg=(
                 f"{name} command failed with the following error:\n"
-                f"{process.stdout}"
+                f"{process.stdout.decode(sys.stdout.encoding)}"
             ),
             klass=RuntimeError,
         )


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR sets proper stdout encoding for `run_ext_cmd` so that the output is easily human readable.