### PR TITLE
[ENH]: Update `Warp` datatype schema and logic

### DIFF
--- a/docs/changes/newsfragments/390.change
+++ b/docs/changes/newsfragments/390.change
@@ -1,0 +1,1 @@
+:class:`.SpaceWarper`'s ``using`` now supports ``"auto"`` allowing auto tool selection based on DataGrabber specification by `Synchon Mandal`_

--- a/docs/changes/newsfragments/390.enh
+++ b/docs/changes/newsfragments/390.enh
@@ -1,0 +1,1 @@
+Update ``Warp`` data type to be a list of dictionaries and adapt to allow multiple transforms to be specified by `Synchon Mandal`_

--- a/docs/extending/dependencies.rst
+++ b/docs/extending/dependencies.rst
@@ -39,7 +39,7 @@ and others who use it will thank you.
 Handling external dependencies from toolboxes
 ---------------------------------------------
 
-You can also specify dependencies of external toolboxes like AFIN, FSL and ANTs,
+You can also specify dependencies of external toolboxes like AFNI, FSL and ANTs,
 by having a class attribute like so:
 
 .. code-block:: python
@@ -87,6 +87,10 @@ that it shows the problem a bit better and how we solve it:
                 "using": "ants",
                 "depends_on": ANTsWarper,
             },
+            {
+                "using": "auto",
+                "depends_on": [FSLWarper, ANTsWarper],
+            },
         ]
 
         def __init__(
@@ -100,12 +104,19 @@ Here, you see a new class attribute ``_CONDITIONAL_DEPENDENCIES`` which is a
 list of dictionaries with two keys:
 
 * ``using`` (str) : lowercased name of the toolbox
-* ``depends_on`` (object) : a class which implements the particular tool's use
+* ``depends_on`` (object or list of objects) : a class or list of classes which \
+  implements the particular tool's use
 
 It is mandatory to have the ``using`` positional argument in the constructor in
 this case as the validation starts with this and moves further. It is also
 mandatory to only allow the value of ``using`` argument to be one of them
 specified in the ``using`` key of ``_CONDITIONAL_DEPENDENCIES`` entries.
+
+For some cases, like we have here, it might be worth to have ``"auto"`` for
+``"using"`` which eases the choice of a particular tool by the user and
+instead lets ``junifer`` do it automatically. In that case, ``"depends_on"``
+needs to be a list of the tool implementation classes. This also requires the
+user to have all the tools in the ``PATH``.
 
 For brevity, we only show the ``FSLWarper`` here but ``ANTsWarper`` looks very
 similar. ``FSLWarper`` looks like this (only the relevant part is shown here):

--- a/docs/understanding/preprocess.rst
+++ b/docs/understanding/preprocess.rst
@@ -157,9 +157,8 @@ The ``Warp`` data type provides the warp or transformation file (can be linear,
 non-linear or linear + non-linear transform) for the purpose. For ``using``
 parameter, you can pass either ``fsl`` or ``ants`` depending on the warp or
 transformation file format. You can also provide ``auto`` to ``using`` in which
-case either ``FSL`` or ``ANTs`` will be used based on the preferred warping tool
-or the one available as provided by the DataGrabber. This also requires that
-both the tools are in the ``PATH``.
+case either ``FSL`` or ``ANTs`` will be used based on the file format provided
+by the DataGrabber. This also requires that both the tools are in the ``PATH``.
 
 And finally, you would need to set the ``on`` parameter to ``BOLD`` to make it
 clear which data type you intend to warp, as the :class:`.SpaceWarper` is also

--- a/docs/understanding/preprocess.rst
+++ b/docs/understanding/preprocess.rst
@@ -146,14 +146,24 @@ Warping to subject's native space
 To warp to subject's native space, the dataset needs to provide ``T1w`` and
 ``Warp`` data types and the DataGrabber needs to at least have
 ``["BOLD", "T1w", "Warp"]`` (if you are warping ``BOLD``) as the ``types``
-parameter's value. The :class:`.SpaceWarper`'s ``reference`` parameter needs
+parameter's value.
+
+The :class:`.SpaceWarper`'s ``reference`` parameter needs
 to be set to ``T1w``, which means that the ``BOLD`` data will be transformed
 using the ``T1w`` as reference (it's resampled internally to match the
-resolution of the ``BOLD``). The ``Warp`` data type is new and it's only purpose
-is to provide the warp or transformation file (can be linear, non-linear or
-linear + non-linear transform) for the purpose. For ``using`` parameter, you can
-pass either ``"fsl"`` or ``"ants"`` depending on the warp or transformation file
-format.
+resolution of the ``BOLD``).
+
+The ``Warp`` data type provides the warp or transformation file (can be linear,
+non-linear or linear + non-linear transform) for the purpose. For ``using``
+parameter, you can pass either ``fsl`` or ``ants`` depending on the warp or
+transformation file format. You can also provide ``auto`` to ``using`` in which
+case either ``FSL`` or ``ANTs`` will be used based on the preferred warping tool
+or the one available as provided by the DataGrabber. This also requires that
+both the tools are in the ``PATH``.
+
+And finally, you would need to set the ``on`` parameter to ``BOLD`` to make it
+clear which data type you intend to warp, as the :class:`.SpaceWarper` is also
+capable of warping ``T1w``.
 
 An example YAML might look like this:
 
@@ -163,6 +173,7 @@ An example YAML might look like this:
          - kind: SpaceWarper
            using: fsl
            reference: T1w
+           on: BOLD
 
 .. _preprocess_warping_template:
 
@@ -174,8 +185,8 @@ data type that you want to work on) in ``MNI152NLin6Asym`` template space but
 you would like to compute features in ``MNI152NLin2009cAsym`` template space,
 you can also use the :class:`.SpaceWarper` by setting the ``reference``
 parameter to the template space's name, in this case,
-``reference="MNI152NLin2009cAsym"``. The ``using`` parameter needs to be set
-to ``"ants"`` as we need it to warp the data.
+``reference: MNI152NLin2009cAsym``. The ``using`` parameter needs to be set
+to ``ants`` as we need it to warp the data.
 
 .. note::
 
@@ -190,3 +201,4 @@ For an YAML example:
          - kind: SpaceWarper
            using: ants
            reference: MNI152NLin2009cAsym
+           on: BOLD

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -342,13 +342,13 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                 seeds = FSLCoordinatesWarper().warp(
                     seeds=seeds,
                     target_data=target_data,
-                    extra_input=extra_input,
+                    warp_data=warper_spec,
                 )
             elif warper == "ants":
                 seeds = ANTsCoordinatesWarper().warp(
                     seeds=seeds,
                     target_data=target_data,
-                    extra_input=extra_input,
+                    warp_data=warper_spec,
                 )
 
         return seeds, labels

--- a/junifer/data/coordinates/_fsl_coordinates_warper.py
+++ b/junifer/data/coordinates/_fsl_coordinates_warper.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 from ...pipeline import WorkDirManager
-from ...utils import logger, run_ext_cmd
+from ...utils import logger, raise_error, run_ext_cmd
 
 
 __all__ = ["FSLCoordinatesWarper"]
@@ -39,16 +39,30 @@ class FSLCoordinatesWarper:
             will be applied.
         extra_input : dict, optional
             The other fields in the data object. Useful for accessing other
-            data kinds that needs to be used in the computation of coordinates
-            (default None).
+            data kinds that needs to be used in the computation of coordinates.
 
         Returns
         -------
         numpy.ndarray
             The transformed coordinates.
 
