### PR TITLE
[MAINT]: Drop Python 3.8 and support Python 3.13

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - run: 'echo "No build required"'
       - name: Create mock coverage.xml file
@@ -40,7 +40,7 @@ jobs:
           echo '</package>' >> coverage.xml
           echo '</packages>' >> coverage.xml
           echo '</coverage>' >> coverage.xml
-        if: matrix.python-version == 3.11
+        if: matrix.python-version == 3.12
       - name: Upload mock coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -48,4 +48,4 @@ jobs:
           # Allow coverage upload failure
           fail_ci_if_error: false
           flags: docs
-        if: success() && matrix.python-version == 3.11
+        if: success() && matrix.python-version == 3.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - name: Set up system
@@ -65,13 +65,13 @@ jobs:
         curl -O https://afni.nimh.nih.gov/pub/dist/bin/misc/@update.afni.binaries
         sudo tcsh @update.afni.binaries -package linux_ubuntu_16_64 -bindir /afni
         echo "/afni" >> $GITHUB_PATH
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == 3.12
       # Bypass AFNI installation failure
       continue-on-error: true
     - name: Check AFNI
       run: |
         echo "Using AFNI : $(afni --version)"
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == 3.12
       # Bypass AFNI installation failure
       continue-on-error: true
     - name: Install ANTs
@@ -82,13 +82,13 @@ jobs:
         mv /opt/ants-2.5.2/bin/* /opt/ants-2.5.2
         rm ants.zip
         echo "/opt/ants-2.5.2" >> $GITHUB_PATH
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == 3.12
       # Bypass ANTs installation failure
       continue-on-error: true
     - name: Check ANTs
       run: |
         echo "Using ANTs : $(antsRegistration --version)"
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == 3.12
       # Bypass ANTs installation failure
       continue-on-error: true
     - name: Install FSL
@@ -98,13 +98,13 @@ jobs:
         echo "FSLOUTPUTTYPE=NIFTI_GZ" >> $GITHUB_ENV
         echo "FSLMULTIFILEQUIT=TRUE" >> $GITHUB_ENV
         echo "/opt/fsl/bin" >> $GITHUB_PATH
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == 3.12
       # Bypass FSL installation failure
       continue-on-error: true
     - name: Check FSL
       run: |
         echo "Using FSL : $(flirt -version)"
-      if: matrix.python-version == 3.11
+      if: matrix.python-version == 3.12
       # Bypass FSL installation failure
       continue-on-error: true
     - name: Test with tox
@@ -116,4 +116,4 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         flags: junifer
-      if: success() && matrix.python-version == 3.11
+      if: success() && matrix.python-version == 3.12

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - name: Set up Python 3.11
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: "3.x"
     - name: Check for sudo
       shell: bash
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,10 @@ jobs:
         # require all of history to see all tagged versions' docs
         fetch-depth: 0
         submodules: true
-    - name: Set up Python 3.11
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: "3.x"
     - name: Check for sudo
       shell: bash
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,10 +15,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - name: Set up Python 3.11
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: "3.x"
     - name: Install build
       run:
         pip install build

--- a/docs/changes/newsfragments/372.misc
+++ b/docs/changes/newsfragments/372.misc
@@ -1,0 +1,1 @@
+Drop support for Python 3.8, add support for Python 3.13 and make Python 3.12 the base for code coverage by `Synchon Mandal`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ docs = [
     "numpydoc>=1.6.0,<1.9.0",
     "julearn==0.3.3",
     "sphinx-copybutton>=0.5.1,<0.5.3",
-    "towncrier>=23.10.0,<=24.8.0",
+    "towncrier>=23.10.0,<24.7.0",
     "sphinxcontrib-mermaid>=0.8.1,<0.10",
     "sphinxcontrib-towncrier==0.4.0a0",
     "setuptools-scm>=8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,25 +29,25 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "click>=8.1.3,<8.2",
-    "numpy>=1.24.0,<2.0.0",
-    "scipy>=1.10.0,<=1.14.0",
+    "numpy>=1.26.0,<2.0.0",
+    "scipy>=1.10.0,<=1.15.0",
     "datalad>=1.0.0,<1.2.0",
     "pandas>=2.0.0,<2.3.0",
-    "nibabel>=5.2.0,<5.3.0",
+    "nibabel>=5.2.0,<5.4.0",
     "nilearn>=0.10.3,<=0.10.4",
     "sqlalchemy>=2.0.25,<=2.1.0",
-    "ruamel.yaml>=0.17,<0.18",
+    "ruamel.yaml>=0.17,<0.19",
     "h5py>=3.10",
-    "httpx[http2]==0.26.0",
-    "tqdm==4.66.1",
+    "httpx[http2]>=0.26.0,<0.28.0",
+    "tqdm>=4.66.1,<4.67.0",
     "templateflow>=23.0.0",
     "lapy>=1.0.0,<2.0.0",
     "lazy_loader==0.4",
@@ -78,13 +78,13 @@ neurokit2 = ["neurokit2>=0.1.7"]
 dev = ["tox", "pre-commit"]
 docs = [
     "seaborn>=0.13.0,<0.14.0",
-    "sphinx>=7.3.0,<7.4.0",
-    "sphinx-gallery>=0.15.0,<0.17.0",
-    "furo>=2024.4.27,<2024.6.0",
-    "numpydoc>=1.6.0,<1.8.0",
+    "sphinx>=7.3.0,<8.1.0",
+    "sphinx-gallery>=0.17.0,<0.18.0",
+    "furo>=2024.4.27,<2024.9.0",
+    "numpydoc>=1.6.0,<1.9.0",
     "julearn==0.3.3",
     "sphinx-copybutton>=0.5.1,<0.5.3",
-    "towncrier>=23.10.0,<23.12.0",
+    "towncrier>=23.10.0,<=24.8.0",
     "sphinxcontrib-mermaid>=0.8.1,<0.10",
     "sphinxcontrib-towncrier==0.4.0a0",
     "setuptools-scm>=8",
@@ -109,7 +109,7 @@ write_to = "junifer/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 extend-exclude = """
 (
   junifer/external/h5io

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = ruff, black, test, coverage, codespell, py3{8,9,10,11,12}
+envlist = ruff, black, test, coverage, codespell, py3{9,10,11,12,13}
 isolated_build = true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
-    3.11: coverage
-    3.12: py312
+    3.11: py311
+    3.12: coverage
+    3.13: py313
 
 [testenv]
 skip_install = false


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR drops support for Python 3.8 and adds support for Python 3.12. It also moves the coverage reporting to Python 3.12 and updates dependencies as required.