### PR TITLE
[BUG]: Typo for `fMRIPrepConfoundRemover` pipeline registration

### DIFF
--- a/docs/changes/newsfragments/369.bugfix
+++ b/docs/changes/newsfragments/369.bugfix
@@ -1,0 +1,1 @@
+Correct listing for :class:`.fMRIPrepConfoundRemover` in ``junifer.pipeline.registry`` by `Synchon Mandal`_

--- a/junifer/pipeline/registry.py
+++ b/junifer/pipeline/registry.py
@@ -60,7 +60,7 @@ _REGISTRY: Dict[str, Dict[str, Union[str, type]]] = {
         "BasePreprocessor": "BasePreprocessor",
         "Smoothing": "Smoothing",
         "SpaceWarper": "SpaceWarper",
-        "fMRIPrepConfoundRemove": "fMRIPrepConfoundRemove",
+        "fMRIPrepConfoundRemover": "fMRIPrepConfoundRemover",
     },
     "marker": {
         "ALFFParcels": "ALFFParcels",


### PR DESCRIPTION
* [x] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry for the latest changes

This PR fixes a typo which didn't allow `fMRIPrepConfoundRemover` to be registered in `junifer.pipeline.registry`.