+        Raises
+        ------
+        RuntimeError
+            If warp file path could not be found in ``extra_input``.
+
         """
         logger.debug("Using FSL for coordinates transformation")
+
+        # Get warp file path
+        warp_file_path = None
+        for entry in extra_input["Warp"]:
+            if entry["dst"] == "native":
+                warp_file_path = entry["path"]
+        if warp_file_path is None:
+            raise_error(
+                klass=RuntimeError, msg="Could not find correct warp file path"
+            )
 
         # Create element-specific tempdir for storing post-warping assets
         element_tempdir = WorkDirManager().get_element_tempdir(
@@ -72,7 +86,7 @@ class FSLCoordinatesWarper:
             "| img2imgcoord -mm",
             f"-src {target_data['path'].resolve()}",
             f"-dest {target_data['reference_path'].resolve()}",
-            f"-warp {extra_input['Warp']['path'].resolve()}",
+            f"-warp {warp_file_path.resolve()}",
             f"> {transformed_coords_path.resolve()};",
             f"sed -i 1d {transformed_coords_path.resolve()}",
         ]

--- a/junifer/data/coordinates/_fsl_coordinates_warper.py
+++ b/junifer/data/coordinates/_fsl_coordinates_warper.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 from ...pipeline import WorkDirManager
-from ...utils import logger, raise_error, run_ext_cmd
+from ...utils import logger, run_ext_cmd
 
 
 __all__ = ["FSLCoordinatesWarper"]
@@ -26,7 +26,7 @@ class FSLCoordinatesWarper:
         self,
         seeds: ArrayLike,
         target_data: Dict[str, Any],
-        extra_input: Dict[str, Any],
+        warp_data: Dict[str, Any],
     ) -> ArrayLike:
         """Warp ``seeds`` to correct space.
 
@@ -37,32 +37,16 @@ class FSLCoordinatesWarper:
         target_data : dict
             The corresponding item of the data object to which the coordinates
             will be applied.
-        extra_input : dict, optional
-            The other fields in the data object. Useful for accessing other
-            data kinds that needs to be used in the computation of coordinates.
+        warp_data : dict
+            The warp data item of the data object.
 
         Returns
         -------
         numpy.ndarray
             The transformed coordinates.
 
-        Raises
-        ------
-        RuntimeError
-            If warp file path could not be found in ``extra_input``.
-
         """
         logger.debug("Using FSL for coordinates transformation")
-
-        # Get warp file path
-        warp_file_path = None
-        for entry in extra_input["Warp"]:
-            if entry["dst"] == "native":
-                warp_file_path = entry["path"]
-        if warp_file_path is None:
-            raise_error(
-                klass=RuntimeError, msg="Could not find correct warp file path"
-            )
 
         # Create element-specific tempdir for storing post-warping assets
         element_tempdir = WorkDirManager().get_element_tempdir(
@@ -86,7 +70,7 @@ class FSLCoordinatesWarper:
             "| img2imgcoord -mm",
             f"-src {target_data['path'].resolve()}",
             f"-dest {target_data['reference_path'].resolve()}",
-            f"-warp {warp_file_path.resolve()}",
+            f"-warp {warp_data['path'].resolve()}",
             f"> {transformed_coords_path.resolve()};",
             f"sed -i 1d {transformed_coords_path.resolve()}",
         ]

--- a/junifer/data/masks/_ants_mask_warper.py
+++ b/junifer/data/masks/_ants_mask_warper.py
@@ -34,7 +34,7 @@ class ANTsMaskWarper:
         src: str,
         dst: str,
         target_data: Dict[str, Any],
-        extra_input: Optional[Dict[str, Any]] = None,
+        warp_data: Optional[Dict[str, Any]],
     ) -> "Nifti1Image":
         """Warp ``mask_img`` to correct space.
 
@@ -55,11 +55,9 @@ class ANTsMaskWarper:
         target_data : dict
             The corresponding item of the data object to which the mask
             will be applied.
-        extra_input : dict, optional
-            The other fields in the data object. Useful for accessing other
-            data kinds that needs to be used in the computation of mask
-            (default None).
-
+        warp_data : dict or None
+            The warp data item of the data object. The value is unused if
+            ``dst!="T1w"``.
 
         Returns
         -------
@@ -69,7 +67,7 @@ class ANTsMaskWarper:
         Raises
         ------
         RuntimeError
-            If warp file path could not be found in ``extra_input``.
+            If ``warp_data`` is None when ``dst="T1w"``.
 
         """
         # Create element-scoped tempdir so that warped mask is
@@ -86,18 +84,11 @@ class ANTsMaskWarper:
 
         # Native space warping
         if dst == "T1w":
-            logger.debug("Using ANTs for mask transformation")
+            # Warp data check
+            if warp_data is None:
+                raise_error("No `warp_data` provided")
 
-            # Get warp file path
-            warp_file_path = None
-            for entry in extra_input["Warp"]:
-                if entry["dst"] == "native":
-                    warp_file_path = entry["path"]
-            if warp_file_path is None:
-                raise_error(
-                    klass=RuntimeError,
-                    msg="Could not find correct warp file path",
-                )
+            logger.debug("Using ANTs for mask transformation")
 
             # Save existing mask image to a tempfile
             prewarp_mask_path = element_tempdir / "prewarp_mask.nii.gz"
@@ -114,7 +105,7 @@ class ANTsMaskWarper:
                 f"-i {prewarp_mask_path.resolve()}",
                 # use resampled reference
                 f"-r {target_data['reference_path'].resolve()}",
-                f"-t {warp_file_path.resolve()}",
+                f"-t {warp_data['path'].resolve()}",
                 f"-o {warped_mask_path.resolve()}",
             ]
             # Call antsApplyTransforms

--- a/junifer/data/masks/_ants_mask_warper.py
+++ b/junifer/data/masks/_ants_mask_warper.py
@@ -83,7 +83,7 @@ class ANTsMaskWarper:
         )
 
         # Native space warping
-        if dst == "T1w":
+        if dst == "native":
             # Warp data check
             if warp_data is None:
                 raise_error("No `warp_data` provided")

--- a/junifer/data/masks/_fsl_mask_warper.py
+++ b/junifer/data/masks/_fsl_mask_warper.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict
 import nibabel as nib
 
 from ...pipeline import WorkDirManager
-from ...utils import logger, run_ext_cmd
+from ...utils import logger, raise_error, run_ext_cmd
 
 
 if TYPE_CHECKING:
@@ -46,16 +46,30 @@ class FSLMaskWarper:
             will be applied.
         extra_input : dict, optional
             The other fields in the data object. Useful for accessing other
-            data kinds that needs to be used in the computation of mask
-            (default None).
+            data kinds that needs to be used in the computation of mask.
 
         Returns
         -------
         nibabel.nifti1.Nifti1Image
             The transformed mask image.
 
+        Raises
+        ------
+        RuntimeError
+            If warp file path could not be found in ``extra_input``.
+
         """
         logger.debug("Using FSL for mask transformation")
+
+        # Get warp file path
+        warp_file_path = None
+        for entry in extra_input["Warp"]:
+            if entry["dst"] == "native":
+                warp_file_path = entry["path"]
+        if warp_file_path is None:
+            raise_error(
+                klass=RuntimeError, msg="Could not find correct warp file path"
+            )
 
         # Create element-scoped tempdir so that warped mask is
         # available later as nibabel stores file path reference for
@@ -77,7 +91,7 @@ class FSLMaskWarper:
             f"-i {prewarp_mask_path.resolve()}",
             # use resampled reference
             f"-r {target_data['reference_path'].resolve()}",
-            f"-w {extra_input['Warp']['path'].resolve()}",
+            f"-w {warp_file_path.resolve()}",
             f"-o {warped_mask_path.resolve()}",
         ]
         # Call applywarp

--- a/junifer/data/masks/_masks.py
+++ b/junifer/data/masks/_masks.py
@@ -499,7 +499,7 @@ class MaskRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                         src=mask_space,
                         dst=target_std_space,
                         target_data=target_data,
-                        extra_input=None,
+                        warp_data=None,
                     )
 
             all_masks.append(mask_img)
@@ -526,7 +526,7 @@ class MaskRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     mask_name="native",
                     mask_img=mask_img,
                     target_data=target_data,
