### PR TITLE
[ENH]: In-built support for spearman correlation for FunctionalConnectivity markers

### DIFF
--- a/junifer/external/nilearn/junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/junifer_connectivity_measure.py
@@ -314,6 +314,7 @@ class JuniferConnectivityMeasure(ConnectivityMeasure):
     * default ``cov_estimator`` is
       :class:`sklearn.covariance.EmpiricalCovariance`
     * default ``kind`` is ``"correlation"``
+    * supports Spearman's correlation via ``kind="spearman correlation"``
 
     Parameters
     ----------
@@ -322,10 +323,10 @@ class JuniferConnectivityMeasure(ConnectivityMeasure):
         (default ``EmpiricalCovariance(store_precision=False)``).
     kind : {"covariance", "correlation", "spearman correlation", \
             "partial correlation", "tangent", "precision"}, optional
-        The matrix kind. For the use of ``"tangent"`` see [1]_
-        (default "correlation", which will use Pearson's correlation).
-        If "spearman correlation" is used, the data will be ranked before
-        estimating the covariance.
+        The matrix kind. The default value uses Pearson's correlation.
+        If ``"spearman correlation"`` is used, the data will be ranked before
+        estimating the covariance. For the use of ``"tangent"`` see [1]_
+        (default "correlation").
     vectorize : bool, optional
         If True, connectivity matrices are reshaped into 1D arrays and only
         their flattened lower triangular parts are returned (default False).

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -71,6 +71,7 @@ CONNECTIVITY_KINDS = (
     "tangent",
     "precision",
     "partial correlation",
+    "spearman correlation",
 )
 
 N_FEATURES = 49


### PR DESCRIPTION
### Which marker do you want to include?

Currently it does not work out of the box, but some people like it and its a small enough thing to expect it out of the box and not really worth it have users implement their own markers for this.

### Is there any publication or available code?

just rank time series and get pearson correlation

### Do you have a sample code that implements this outside of junifer?

```shell
I can take a shot at implementing this if everyone agrees we should have it.
```


### Anything else to say?

_No response_