### PR TITLE
[ENH]: Allow for external modules to import other files

### DIFF
--- a/docs/changes/newsfragments/367.enh
+++ b/docs/changes/newsfragments/367.enh
@@ -1,0 +1,1 @@
+Allow for external python files in the ``with`` section of the yaml to import other files by `Fede Raimondo`_

--- a/docs/extending/extension.rst
+++ b/docs/extending/extension.rst
@@ -37,6 +37,7 @@ This is the ideal place to include ``junifer`` extensions.
    ``junifer`` about the dependencies of the module:
 
    .. code-block:: python
+
       def junifer_module_deps() -> List[str]:
         """Return the dependencies of the module.
 

--- a/docs/extending/extension.rst
+++ b/docs/extending/extension.rst
@@ -28,8 +28,24 @@ This is the ideal place to include ``junifer`` extensions.
 
 .. important::
 
-   Some ``junifer`` commands will not consider files imported from files included
-   in the ``with`` statement. If ``my_file.py`` imports ``my_other_file.py``,
-   some of the ``junifer`` commands will not consider ``my_other_file.py``. Either
-   place all the code in one file or add multiple files to the ``with``
-   statement.
+   Some ``junifer`` commands will not consider files imported from files
+   included in the ``with`` statement, unless this is known to junifer. If
+   ``my_file.py`` imports ``my_other_file.py``, the ``run`` command will work,
+   but ``queue`` will not create a proper job. This is because we need to 
+   let junifer know that ``my_other_file.py`` is also part of the code. To do
+   so, we need to include a special function in ``my_file.py`` which tells
+   ``junifer`` about the dependencies of the module:
+
+   .. code-block:: python
+      def junifer_module_deps() -> List[str]:
+        """Return the dependencies of the module.
+
+        Returns
+        -------
+        List[str]
+            The list of dependencies.
+
+        """
+
+        return ["my_other_file.py"]
+

--- a/docs/extending/extension.rst
+++ b/docs/extending/extension.rst
@@ -42,7 +42,7 @@ This is the ideal place to include ``junifer`` extensions.
 
         Returns
         -------
-        List[str]
+        list of str
             The list of dependencies.
 
         """

--- a/junifer/cli/parser.py
+++ b/junifer/cli/parser.py
@@ -18,7 +18,7 @@ from ..utils import logger, raise_error, warn_with_log, yaml
 __all__ = ["parse_yaml", "parse_elements"]
 
 
-def parse_yaml(filepath: Union[str, Path]) -> Dict:
+def parse_yaml(filepath: Union[str, Path]) -> Dict:  # noqa: C901
     """Parse YAML.
 
     Parameters


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

I am currently working on an extension in juni-farm which requires another .py file to be imported. When I add it to the `with` section of the yaml, even though both files are in there, it fails with a `ModuleNotFoundError`.

We originally though of having extensions be a single file, but now things have grown and it's not suitable anymore.

For example, in `my_extension_b.py`, we can have something like 

```python
from my_extension_a import CoolDataGrabber

@registerdatagrabber
class SuperCoolDataGrabber(CoolDataGrabber):
...
```

The solution is quite simple, for this to work, we need to add the path of each module to `sys.path`, so all imports work properly.

This creates an issue with the YAML file in the case of the `queue` command being inconsistent with the `run` one. 

On the `run` scenario, the module is ran from it's original location, where both files are present. In the `queue` scenario, only the elements in the `with` statement are copied to the `junifer_jobs` respective directory. 

### How do you imagine this integrated in junifer?

In order to work, it needs to modifications in junifer:

1) Before importing any module in the with statement, add it's parent directory to `sys.path`
2) After loading the module, check if the module has a `junifer_module_deps` function. If so, call it and add all of this files to the `with` section of the parsed yaml. This will create the full yaml required for the `queue` command to work.

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_