-                    extra_input=extra_input,
+                    warp_data=warper_spec,
                 )
             elif warper == "ants":
                 mask_img = ANTsMaskWarper().warp(
@@ -535,7 +535,7 @@ class MaskRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     src="",
                     dst="T1w",
                     target_data=target_data,
-                    extra_input=extra_input,
+                    warp_data=warper_spec,
                 )
 
         return mask_img

--- a/junifer/data/masks/_masks.py
+++ b/junifer/data/masks/_masks.py
@@ -114,7 +114,7 @@ def compute_brain_mask(
         space=target_std_space,
         target_data=target_data,
         extra_input=extra_input,
-        template_type=mask_type if mask_type in ["gm", "wm"] else "T1w",
+        template_type=mask_type,
     )
     # Resample template to target image
     target_img = target_data["data"]

--- a/junifer/data/masks/_masks.py
+++ b/junifer/data/masks/_masks.py
@@ -529,7 +529,7 @@ class MaskRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     mask_name="native",
                     mask_img=mask_img,
                     src="",
-                    dst="T1w",
+                    dst="native",
                     target_data=target_data,
                     warp_data=warper_spec,
                 )

--- a/junifer/data/parcellations/_ants_parcellation_warper.py
+++ b/junifer/data/parcellations/_ants_parcellation_warper.py
@@ -34,7 +34,7 @@ class ANTsParcellationWarper:
         src: str,
         dst: str,
         target_data: Dict[str, Any],
-        extra_input: Optional[Dict[str, Any]] = None,
+        warp_data: Optional[Dict[str, Any]],
     ) -> "Nifti1Image":
         """Warp ``parcellation_img`` to correct space.
 
@@ -55,11 +55,9 @@ class ANTsParcellationWarper:
         target_data : dict
             The corresponding item of the data object to which the parcellation
             will be applied.
-        extra_input : dict, optional
-            The other fields in the data object. Useful for accessing other
-            data kinds that needs to be used in the computation of parcellation
-            (default None).
-
+        warp_data : dict or None
+            The warp data item of the data object. The value is unused if
+            ``dst!="T1w"``.
 
         Returns
         -------
@@ -68,8 +66,8 @@ class ANTsParcellationWarper:
 
         Raises
         ------
-        RuntimeError
-            If warp file path could not be found in ``extra_input``.
+        ValueError
+            If ``warp_data`` is None when ``dst="T1w"``.
 
         """
         # Create element-scoped tempdir so that warped parcellation is
@@ -86,18 +84,11 @@ class ANTsParcellationWarper:
 
         # Native space warping
         if dst == "T1w":
-            logger.debug("Using ANTs for parcellation transformation")
+            # Warp data check
+            if warp_data is None:
+                raise_error("No `warp_data` provided")
 
-            # Get warp file path
-            warp_file_path = None
-            for entry in extra_input["Warp"]:
-                if entry["dst"] == "native":
-                    warp_file_path = entry["path"]
-            if warp_file_path is None:
-                raise_error(
-                    klass=RuntimeError,
-                    msg="Could not find correct warp file path",
-                )
+            logger.debug("Using ANTs for parcellation transformation")
 
             # Save existing parcellation image to a tempfile
             prewarp_parcellation_path = (
@@ -118,7 +109,7 @@ class ANTsParcellationWarper:
                 f"-i {prewarp_parcellation_path.resolve()}",
                 # use resampled reference
                 f"-r {target_data['reference_path'].resolve()}",
-                f"-t {warp_file_path.resolve()}",
+                f"-t {warp_data['path'].resolve()}",
                 f"-o {warped_parcellation_path.resolve()}",
             ]
             # Call antsApplyTransforms

--- a/junifer/data/parcellations/_ants_parcellation_warper.py
+++ b/junifer/data/parcellations/_ants_parcellation_warper.py
@@ -83,7 +83,7 @@ class ANTsParcellationWarper:
         )
 
         # Native space warping
-        if dst == "T1w":
+        if dst == "native":
             # Warp data check
             if warp_data is None:
                 raise_error("No `warp_data` provided")

--- a/junifer/data/parcellations/_fsl_parcellation_warper.py
+++ b/junifer/data/parcellations/_fsl_parcellation_warper.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict
 import nibabel as nib
 
 from ...pipeline import WorkDirManager
-from ...utils import logger, raise_error, run_ext_cmd
+from ...utils import logger, run_ext_cmd
 
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class FSLParcellationWarper:
         parcellation_name: str,
         parcellation_img: "Nifti1Image",
         target_data: Dict[str, Any],
-        extra_input: Dict[str, Any],
+        warp_data: Dict[str, Any],
     ) -> "Nifti1Image":
         """Warp ``parcellation_img`` to correct space.
 
@@ -44,33 +44,16 @@ class FSLParcellationWarper:
         target_data : dict
             The corresponding item of the data object to which the parcellation
             will be applied.
-        extra_input : dict, optional
-            The other fields in the data object. Useful for accessing other
-            data kinds that needs to be used in the computation of
-            parcellation.
+        warp_data : dict
+            The warp data item of the data object.
 
         Returns
         -------
         nibabel.nifti1.Nifti1Image
             The transformed parcellation image.
 
-        Raises
-        ------
-        RuntimeError
-            If warp file path could not be found in ``extra_input``.
-
         """
         logger.debug("Using FSL for parcellation transformation")
-
-        # Get warp file path
-        warp_file_path = None
-        for entry in extra_input["Warp"]:
-            if entry["dst"] == "native":
-                warp_file_path = entry["path"]
-        if warp_file_path is None:
-            raise_error(
-                klass=RuntimeError, msg="Could not find correct warp file path"
-            )
 
         # Create element-scoped tempdir so that warped parcellation is
         # available later as nibabel stores file path reference for
@@ -96,7 +79,7 @@ class FSLParcellationWarper:
             f"-i {prewarp_parcellation_path.resolve()}",
             # use resampled reference
             f"-r {target_data['reference_path'].resolve()}",
-            f"-w {warp_file_path.resolve()}",
+            f"-w {warp_data['path'].resolve()}",
             f"-o {warped_parcellation_path.resolve()}",
         ]
         # Call applywarp

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -490,7 +490,7 @@ class ParcellationRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     parcellation_name="native",
                     parcellation_img=resampled_parcellation_img,
                     src="",
-                    dst="T1w",
+                    dst="native",
                     target_data=target_data,
                     warp_data=warper_spec,
                 )

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -449,7 +449,7 @@ class ParcellationRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     src=space,
                     dst=target_std_space,
                     target_data=target_data,
-                    extra_input=None,
+                    warp_data=None,
                 )
                 # Remove extra dimension added by ANTs
                 img = image.math_img("np.squeeze(img)", img=raw_img)
@@ -485,7 +485,7 @@ class ParcellationRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     parcellation_name="native",
                     parcellation_img=resampled_parcellation_img,
                     target_data=target_data,
-                    extra_input=extra_input,
+                    warp_data=warper_spec,
                 )
             elif warper == "ants":
                 resampled_parcellation_img = ANTsParcellationWarper().warp(
@@ -494,7 +494,7 @@ class ParcellationRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     src="",
                     dst="T1w",
                     target_data=target_data,
-                    extra_input=extra_input,
+                    warp_data=warper_spec,
                 )
 
         return resampled_parcellation_img, labels

--- a/junifer/datagrabber/aomic/id1000.py
+++ b/junifer/datagrabber/aomic/id1000.py
@@ -169,15 +169,26 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
                             "space": "native",
                         },
                     },
-                    "Warp": {
-                        "pattern": (
-                            "derivatives/fmriprep/{subject}/anat/"
-                            "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
-                            "mode-image_xfm.h5"
-                        ),
-                        "src": "MNI152NLin2009cAsym",
-                        "dst": "native",
-                    },
+                    "Warp": [
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "MNI152NLin2009cAsym",
+                            "dst": "native",
+                        },
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_from-T1w_to-MNI152NLin2009cAsym_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "native",
+                            "dst": "MNI152NLin2009cAsym",
+                        },
+                    ],
                 }
             )
         # Set default types

