### PR TITLE
[ENH]: Refactor `Singleton` as a metaclass

### DIFF
--- a/docs/changes/newsfragments/391.misc
+++ b/docs/changes/newsfragments/391.misc
@@ -1,0 +1,1 @@
+Refactor ``Singleton`` class to use a metaclass instead of a class decorator by `Fede Raimondo`_

--- a/junifer/conftest.py
+++ b/junifer/conftest.py
@@ -2,6 +2,7 @@
 
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 # License: AGPL
+
 import pytest
 
 from junifer.utils.singleton import Singleton

--- a/junifer/conftest.py
+++ b/junifer/conftest.py
@@ -12,8 +12,14 @@ from junifer.utils.singleton import Singleton
 def reset_singletons() -> None:
     """Reset all singletons."""
     to_clean = ["WorkDirManager"]
+    to_remove = [
+        v for k, v in Singleton.instances.items() if k.__name__ in to_clean
+    ]
     Singleton.instances = {
         k: v
         for k, v in Singleton.instances.items()
         if k.__name__ not in to_clean
     }
+    # Force deleting the singletons
+    for elem in to_remove:
+        del elem

--- a/junifer/conftest.py
+++ b/junifer/conftest.py
@@ -1,0 +1,18 @@
+"""Provide conftest for pytest."""
+
+# Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
+# License: AGPL
+import pytest
+
+from junifer.utils.singleton import Singleton
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons() -> None:
+    """Reset all singletons."""
+    to_clean = ["WorkDirManager"]
+    Singleton.instances = {
+        k: v
+        for k, v in Singleton.instances.items()
+        if k.__name__ not in to_clean
+    }

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -11,8 +11,8 @@ import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike
 
-from ...pipeline.singleton import singleton
 from ...utils import logger, raise_error
+from ...utils.singleton import Singleton
 from ..pipeline_data_registry_base import BasePipelineDataRegistry
 from ._ants_coordinates_warper import ANTsCoordinatesWarper
 from ._fsl_coordinates_warper import FSLCoordinatesWarper
@@ -21,8 +21,7 @@ from ._fsl_coordinates_warper import FSLCoordinatesWarper
 __all__ = ["CoordinatesRegistry"]
 
 
-@singleton
-class CoordinatesRegistry(BasePipelineDataRegistry):
+class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
     """Class for coordinates data registry.
 
     This class is a singleton and is used for managing available coordinates

--- a/junifer/data/masks/_masks.py
+++ b/junifer/data/masks/_masks.py
@@ -25,8 +25,8 @@ from nilearn.masking import (
     intersect_masks,
 )
 
-from ...pipeline.singleton import singleton
 from ...utils import logger, raise_error
+from ...utils.singleton import Singleton
 from ..pipeline_data_registry_base import BasePipelineDataRegistry
 from ..template_spaces import get_template
 from ..utils import closest_resolution
@@ -126,8 +126,7 @@ def compute_brain_mask(
     return new_img_like(target_img, mask)  # type: ignore
 
 
-@singleton
-class MaskRegistry(BasePipelineDataRegistry):
+class MaskRegistry(BasePipelineDataRegistry, metaclass=Singleton):
     """Class for mask data registry.
 
     This class is a singleton and is used for managing available mask

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -20,8 +20,8 @@ import numpy as np
 import pandas as pd
 from nilearn import datasets, image
 
-from ...pipeline.singleton import singleton
 from ...utils import logger, raise_error, warn_with_log
+from ...utils.singleton import Singleton
 from ..pipeline_data_registry_base import BasePipelineDataRegistry
 from ..utils import closest_resolution
 from ._ants_parcellation_warper import ANTsParcellationWarper
@@ -38,8 +38,7 @@ __all__ = [
 ]
 
 
-@singleton
-class ParcellationRegistry(BasePipelineDataRegistry):
+class ParcellationRegistry(BasePipelineDataRegistry, metaclass=Singleton):
     """Class for parcellation data registry.
 
     This class is a singleton and is used for managing available parcellation

--- a/junifer/data/pipeline_data_registry_base.py
+++ b/junifer/data/pipeline_data_registry_base.py
@@ -7,12 +7,13 @@ from abc import ABC, abstractmethod
 from typing import Any, List, Mapping
 
 from ..utils import raise_error
+from ..utils.singleton import ABCSingleton
 
 
 __all__ = ["BasePipelineDataRegistry"]
 
 
-class BasePipelineDataRegistry(ABC):
+class BasePipelineDataRegistry(ABC, metaclass=ABCSingleton):
     """Abstract base class for pipeline data registry.
 
     For every interface that is required, one needs to provide a concrete

