### PR TITLE
[FIX]: Enable `spike` for `fMRIPrepConfoundRemover`

### DIFF
--- a/docs/changes/newsfragments/360.bugfix
+++ b/docs/changes/newsfragments/360.bugfix
@@ -1,0 +1,1 @@
+Enable ``spike`` mapping from ``adhoc`` to ``fmriprep`` for :class:`.fMRIPrepConfoundRemover` by `Leonard Sasse`_ and `Synchon Mandal`_

--- a/junifer/preprocess/confounds/fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/fmriprep_confound_remover.py
@@ -93,6 +93,9 @@ FMRIPREP_VALID_NAMES = [
     for t_list in x.values()
     for elem in t_list
 ]
+# NOTE: Check with @fraimondo about the spike mapping intent
+# Add spike_name to FMRIPREP_VALID_NAMES
+FMRIPREP_VALID_NAMES.append("framewise_displacement")
 
 
 @register_preprocessor
@@ -353,9 +356,6 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
                     "Check if this file is really an fmriprep confounds file. "
                     "You can also deactivate spike (set spike = None)."
                 )
-            # NOTE: Check with @fraimondo about the spike mapping intent
-            # Add spike_name to FMRIPREP_VALID_NAMES
-            FMRIPREP_VALID_NAMES.append(spike_name)
         out = to_select, squares_to_compute, derivatives_to_compute, spike_name
         return out
 

--- a/junifer/preprocess/confounds/fmriprep_confound_remover.py
+++ b/junifer/preprocess/confounds/fmriprep_confound_remover.py
@@ -353,6 +353,9 @@ class fMRIPrepConfoundRemover(BasePreprocessor):
                     "Check if this file is really an fmriprep confounds file. "
                     "You can also deactivate spike (set spike = None)."
                 )
+            # NOTE: Check with @fraimondo about the spike mapping intent
+            # Add spike_name to FMRIPREP_VALID_NAMES
+            FMRIPREP_VALID_NAMES.append(spike_name)
         out = to_select, squares_to_compute, derivatives_to_compute, spike_name
         return out
 


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR fixes the `spike` mapping from `adhoc` to `fmriprep`'s `"framewise_displacement"` by including it in the validation.