--- a/junifer/datagrabber/aomic/id1000.py
+++ b/junifer/datagrabber/aomic/id1000.py
@@ -178,6 +178,7 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
                             ),
                             "src": "MNI152NLin2009cAsym",
                             "dst": "native",
+                            "warper": "ants",
                         },
                         {
                             "pattern": (
@@ -187,6 +188,7 @@ class DataladAOMICID1000(PatternDataladDataGrabber):
                             ),
                             "src": "native",
                             "dst": "MNI152NLin2009cAsym",
+                            "warper": "ants",
                         },
                     ],
                 }

--- a/junifer/datagrabber/aomic/piop1.py
+++ b/junifer/datagrabber/aomic/piop1.py
@@ -213,6 +213,7 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
                             ),
                             "src": "MNI152NLin2009cAsym",
                             "dst": "native",
+                            "warper": "ants",
                         },
                         {
                             "pattern": (
@@ -222,6 +223,7 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
                             ),
                             "src": "native",
                             "dst": "MNI152NLin2009cAsym",
+                            "warper": "ants",
                         },
                     ],
                 }

--- a/junifer/datagrabber/aomic/piop1.py
+++ b/junifer/datagrabber/aomic/piop1.py
@@ -204,15 +204,26 @@ class DataladAOMICPIOP1(PatternDataladDataGrabber):
                             "space": "native",
                         },
                     },
-                    "Warp": {
-                        "pattern": (
-                            "derivatives/fmriprep/{subject}/anat/"
-                            "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
-                            "mode-image_xfm.h5"
-                        ),
-                        "src": "MNI152NLin2009cAsym",
-                        "dst": "native",
-                    },
+                    "Warp": [
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "MNI152NLin2009cAsym",
+                            "dst": "native",
+                        },
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_from-T1w_to-MNI152NLin2009cAsym_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "native",
+                            "dst": "MNI152NLin2009cAsym",
+                        },
+                    ],
                 }
             )
         # Set default types

--- a/junifer/datagrabber/aomic/piop2.py
+++ b/junifer/datagrabber/aomic/piop2.py
@@ -211,6 +211,7 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
                             ),
                             "src": "MNI152NLin2009cAsym",
                             "dst": "native",
+                            "warper": "ants",
                         },
                         {
                             "pattern": (
@@ -220,6 +221,7 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
                             ),
                             "src": "native",
                             "dst": "MNI152NLin2009cAsym",
+                            "warper": "ants",
                         },
                     ],
                 }

--- a/junifer/datagrabber/aomic/piop2.py
+++ b/junifer/datagrabber/aomic/piop2.py
@@ -202,15 +202,26 @@ class DataladAOMICPIOP2(PatternDataladDataGrabber):
                             "space": "native",
                         },
                     },
-                    "Warp": {
-                        "pattern": (
-                            "derivatives/fmriprep/{subject}/anat/"
-                            "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
-                            "mode-image_xfm.h5"
-                        ),
-                        "src": "MNI152NLin2009cAsym",
-                        "dst": "native",
-                    },
+                    "Warp": [
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "MNI152NLin2009cAsym",
+                            "dst": "native",
+                        },
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep/{subject}/anat/"
+                                "{subject}_from-T1w_to-MNI152NLin2009cAsym_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "native",
+                            "dst": "MNI152NLin2009cAsym",
+                        },
+                    ],
                 }
             )
         # Set default types

--- a/junifer/datagrabber/base.py
+++ b/junifer/datagrabber/base.py
@@ -96,7 +96,12 @@ class BaseDataGrabber(ABC, UpdateMetaMixin):
         # Update metadata
         for _, t_val in out.items():
             self.update_meta(t_val, "datagrabber")
-            t_val["meta"]["element"] = named_element
+            # Conditional for list dtype vals like Warp
+            if isinstance(t_val, list):
+                for entry in t_val:
+                    entry["meta"]["element"] = named_element
+            else:
+                t_val["meta"]["element"] = named_element
 
         return out
 

