### PR TITLE
Bypass cleanup of temporary dirs if needed

### DIFF
--- a/docs/changes/newsfragments/389.enh
+++ b/docs/changes/newsfragments/389.enh
@@ -1,1 +1,1 @@
-Add a ``cleanup`` parameter to the :class:`.WorkDirManager`, which allows to disable cleaning up temporary directories by `Fede Raimondo`_
+Add a ``cleanup`` parameter to the :class:`junifer.pipeline.WorkDirManager`, which allows to disable cleaning up temporary directories by `Fede Raimondo`_

--- a/docs/changes/newsfragments/389.enh
+++ b/docs/changes/newsfragments/389.enh
@@ -1,0 +1,1 @@
+Add a ``cleanup`` parameter to the :class:`.WorkDirManager`, which allows to disable cleaning up temporary directories by `Fede Raimondo`_

--- a/junifer/pipeline/tests/test_workdir_manager.py
+++ b/junifer/pipeline/tests/test_workdir_manager.py
@@ -102,3 +102,45 @@ def test_workdir_manager_get_and_delete_tempdir(tmp_path: Path) -> None:
     workdir_mgr._cleanup()
     # Should remove temporary directory
     assert workdir_mgr.root_tempdir is None
+
+def test_workdir_manager_no_cleanup(tmp_path: Path) -> None:
+    """Test WorkDirManager correctly bypasses cleanup.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        The path to the test directory.
+
+    """
+    workdir_mgr = WorkDirManager(cleanup=False)
+    workdir_mgr.workdir = tmp_path
+    # Check no root temporary directory
+    assert workdir_mgr.root_tempdir is None
+
+    tempdir = workdir_mgr.get_tempdir()
+    assert tempdir.exists()
+    # Should create a temporary directory
+    assert workdir_mgr.root_tempdir is not None
+
+    workdir_mgr.delete_tempdir(tempdir)
+    workdir_mgr._cleanup()
+
+    # Should remove temporary directory
+    assert workdir_mgr.root_tempdir is None
+    # But the temporary directory should still exist
+    assert tempdir.exists()
+
+    # Now the same but for the element directory
+
+    # Check no element directory
+    assert workdir_mgr.elementdir is None
+
+    tempdir = workdir_mgr.get_element_tempdir()
+    # Should create a temporary directory
+    assert workdir_mgr.elementdir is not None
+
+    workdir_mgr.cleanup_elementdir()
+    # Should remove temporary directory
+    assert workdir_mgr.elementdir is None
+    # But the temporary directory should still exist
+    assert tempdir.exists()

--- a/junifer/pipeline/workdir_manager.py
+++ b/junifer/pipeline/workdir_manager.py
@@ -39,9 +39,9 @@ class WorkDirManager(metaclass=Singleton):
         The path to the element directory.
     root_tempdir : pathlib.Path or None
         The path to the root temporary directory.
-    cleanup : bool
-        If false, the directories are not cleaned up after the object is
-        destroyed. This is useful for debugging purposes. Default is True.
+    cleanup : bool, optional
+        If False, the directories are not cleaned up after the object is
+        destroyed. This is useful for debugging purposes (default True).
 
     """
 

--- a/junifer/pipeline/workdir_manager.py
+++ b/junifer/pipeline/workdir_manager.py
@@ -39,15 +39,20 @@ class WorkDirManager(metaclass=Singleton):
         The path to the element directory.
     root_tempdir : pathlib.Path or None
         The path to the root temporary directory.
+    cleanup : bool
+        If false, the directories are not cleaned up after the object is
+        destroyed. This is useful for debugging purposes. Default is True.
 
     """
 
-    def __init__(self, workdir: Optional[Union[str, Path]] = None) -> None:
+    def __init__(
+        self, workdir: Optional[Union[str, Path]] = None, cleanup=True
+    ) -> None:
         """Initialize the class."""
         self._workdir = Path(workdir) if isinstance(workdir, str) else workdir
         self._elementdir = None
         self._root_tempdir = None
-
+        self._cleanup_dirs = cleanup
         self._set_default_workdir()
 
     def _set_default_workdir(self) -> None:
@@ -72,6 +77,8 @@ class WorkDirManager(metaclass=Singleton):
 
     def _cleanup(self) -> None:
         """Clean up the element and temporary directories."""
+        if self._cleanup_dirs is False:
+            return
         # Remove element directory
         self.cleanup_elementdir()
         # Remove root temporary directory
@@ -171,6 +178,8 @@ class WorkDirManager(metaclass=Singleton):
             The temporary directory path to be deleted.
 
         """
+        if self._cleanup_dirs is False:
+            return
         logger.debug(f"Deleting element temporary directory at {tempdir}")
         shutil.rmtree(tempdir, ignore_errors=True)
 
@@ -182,6 +191,8 @@ class WorkDirManager(metaclass=Singleton):
         can lead to required intermediate files not being found.
 
         """
+        if self._cleanup_dirs is False:
+            return
         if self._elementdir is not None:
             logger.debug(
                 "Deleting element directory at "
@@ -244,5 +255,7 @@ class WorkDirManager(metaclass=Singleton):
             The temporary directory path to be deleted.
 
         """
+        if self._cleanup_dirs is False:
+            return
         logger.debug(f"Deleting temporary directory at {tempdir}")
         shutil.rmtree(tempdir, ignore_errors=True)

--- a/junifer/pipeline/workdir_manager.py
+++ b/junifer/pipeline/workdir_manager.py
@@ -78,6 +78,7 @@ class WorkDirManager(metaclass=Singleton):
     def _cleanup(self) -> None:
         """Clean up the element and temporary directories."""
         if self._cleanup_dirs is False:
+            self._root_tempdir = None
             return
         # Remove element directory
         self.cleanup_elementdir()
@@ -192,6 +193,7 @@ class WorkDirManager(metaclass=Singleton):
 
         """
         if self._cleanup_dirs is False:
+            self._elementdir = None
             return
         if self._elementdir is not None:
             logger.debug(


### PR DESCRIPTION
* [x] implement the posibility of not cleaning up temporary dirs, to allow for fine-grained debugging
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR adds a `cleanup` parameter to the `WorkDirManager`, which allows to disable cleaning up temporary directories. While this does not add any important feature to the user, it allows to keep temporary files in case developers want to trace potential issues, mosly when using external tools.