--- a/junifer/datagrabber/hcp1200/tests/test_hcp1200.py
+++ b/junifer/datagrabber/hcp1200/tests/test_hcp1200.py
@@ -3,6 +3,9 @@
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+import shutil
+import tempfile
+from pathlib import Path
 from typing import Iterable, Optional
 
 import pytest
@@ -17,7 +20,8 @@ URI = "https://gin.g-node.org/juaml/datalad-example-hcp1200"
 @pytest.fixture(scope="module")
 def hcpdg() -> Iterable[DataladHCP1200]:
     """Return a HCP1200 DataGrabber."""
-    dg = DataladHCP1200()
+    tmpdir = Path(tempfile.gettempdir())
+    dg = DataladHCP1200(datadir=tmpdir / "datadir")
     # Set URI to Gin
     dg.uri = URI
     # Set correct root directory
@@ -26,6 +30,7 @@ def hcpdg() -> Iterable[DataladHCP1200]:
         for t_elem in dg.get_elements():
             dg[t_elem]
         yield dg
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 @pytest.mark.parametrize(

--- a/junifer/datagrabber/hcp1200/tests/test_hcp1200.py
+++ b/junifer/datagrabber/hcp1200/tests/test_hcp1200.py
@@ -30,7 +30,7 @@ def hcpdg() -> Iterable[DataladHCP1200]:
         for t_elem in dg.get_elements():
             dg[t_elem]
         yield dg
-    shutil.rmtree(tmpdir, ignore_errors=True)
+    shutil.rmtree(tmpdir / "datadir", ignore_errors=True)
 
 
 @pytest.mark.parametrize(

--- a/junifer/markers/falff/_afni_falff.py
+++ b/junifer/markers/falff/_afni_falff.py
@@ -18,8 +18,8 @@ from typing import (
 import nibabel as nib
 
 from ...pipeline import WorkDirManager
-from ...pipeline.singleton import singleton
 from ...utils import logger, run_ext_cmd
+from ...utils.singleton import Singleton
 
 
 if TYPE_CHECKING:
@@ -29,8 +29,7 @@ if TYPE_CHECKING:
 __all__ = ["AFNIALFF"]
 
 
-@singleton
-class AFNIALFF:
+class AFNIALFF(metaclass=Singleton):
     """Class for computing ALFF using AFNI.
 
     This class uses AFNI's 3dRSFC to compute ALFF. It's designed as a singleton

--- a/junifer/markers/falff/_junifer_falff.py
+++ b/junifer/markers/falff/_junifer_falff.py
@@ -19,8 +19,8 @@ import scipy as sp
 from nilearn import image as nimg
 
 from ...pipeline import WorkDirManager
-from ...pipeline.singleton import singleton
 from ...utils import logger
+from ...utils.singleton import Singleton
 
 
 if TYPE_CHECKING:
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
 __all__ = ["JuniferALFF"]
 
 
-@singleton
-class JuniferALFF:
+class JuniferALFF(metaclass=Singleton):
     """Class for computing ALFF using junifer.
 
     It's designed as a singleton with caching for efficient computation.

--- a/junifer/markers/reho/_afni_reho.py
+++ b/junifer/markers/reho/_afni_reho.py
@@ -18,8 +18,8 @@ from typing import (
 import nibabel as nib
 
 from ...pipeline import WorkDirManager
-from ...pipeline.singleton import singleton
 from ...utils import logger, run_ext_cmd
+from ...utils.singleton import Singleton
 
 
 if TYPE_CHECKING:
@@ -29,8 +29,7 @@ if TYPE_CHECKING:
 __all__ = ["AFNIReHo"]
 
 
-@singleton
-class AFNIReHo:
+class AFNIReHo(metaclass=Singleton):
     """Class for computing ReHo using AFNI.
 
     This class uses AFNI's 3dReHo to compute ReHo. It's designed as a singleton

--- a/junifer/markers/reho/_junifer_reho.py
+++ b/junifer/markers/reho/_junifer_reho.py
@@ -20,8 +20,8 @@ from nilearn import image as nimg
 from nilearn import masking as nmask
 
 from ...pipeline import WorkDirManager
-from ...pipeline.singleton import singleton
 from ...utils import logger, raise_error
+from ...utils.singleton import Singleton
 
 
 if TYPE_CHECKING:
@@ -31,8 +31,7 @@ if TYPE_CHECKING:
 __all__ = ["JuniferReHo"]
 
 
-@singleton
-class JuniferReHo:
+class JuniferReHo(metaclass=Singleton):
     """Class for computing ReHo using junifer.
 
     It's designed as a singleton with caching for efficient computation.

--- a/junifer/pipeline/pipeline_component_registry.py
+++ b/junifer/pipeline/pipeline_component_registry.py
@@ -9,7 +9,7 @@ import importlib
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
 
 from ..utils import logger, raise_error
-from .singleton import singleton
+from ..utils.singleton import Singleton
 
 
 if TYPE_CHECKING:
@@ -21,8 +21,7 @@ if TYPE_CHECKING:
 __all__ = ["PipelineComponentRegistry"]
 
 
-@singleton
-class PipelineComponentRegistry:
+class PipelineComponentRegistry(metaclass=Singleton):
     """Class for pipeline component registry.
 
     This class is a singleton and is used for managing pipeline components.

--- a/junifer/pipeline/workdir_manager.py
+++ b/junifer/pipeline/workdir_manager.py
@@ -10,14 +10,13 @@ from pathlib import Path
 from typing import Optional, Union
 
 from ..utils import logger
-from .singleton import singleton
+from ..utils.singleton import Singleton
 
 
 __all__ = ["WorkDirManager"]
 
 
-@singleton
-class WorkDirManager:
+class WorkDirManager(metaclass=Singleton):
     """Class for working directory manager.
 
     This class is a singleton and is used for managing temporary and working

--- a/junifer/utils/singleton.py
+++ b/junifer/utils/singleton.py
@@ -1,13 +1,14 @@
 """Provide a singleton class to be used by pipeline components."""
 
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
+#          Federico Raimondo <f.raimondo@fz-juelich.de>
 # License: AGPL
 
 from abc import ABCMeta
 from typing import Any, ClassVar, Dict, Type
 
 
-__all__ = ["Singleton"]
+__all__ = ["Singleton", "ABCSingleton"]
 
 
 class Singleton(type):
@@ -47,4 +48,6 @@ class Singleton(type):
 
 
 class ABCSingleton(ABCMeta, Singleton):
+    """Make an abstract class a singleton."""
+
     pass

--- a/junifer/utils/singleton.py
+++ b/junifer/utils/singleton.py
@@ -4,7 +4,7 @@
 # License: AGPL
 
 from abc import ABCMeta
-from typing import Any, Dict, Type
+from typing import Any, ClassVar, Dict, Type
 
 
 __all__ = ["Singleton"]
@@ -20,7 +20,7 @@ class Singleton(type):
 
     """
 
-    instances: Dict = {}
+    instances: ClassVar[Dict] = {}
 
     def __call__(cls, *args: Any, **kwargs: Any) -> Type:
         """Get the only instance for a class.
@@ -39,7 +39,7 @@ class Singleton(type):
 
         """
         if cls not in cls.instances:
-            cls.instances[cls] = super(Singleton, cls).__call__(
+            cls.instances[cls] = super(Singleton, cls).__call__(  # noqa: UP008
                 *args, **kwargs
             )
 

--- a/junifer/utils/singleton.py
+++ b/junifer/utils/singleton.py
@@ -3,13 +3,14 @@
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+from abc import ABCMeta
 from typing import Any, Dict, Type
 
 
-__all__ = ["singleton"]
+__all__ = ["Singleton"]
 
 
-def singleton(cls: Type) -> Type:
+class Singleton(type):
     """Make a class singleton.
 
     Parameters
@@ -17,15 +18,11 @@ def singleton(cls: Type) -> Type:
     cls : class
         The class to designate as singleton.
 
-    Returns
-    -------
-    class
-        The only instance of the class.
-
     """
+
     instances: Dict = {}
 
-    def get_instance(*args: Any, **kwargs: Any) -> Type:
+    def __call__(cls, *args: Any, **kwargs: Any) -> Type:
         """Get the only instance for a class.
 
         Parameters
@@ -41,8 +38,13 @@ def singleton(cls: Type) -> Type:
             The only instance of the class.
 
         """
-        if cls not in instances:
-            instances[cls] = cls(*args, **kwargs)
-        return instances[cls]
+        if cls not in cls.instances:
+            cls.instances[cls] = super(Singleton, cls).__call__(
+                *args, **kwargs
+            )
 
-    return get_instance
+        return cls.instances[cls]
+
+
+class ABCSingleton(ABCMeta, Singleton):
+    pass


### PR DESCRIPTION
Refactor the Singleton so it stays a metaclass, allowing to reset the instances. 

This is needed if we want to test some elements independently and "reset" them between unit tests. E.g. the `WorkDirManager`