--- a/junifer/datagrabber/datalad_base.py
+++ b/junifer/datagrabber/datalad_base.py
@@ -181,14 +181,21 @@ class DataladDataGrabber(BaseDataGrabber):
         """
         to_get = []
         for type_val in out.values():
-            # Iterate to check for nested "types" like mask
-            for k, v in type_val.items():
-                # Add base data type path
-                if k == "path":
-                    to_get.append(v)
-                # Add nested data type path
-                if isinstance(v, dict) and "path" in v:
-                    to_get.append(v["path"])
+            # Conditional for list dtype vals like Warp
+            if isinstance(type_val, list):
+                for entry in type_val:
+                    for k, v in entry.items():
+                        if k == "path":
+                            to_get.append(v)
+            else:
+                # Iterate to check for nested "types" like mask
+                for k, v in type_val.items():
+                    # Add base data type path
+                    if k == "path":
+                        to_get.append(v)
+                    # Add nested data type path
+                    if isinstance(v, dict) and "path" in v:
+                        to_get.append(v["path"])
 
         if len(to_get) > 0:
             logger.debug(f"Getting {len(to_get)} files using datalad:")

--- a/junifer/datagrabber/dmcc13_benchmark.py
+++ b/junifer/datagrabber/dmcc13_benchmark.py
@@ -150,7 +150,7 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                 "mask": {
                     "pattern": (
                         "derivatives/fmriprep-1.3.2/{subject}/{session}/"
-                        "/func/{subject}_{session}_task-{task}_acq-mb4"
+                        "func/{subject}_{session}_task-{task}_acq-mb4"
                         "{phase_encoding}_run-{run}_"
                         "space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz"
                     ),

--- a/junifer/datagrabber/dmcc13_benchmark.py
+++ b/junifer/datagrabber/dmcc13_benchmark.py
@@ -221,15 +221,26 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                             "space": "native",
                         },
                     },
-                    "Warp": {
-                        "pattern": (
-                            "derivatives/fmriprep-1.3.2/{subject}/anat/"
-                            "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
-                            "mode-image_xfm.h5"
-                        ),
-                        "src": "MNI152NLin2009cAsym",
-                        "dst": "native",
-                    },
+                    "Warp": [
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep-1.3.2/{subject}/anat/"
+                                "{subject}_from-MNI152NLin2009cAsym_to-T1w_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "MNI152NLin2009cAsym",
+                            "dst": "native",
+                        },
+                        {
+                            "pattern": (
+                                "derivatives/fmriprep-1.3.2/{subject}/anat/"
+                                "{subject}_from-T1w_to-MNI152NLin2009cAsym_"
+                                "mode-image_xfm.h5"
+                            ),
+                            "src": "native",
+                            "dst": "MNI152NLin2009cAsym",
+                        },
+                    ],
                 }
             )
         # Set default types

--- a/junifer/datagrabber/dmcc13_benchmark.py
+++ b/junifer/datagrabber/dmcc13_benchmark.py
@@ -230,6 +230,7 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                             ),
                             "src": "MNI152NLin2009cAsym",
                             "dst": "native",
+                            "warper": "ants",
                         },
                         {
                             "pattern": (
@@ -239,6 +240,7 @@ class DMCC13Benchmark(PatternDataladDataGrabber):
                             ),
                             "src": "native",
                             "dst": "MNI152NLin2009cAsym",
+                            "warper": "ants",
                         },
                     ],
                 }

--- a/junifer/datagrabber/hcp1200/hcp1200.py
+++ b/junifer/datagrabber/hcp1200/hcp1200.py
@@ -129,6 +129,7 @@ class HCP1200(PatternDataGrabber):
                     ),
                     "src": "MNI152NLin6Asym",
                     "dst": "native",
+                    "warper": "fsl",
                 },
                 {
                     "pattern": (
@@ -136,6 +137,7 @@ class HCP1200(PatternDataGrabber):
                     ),
                     "src": "native",
                     "dst": "MNI152NLin6Asym",
+                    "warper": "fsl",
                 },
             ],
         }

--- a/junifer/datagrabber/hcp1200/hcp1200.py
+++ b/junifer/datagrabber/hcp1200/hcp1200.py
@@ -122,13 +122,22 @@ class HCP1200(PatternDataGrabber):
                 "pattern": "{subject}/T1w/T1w_acpc_dc_restore.nii.gz",
                 "space": "native",
             },
-            "Warp": {
-                "pattern": (
-                    "{subject}/MNINonLinear/xfms/standard2acpc_dc.nii.gz"
-                ),
-                "src": "MNI152NLin6Asym",
-                "dst": "native",
-            },
+            "Warp": [
+                {
+                    "pattern": (
+                        "{subject}/MNINonLinear/xfms/standard2acpc_dc.nii.gz"
+                    ),
+                    "src": "MNI152NLin6Asym",
+                    "dst": "native",
+                },
+                {
+                    "pattern": (
+                        "{subject}/MNINonLinear/xfms/acpc_dc2standard.nii.gz"
+                    ),
+                    "src": "native",
+                    "dst": "MNI152NLin6Asym",
+                },
+            ],
         }
         # The replacements
         replacements = ["subject", "task", "phase_encoding"]

--- a/junifer/datagrabber/pattern.py
+++ b/junifer/datagrabber/pattern.py
@@ -89,7 +89,7 @@ class PatternDataGrabber(BaseDataGrabber, PatternValidationMixin):
           .. code-block:: none
 
             {
-              "mandatory": ["pattern", "src", "dst"],
+              "mandatory": ["pattern", "src", "dst", "warper"],
               "optional": []
             }
 
@@ -140,6 +140,7 @@ class PatternDataGrabber(BaseDataGrabber, PatternValidationMixin):
                   "pattern": "...",
                   "src": "...",
                   "dst": "...",
+                  "warper": "...",
                 },
               ],
           }

--- a/junifer/datagrabber/pattern_validation_mixin.py
+++ b/junifer/datagrabber/pattern_validation_mixin.py
@@ -132,7 +132,7 @@ class PatternValidationMixin:
 
         if any(not isinstance(x, str) for x in replacements):
             raise_error(
-                msg="`replacements` must be a list of strings.",
+                msg="`replacements` must be a list of strings",
                 klass=TypeError,
             )
 
@@ -152,11 +152,11 @@ class PatternValidationMixin:
                     warn_with_log(
                         f"Replacement: `{x}` is not part of any pattern, "
                         "things might not work as expected if you are unsure "
-                        "of what you are doing"
+                        "of what you are doing."
                     )
                 else:
                     raise_error(
-                        msg=f"Replacement: {x} is not part of any pattern."
+                        msg=f"Replacement: `{x}` is not part of any pattern"
                     )
 
         # Check that at least one pattern has all the replacements
@@ -176,7 +176,7 @@ class PatternValidationMixin:
                     at_least_one = True
         if not at_least_one and not partial_pattern_ok:
             raise_error(
-                msg="At least one pattern must contain all replacements."
+                msg="At least one pattern must contain all replacements"
             )
 
     def _validate_mandatory_keys(
@@ -219,7 +219,7 @@ class PatternValidationMixin:
                     warn_with_log(
                         f"Mandatory key: `{key}` not found for {data_type}, "
                         "things might not work as expected if you are unsure "
-                        "of what you are doing"
+                        "of what you are doing."
                     )
                 else:
                     raise_error(
@@ -227,7 +227,7 @@ class PatternValidationMixin:
                         klass=KeyError,
                     )
             else:
-                logger.debug(f"Mandatory key: `{key}` found for {data_type}")
+                logger.debug(f"Mandatory key: `{key}` found for {data_type}.")
 
     def _identify_stray_keys(
         self, keys: List[str], schema: List[str], data_type: str

--- a/junifer/datagrabber/pattern_validation_mixin.py
+++ b/junifer/datagrabber/pattern_validation_mixin.py
@@ -36,7 +36,7 @@ PATTERNS_SCHEMA = {
         },
     },
     "Warp": {
-        "mandatory": ["pattern", "src", "dst"],
+        "mandatory": ["pattern", "src", "dst", "warper"],
         "optional": {},
     },
     "VBM_GM": {

--- a/junifer/datagrabber/pattern_validation_mixin.py
+++ b/junifer/datagrabber/pattern_validation_mixin.py
@@ -3,7 +3,7 @@
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from ..utils import logger, raise_error, warn_with_log
 
@@ -96,7 +96,7 @@ class PatternValidationMixin:
     def _validate_replacements(
         self,
         replacements: List[str],
-        patterns: Dict[str, Dict[str, str]],
+        patterns: Dict[str, Union[Dict[str, str], List[Dict[str, str]]]],
         partial_pattern_ok: bool,
     ) -> None:
         """Validate the replacements.
@@ -136,14 +136,18 @@ class PatternValidationMixin:
                 klass=TypeError,
             )
 
+        # Make a list of all patterns recursively
+        all_patterns = []
+        for dtype_val in patterns.values():
+            # Conditional for list dtype vals like Warp
+            if isinstance(dtype_val, list):
+                for entry in dtype_val:
+                    all_patterns.append(entry.get("pattern", ""))
+            else:
+                all_patterns.append(dtype_val.get("pattern", ""))
+        # Check for stray replacements
         for x in replacements:
-            if all(
-                x not in y
-                for y in [
-                    data_type_val.get("pattern", "")
-                    for data_type_val in patterns.values()
-                ]
-            ):
+            if all(x not in y for y in all_patterns):
                 if partial_pattern_ok:
                     warn_with_log(
                         f"Replacement: `{x}` is not part of any pattern, "
@@ -157,11 +161,19 @@ class PatternValidationMixin:
 
         # Check that at least one pattern has all the replacements
         at_least_one = False
-        for data_type_val in patterns.values():
-            if all(
-                x in data_type_val.get("pattern", "") for x in replacements
-            ):
-                at_least_one = True
+        for dtype_val in patterns.values():
+            # Conditional for list dtype vals like Warp
+            if isinstance(dtype_val, list):
+                for entry in dtype_val:
+                    if all(
+                        x in entry.get("pattern", "") for x in replacements
+                    ):
+                        at_least_one = True
+            else:
+                if all(
+                    x in dtype_val.get("pattern", "") for x in replacements
+                ):
+                    at_least_one = True
         if not at_least_one and not partial_pattern_ok:
             raise_error(
                 msg="At least one pattern must contain all replacements."
@@ -251,7 +263,7 @@ class PatternValidationMixin:
         self,
         types: List[str],
         replacements: List[str],
-        patterns: Dict[str, Dict[str, str]],
+        patterns: Dict[str, Union[Dict[str, str], List[Dict[str, str]]]],
         partial_pattern_ok: bool = False,
     ) -> None:
         """Validate the patterns.
@@ -298,87 +310,185 @@ class PatternValidationMixin:
                 msg="`patterns` must contain all `types`", klass=ValueError
             )
         # Check against schema
-        for data_type_key, data_type_val in patterns.items():
+        for dtype_key, dtype_val in patterns.items():
             # Check if valid data type is provided
-            if data_type_key not in PATTERNS_SCHEMA:
+            if dtype_key not in PATTERNS_SCHEMA:
                 raise_error(
-                    f"Unknown data type: {data_type_key}, "
+                    f"Unknown data type: {dtype_key}, "
                     f"should be one of: {list(PATTERNS_SCHEMA.keys())}"
                 )
-            # Check mandatory keys for data type
-            self._validate_mandatory_keys(
-                keys=list(data_type_val),
-                schema=PATTERNS_SCHEMA[data_type_key]["mandatory"],
-                data_type=data_type_key,
-                partial_pattern_ok=partial_pattern_ok,
-            )
-            # Check optional keys for data type
-            for optional_key, optional_val in PATTERNS_SCHEMA[data_type_key][
-                "optional"
-            ].items():
-                if optional_key not in data_type_val:
-                    logger.debug(
-                        f"Optional key: `{optional_key}` missing for "
-                        f"{data_type_key}"
-                    )
-                else:
-                    logger.debug(
-                        f"Optional key: `{optional_key}` found for "
-                        f"{data_type_key}"
-                    )
-                    # Set nested type name for easier access
-                    nested_data_type = f"{data_type_key}.{optional_key}"
-                    nested_mandatory_keys_schema = PATTERNS_SCHEMA[
-                        data_type_key
-                    ]["optional"][optional_key]["mandatory"]
-                    nested_optional_keys_schema = PATTERNS_SCHEMA[
-                        data_type_key
-                    ]["optional"][optional_key]["optional"]
-                    # Check mandatory keys for nested type
+            # Conditional for list dtype vals like Warp
+            if isinstance(dtype_val, list):
+                for idx, entry in enumerate(dtype_val):
+                    # Check mandatory keys for data type
                     self._validate_mandatory_keys(
-                        keys=list(optional_val["mandatory"]),
-                        schema=nested_mandatory_keys_schema,
-                        data_type=nested_data_type,
+                        keys=list(entry),
+                        schema=PATTERNS_SCHEMA[dtype_key]["mandatory"],
+                        data_type=f"{dtype_key}.{idx}",
                         partial_pattern_ok=partial_pattern_ok,
                     )
-                    # Check optional keys for nested type
-                    for nested_optional_key in nested_optional_keys_schema:
-                        if nested_optional_key not in optional_val["optional"]:
+                    # Check optional keys for data type
+                    for optional_key, optional_val in PATTERNS_SCHEMA[
+                        dtype_key
+                    ]["optional"].items():
+                        if optional_key not in entry:
                             logger.debug(
-                                f"Optional key: `{nested_optional_key}` "
-                                f"missing for {nested_data_type}"
+                                f"Optional key: `{optional_key}` missing for "
+                                f"{dtype_key}.{idx}"
                             )
                         else:
                             logger.debug(
-                                f"Optional key: `{nested_optional_key}` found "
-                                f"for {nested_data_type}"
+                                f"Optional key: `{optional_key}` found for "
+                                f"{dtype_key}.{idx}"
                             )
-                    # Check stray key for nested data type
+                            # Set nested type name for easier access
+                            nested_dtype = f"{dtype_key}.{idx}.{optional_key}"
+                            nested_mandatory_keys_schema = PATTERNS_SCHEMA[
+                                dtype_key
+                            ]["optional"][optional_key]["mandatory"]
+                            nested_optional_keys_schema = PATTERNS_SCHEMA[
+                                dtype_key
+                            ]["optional"][optional_key]["optional"]
+                            # Check mandatory keys for nested type
+                            self._validate_mandatory_keys(
+                                keys=list(optional_val["mandatory"]),
+                                schema=nested_mandatory_keys_schema,
+                                data_type=nested_dtype,
+                                partial_pattern_ok=partial_pattern_ok,
+                            )
+                            # Check optional keys for nested type
+                            for (
+                                nested_optional_key
+                            ) in nested_optional_keys_schema:
+                                if (
+                                    nested_optional_key
+                                    not in optional_val["optional"]
+                                ):
+                                    logger.debug(
+                                        f"Optional key: "
+                                        f"`{nested_optional_key}` missing for "
+                                        f"{nested_dtype}"
+                                    )
+                                else:
+                                    logger.debug(
+                                        f"Optional key: "
+                                        f"`{nested_optional_key}` found for "
+                                        f"{nested_dtype}"
+                                    )
+                            # Check stray key for nested data type
+                            self._identify_stray_keys(
+                                keys=(
+                                    optional_val["mandatory"]
+                                    + optional_val["optional"]
+                                ),
+                                schema=(
+                                    nested_mandatory_keys_schema
+                                    + nested_optional_keys_schema
+                                ),
+                                data_type=nested_dtype,
+                            )
+                    # Check stray key for data type
                     self._identify_stray_keys(
-                        keys=optional_val["mandatory"]
-                        + optional_val["optional"],
-                        schema=nested_mandatory_keys_schema
-                        + nested_optional_keys_schema,
-                        data_type=nested_data_type,
+                        keys=list(entry.keys()),
+                        schema=(
+                            PATTERNS_SCHEMA[dtype_key]["mandatory"]
+                            + list(
+                                PATTERNS_SCHEMA[dtype_key]["optional"].keys()
+                            )
+                        ),
+                        data_type=dtype_key,
                     )
-            # Check stray key for data type
-            self._identify_stray_keys(
-                keys=list(data_type_val.keys()),
-                schema=(
-                    PATTERNS_SCHEMA[data_type_key]["mandatory"]
-                    + list(PATTERNS_SCHEMA[data_type_key]["optional"].keys())
-                ),
-                data_type=data_type_key,
-            )
-            # Wildcard check in patterns
-            if "}*" in data_type_val.get("pattern", ""):
-                raise_error(
-                    msg=(
-                        f"`{data_type_key}.pattern` must not contain `*` "
-                        "following a replacement"
-                    ),
-                    klass=ValueError,
+                    # Wildcard check in patterns
+                    if "}*" in entry.get("pattern", ""):
+                        raise_error(
+                            msg=(
+                                f"`{dtype_key}.pattern` must not contain `*` "
+                                "following a replacement"
+                            ),
+                            klass=ValueError,
+                        )
+            else:
+                # Check mandatory keys for data type
+                self._validate_mandatory_keys(
+                    keys=list(dtype_val),
+                    schema=PATTERNS_SCHEMA[dtype_key]["mandatory"],
+                    data_type=dtype_key,
+                    partial_pattern_ok=partial_pattern_ok,
                 )
+                # Check optional keys for data type
+                for optional_key, optional_val in PATTERNS_SCHEMA[dtype_key][
+                    "optional"
+                ].items():
+                    if optional_key not in dtype_val:
+                        logger.debug(
+                            f"Optional key: `{optional_key}` missing for "
+                            f"{dtype_key}."
+                        )
+                    else:
+                        logger.debug(
+                            f"Optional key: `{optional_key}` found for "
+                            f"{dtype_key}."
+                        )
+                        # Set nested type name for easier access
+                        nested_dtype = f"{dtype_key}.{optional_key}"
+                        nested_mandatory_keys_schema = PATTERNS_SCHEMA[
+                            dtype_key
+                        ]["optional"][optional_key]["mandatory"]
+                        nested_optional_keys_schema = PATTERNS_SCHEMA[
+                            dtype_key
+                        ]["optional"][optional_key]["optional"]
+                        # Check mandatory keys for nested type
+                        self._validate_mandatory_keys(
+                            keys=list(optional_val["mandatory"]),
+                            schema=nested_mandatory_keys_schema,
+                            data_type=nested_dtype,
+                            partial_pattern_ok=partial_pattern_ok,
+                        )
+                        # Check optional keys for nested type
+                        for nested_optional_key in nested_optional_keys_schema:
+                            if (
+                                nested_optional_key
+                                not in optional_val["optional"]
+                            ):
+                                logger.debug(
+                                    f"Optional key: `{nested_optional_key}` "
+                                    f"missing for {nested_dtype}"
+                                )
+                            else:
+                                logger.debug(
+                                    f"Optional key: `{nested_optional_key}` "
+                                    f"found for {nested_dtype}"
+                                )
+                        # Check stray key for nested data type
+                        self._identify_stray_keys(
+                            keys=(
+                                optional_val["mandatory"]
+                                + optional_val["optional"]
+                            ),
+                            schema=(
+                                nested_mandatory_keys_schema
+                                + nested_optional_keys_schema
+                            ),
+                            data_type=nested_dtype,
+                        )
+                # Check stray key for data type
+                self._identify_stray_keys(
+                    keys=list(dtype_val.keys()),
+                    schema=(
+                        PATTERNS_SCHEMA[dtype_key]["mandatory"]
+                        + list(PATTERNS_SCHEMA[dtype_key]["optional"].keys())
+                    ),
+                    data_type=dtype_key,
+                )
+                # Wildcard check in patterns
+                if "}*" in dtype_val.get("pattern", ""):
+                    raise_error(
+                        msg=(
+                            f"`{dtype_key}.pattern` must not contain `*` "
+                            "following a replacement"
+                        ),
+                        klass=ValueError,
+                    )
 
         # Validate replacements
         self._validate_replacements(

--- a/junifer/datagrabber/tests/test_dmcc13_benchmark.py
+++ b/junifer/datagrabber/tests/test_dmcc13_benchmark.py
@@ -116,7 +116,12 @@ def test_DMCC13Benchmark(
             data_file_names.extend(
                 [
                     "sub-01_desc-preproc_T1w.nii.gz",
-                    "sub-01_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5",
+                    [
+                        "sub-01_from-MNI152NLin2009cAsym_to-T1w"
+                        "_mode-image_xfm.h5",
+                        "sub-01_from-T1w_to-MNI152NLin2009cAsym"
+                        "_mode-image_xfm.h5",
+                    ],
                 ]
             )
         else:
@@ -127,14 +132,26 @@ def test_DMCC13Benchmark(
         for data_type, data_file_name in zip(data_types, data_file_names):
             # Assert data type
             assert data_type in out
-            # Assert data file path exists
-            assert out[data_type]["path"].exists()
-            # Assert data file path is a file
-            assert out[data_type]["path"].is_file()
-            # Assert data file name
-            assert out[data_type]["path"].name == data_file_name
-            # Assert metadata
-            assert "meta" in out[data_type]
+            # Conditional for Warp
+            if data_type == "Warp":
+                for idx, fname in enumerate(data_file_name):
+                    # Assert data file path exists
+                    assert out[data_type][idx]["path"].exists()
+                    # Assert data file path is a file
+                    assert out[data_type][idx]["path"].is_file()
+                    # Assert data file name
+                    assert out[data_type][idx]["path"].name == fname
+                    # Assert metadata
+                    assert "meta" in out[data_type][idx]
+            else:
+                # Assert data file path exists
+                assert out[data_type]["path"].exists()
+                # Assert data file path is a file
+                assert out[data_type]["path"].is_file()
+                # Assert data file name
+                assert out[data_type]["path"].name == data_file_name
+                # Assert metadata
+                assert "meta" in out[data_type]
 
         # Check BOLD nested data types
         for type_, file_name in zip(

--- a/junifer/pipeline/pipeline_step_mixin.py
+++ b/junifer/pipeline/pipeline_step_mixin.py
@@ -197,17 +197,13 @@ class PipelineStepMixin:
                         if dependency["using"] == obj.using:
                             depends_on = dependency["depends_on"]
                             # Conditional to make `using="auto"` work
-                            if isinstance(depends_on, list):
-                                for entry in depends_on:
-                                    # Check dependencies
-                                    _check_dependencies(entry)
-                                    # Check external dependencies
-                                    _check_ext_dependencies(entry)
-                            else:
+                            if not isinstance(depends_on, list):
+                                depends_on = [depends_on]
+                            for entry in depends_on:
                                 # Check dependencies
-                                _check_dependencies(depends_on)
+                                _check_dependencies(entry)
                                 # Check external dependencies
-                                _check_ext_dependencies(depends_on)
+                                _check_ext_dependencies(entry)
 
         # Check dependencies
         _check_dependencies(self)

--- a/junifer/pipeline/pipeline_step_mixin.py
+++ b/junifer/pipeline/pipeline_step_mixin.py
@@ -196,10 +196,18 @@ class PipelineStepMixin:
                     for dependency in obj._CONDITIONAL_DEPENDENCIES:
                         if dependency["using"] == obj.using:
                             depends_on = dependency["depends_on"]
-                            # Check dependencies
-                            _check_dependencies(depends_on)
-                            # Check external dependencies
-                            _check_ext_dependencies(depends_on)
+                            # Conditional to make `using="auto"` work
+                            if isinstance(depends_on, list):
+                                for entry in depends_on:
+                                    # Check dependencies
+                                    _check_dependencies(entry)
+                                    # Check external dependencies
+                                    _check_ext_dependencies(entry)
+                            else:
+                                # Check dependencies
+                                _check_dependencies(depends_on)
+                                # Check external dependencies
+                                _check_ext_dependencies(depends_on)
 
         # Check dependencies
         _check_dependencies(self)

--- a/junifer/pipeline/update_meta_mixin.py
+++ b/junifer/pipeline/update_meta_mixin.py
@@ -36,17 +36,35 @@ class UpdateMetaMixin:
         for k, v in vars(self).items():
             if not k.startswith("_"):
                 t_meta[k] = v
-        # Add "meta" to the step's local context dict
-        if "meta" not in input:
-            input["meta"] = {}
-        # Add step name
-        input["meta"][step_name] = t_meta
-        # Add step dependencies
-        if "dependencies" not in input["meta"]:
-            input["meta"]["dependencies"] = set()
-        # Update step dependencies
-        dependencies = getattr(self, "_DEPENDENCIES", set())
-        if dependencies is not None:
-            if not isinstance(dependencies, (set, list)):
-                dependencies = {dependencies}
-            input["meta"]["dependencies"].update(dependencies)
+        # Conditional for list dtype vals like Warp
+        if isinstance(input, list):
+            for entry in input:
+                # Add "meta" to the step's entry's local context dict
+                if "meta" not in entry:
+                    entry["meta"] = {}
+                # Add step name
+                entry["meta"][step_name] = t_meta
+                # Add step dependencies
+                if "dependencies" not in entry["meta"]:
+                    entry["meta"]["dependencies"] = set()
+                # Update step dependencies
+                dependencies = getattr(self, "_DEPENDENCIES", set())
+                if dependencies is not None:
+                    if not isinstance(dependencies, (set, list)):
+                        dependencies = {dependencies}
+                    entry["meta"]["dependencies"].update(dependencies)
+        else:
+            # Add "meta" to the step's local context dict
+            if "meta" not in input:
+                input["meta"] = {}
+            # Add step name
+            input["meta"][step_name] = t_meta
+            # Add step dependencies
+            if "dependencies" not in input["meta"]:
+                input["meta"]["dependencies"] = set()
+            # Update step dependencies
+            dependencies = getattr(self, "_DEPENDENCIES", set())
+            if dependencies is not None:
+                if not isinstance(dependencies, (set, list)):
+                    dependencies = {dependencies}
+                input["meta"]["dependencies"].update(dependencies)

--- a/junifer/pipeline/update_meta_mixin.py
+++ b/junifer/pipeline/update_meta_mixin.py
@@ -4,7 +4,7 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import Dict
+from typing import Dict, List, Union
 
 
 __all__ = ["UpdateMetaMixin"]
@@ -15,14 +15,14 @@ class UpdateMetaMixin:
 
     def update_meta(
         self,
-        input: Dict,
+        input: Union[Dict, List[Dict]],
         step_name: str,
     ) -> None:
         """Update metadata.
 
         Parameters
         ----------
-        input : dict
+        input : dict or list of dict
             The data object to update.
         step_name : str
             The name of the pipeline step.
@@ -37,34 +37,20 @@ class UpdateMetaMixin:
             if not k.startswith("_"):
                 t_meta[k] = v
         # Conditional for list dtype vals like Warp
-        if isinstance(input, list):
-            for entry in input:
-                # Add "meta" to the step's entry's local context dict
-                if "meta" not in entry:
-                    entry["meta"] = {}
-                # Add step name
-                entry["meta"][step_name] = t_meta
-                # Add step dependencies
-                if "dependencies" not in entry["meta"]:
-                    entry["meta"]["dependencies"] = set()
-                # Update step dependencies
-                dependencies = getattr(self, "_DEPENDENCIES", set())
-                if dependencies is not None:
-                    if not isinstance(dependencies, (set, list)):
-                        dependencies = {dependencies}
-                    entry["meta"]["dependencies"].update(dependencies)
-        else:
-            # Add "meta" to the step's local context dict
-            if "meta" not in input:
-                input["meta"] = {}
+        if not isinstance(input, list):
+            input = [input]
+        for entry in input:
+            # Add "meta" to the step's entry's local context dict
+            if "meta" not in entry:
+                entry["meta"] = {}
             # Add step name
-            input["meta"][step_name] = t_meta
+            entry["meta"][step_name] = t_meta
             # Add step dependencies
-            if "dependencies" not in input["meta"]:
-                input["meta"]["dependencies"] = set()
+            if "dependencies" not in entry["meta"]:
+                entry["meta"]["dependencies"] = set()
             # Update step dependencies
             dependencies = getattr(self, "_DEPENDENCIES", set())
             if dependencies is not None:
                 if not isinstance(dependencies, (set, list)):
                     dependencies = {dependencies}
-                input["meta"]["dependencies"].update(dependencies)
+                entry["meta"]["dependencies"].update(dependencies)

--- a/junifer/preprocess/warping/_ants_warper.py
+++ b/junifer/preprocess/warping/_ants_warper.py
@@ -15,7 +15,7 @@ import numpy as np
 from ...data import get_template, get_xfm
 from ...pipeline import WorkDirManager
 from ...typing import Dependencies, ExternalDependencies
-from ...utils import logger, run_ext_cmd
+from ...utils import logger, raise_error, run_ext_cmd
 
 
 __all__ = ["ANTsWarper"]
@@ -63,6 +63,11 @@ class ANTsWarper:
             values and new ``reference_path`` key whose value points to the
             reference file used for warping.
 
+        Raises
+        ------
+        RuntimeError
+            If warp file path could not be found in ``extra_input``.
+
         """
         # Create element-specific tempdir for storing post-warping assets
         element_tempdir = WorkDirManager().get_element_tempdir(
@@ -76,6 +81,17 @@ class ANTsWarper:
             # Get the min of the voxel sizes from input and use it as the
             # resolution
             resolution = np.min(input["data"].header.get_zooms()[:3])
+
+            # Get warp file path
+            warp_file_path = None
+            for entry in extra_input["Warp"]:
+                if entry["dst"] == "native":
+                    warp_file_path = entry["path"]
+            if warp_file_path is None:
+                raise_error(
+                    klass=RuntimeError,
+                    msg="Could not find correct warp file path",
+                )
 
             # Create a tempfile for resampled reference output
             resample_image_out_path = (
@@ -105,7 +121,7 @@ class ANTsWarper:
                 f"-i {input['path'].resolve()}",
                 # use resampled reference
                 f"-r {resample_image_out_path.resolve()}",
-                f"-t {extra_input['Warp']['path'].resolve()}",
+                f"-t {warp_file_path.resolve()}",
                 f"-o {apply_transforms_out_path.resolve()}",
             ]
             # Call antsApplyTransforms

--- a/junifer/preprocess/warping/_ants_warper.py
+++ b/junifer/preprocess/warping/_ants_warper.py
@@ -131,6 +131,8 @@ class ANTsWarper:
             input["data"] = nib.load(apply_transforms_out_path)
             # Save resampled reference path
             input["reference_path"] = resample_image_out_path
+            # Keep pre-warp space for further operations
+            input["prewarp_space"] = input["space"]
             # Use reference input's space as warped input's space
             input["space"] = extra_input["T1w"]["space"]
 
@@ -179,6 +181,9 @@ class ANTsWarper:
 
             # Modify target data
             input["data"] = nib.load(warped_output_path)
+            # Keep pre-warp space for further operations
+            input["prewarp_space"] = input["space"]
+            # Update warped input's space
             input["space"] = reference
 
         return input

--- a/junifer/preprocess/warping/_fsl_warper.py
+++ b/junifer/preprocess/warping/_fsl_warper.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from ...pipeline import WorkDirManager
 from ...typing import Dependencies, ExternalDependencies
-from ...utils import logger, run_ext_cmd
+from ...utils import logger, raise_error, run_ext_cmd
 
 
 __all__ = ["FSLWarper"]
@@ -59,12 +59,27 @@ class FSLWarper:
             values and new ``reference_path`` key whose value points to the
             reference file used for warping.
 
+        Raises
+        ------
+        RuntimeError
+            If warp file path could not be found in ``extra_input``.
+
         """
         logger.debug("Using FSL for space warping")
 
         # Get the min of the voxel sizes from input and use it as the
         # resolution
         resolution = np.min(input["data"].header.get_zooms()[:3])
+
+        # Get warp file path
+        warp_file_path = None
+        for entry in extra_input["Warp"]:
+            if entry["dst"] == "native":
+                warp_file_path = entry["path"]
+        if warp_file_path is None:
+            raise_error(
+                klass=RuntimeError, msg="Could not find correct warp file path"
+            )
 
         # Create element-specific tempdir for storing post-warping assets
         element_tempdir = WorkDirManager().get_element_tempdir(
@@ -93,7 +108,7 @@ class FSLWarper:
             "--interp=spline",
             f"-i {input['path'].resolve()}",
             f"-r {flirt_out_path.resolve()}",  # use resampled reference
-            f"-w {extra_input['Warp']['path'].resolve()}",
+            f"-w {warp_file_path.resolve()}",
             f"-o {applywarp_out_path.resolve()}",
         ]
         # Call applywarp

--- a/junifer/preprocess/warping/_fsl_warper.py
+++ b/junifer/preprocess/warping/_fsl_warper.py
@@ -118,7 +118,8 @@ class FSLWarper:
         input["data"] = nib.load(applywarp_out_path)
         # Save resampled reference path
         input["reference_path"] = flirt_out_path
-
+        # Keep pre-warp space for further operations
+        input["prewarp_space"] = input["space"]
         # Use reference input's space as warped input's space
         input["space"] = extra_input["T1w"]["space"]
 

--- a/tools/create_dmcc13_benchmark_example_dataset.py
+++ b/tools/create_dmcc13_benchmark_example_dataset.py
@@ -78,7 +78,11 @@ if __name__ == "__main__":
                 (
                     f"anat/sub-{sub:02d}_from-MNI152NLin2009cAsym_to-T1w_"
                     "mode-image_xfm.h5"
-                ),  # Warp
+                ),  # Warp to native
+                (
+                    f"anat/sub-{sub:02d}_from-T1w_to-MNI152NLin2009cAsym_"
+                    "mode-image_xfm.h5"
+                ),  # Warp from native
             ]
 
             # Tasks for functional data

--- a/tools/create_hcp1200_example_dataset.py
+++ b/tools/create_hcp1200_example_dataset.py
@@ -44,11 +44,15 @@ if __name__ == "__main__":
             sub_warp_datadir = subdir / "MNINonLinear" / "xfms"
             # Create subject data directory
             sub_warp_datadir.mkdir(parents=True)
-            # Set subject data file
-            sub_warp_datafile = sub_warp_datadir / "standard2acpc_dc.nii.gz"
-            # Write subject data file
-            with open(sub_warp_datafile, "w") as f:
-                f.write("placeholder")
+            # Set subject data files
+            sub_warp_datafiles = [
+                sub_warp_datadir / "standard2acpc_dc.nii.gz",
+                sub_warp_datadir / "acpc_dc2standard.nii.gz",
+            ]
+            # Write subject data files
+            for datafile in sub_warp_datafiles:
+                with open(datafile, "w") as f:
+                    f.write("placeholder")
 
             # BOLD data
             for task, phase_encoding in product(


### PR DESCRIPTION
1) Modify the `Warp` datatype to be a "list" of mappings from / to spaces.
2) Add a `"warper"` key to the `Warp` datatype indicating which warper was used: `fsl` or `ants` for the moment.
3) Modify the `SpaceWarper` to allow to `"auto"` select the warper based on the dataset. This should require both FSL and ANTs as external dependencies. This only works if reference is `"T1w"`: `"auto"` is not defined for junifer internal transforms (i.e. between template spaces)
4) Modify coordinates/masks/parcellations so they check for the right transform and use the "warper" parameter accordingly.