### PR TITLE
[BUG]: Coordinates transforms to native space using `ANTs` are off

### DIFF
--- a/docs/changes/newsfragments/388.bugfix
+++ b/docs/changes/newsfragments/388.bugfix
@@ -1,0 +1,1 @@
+Fix coordinates space transformation using ANTs by `Synchon Mandal`_

--- a/junifer/data/coordinates/_ants_coordinates_warper.py
+++ b/junifer/data/coordinates/_ants_coordinates_warper.py
@@ -55,7 +55,7 @@ class ANTsCoordinatesWarper:
 
         # Save existing coordinates to a tempfile
         pretransform_coordinates_path = (
-            element_tempdir / "pretransform_coordinates.txt"
+            element_tempdir / "pretransform_coordinates.csv"
         )
         np.savetxt(
             pretransform_coordinates_path,
@@ -68,7 +68,7 @@ class ANTsCoordinatesWarper:
 
         # Create a tempfile for transformed coordinates output
         transformed_coords_path = (
-            element_tempdir / "coordinates_transformed.txt"
+            element_tempdir / "coordinates_transformed.csv"
         )
         # Set antsApplyTransformsToPoints command
         apply_transforms_to_points_cmd = [

--- a/junifer/data/coordinates/_ants_coordinates_warper.py
+++ b/junifer/data/coordinates/_ants_coordinates_warper.py
@@ -57,10 +57,12 @@ class ANTsCoordinatesWarper:
         pretransform_coordinates_path = (
             element_tempdir / "pretransform_coordinates.csv"
         )
+        # Convert LPS to RAS
+        seeds[:, 0] *= -1
+        seeds[:, 1] *= -1
         np.savetxt(
             pretransform_coordinates_path,
-            # convert to LPS coordinate system
-            np.apply_along_axis(lambda x: x * [-1, -1, 1], 1, seeds),
+            seeds,
             delimiter=",",
             # Add header while saving to make ANTs work
             header="x,y,z",
@@ -95,7 +97,8 @@ class ANTsCoordinatesWarper:
             delimiter=",",
             skiprows=1,
         )
-        # convert to RAS coordinate system
-        return np.apply_along_axis(
-            lambda x: x * [-1, -1, 1], 1, transformed_seeds
-        )
+        # Convert RAS to LPS
+        transformed_seeds[:, 0] *= -1
+        transformed_seeds[:, 1] *= -1
+
+        return transformed_seeds

--- a/junifer/data/coordinates/_ants_coordinates_warper.py
+++ b/junifer/data/coordinates/_ants_coordinates_warper.py
@@ -59,7 +59,8 @@ class ANTsCoordinatesWarper:
         )
         np.savetxt(
             pretransform_coordinates_path,
-            seeds,
+            # convert to LPS coordinate system
+            np.apply_along_axis(lambda x: x * [-1, -1, 1], 1, seeds),
             delimiter=",",
             # Add header while saving to make ANTs work
             header="x,y,z",
@@ -86,9 +87,13 @@ class ANTsCoordinatesWarper:
         )
 
         # Load coordinates
-        return np.loadtxt(
+        transformed_seeds = np.loadtxt(
             # Skip header when reading
             transformed_coords_path,
             delimiter=",",
             skiprows=1,
+        )
+        # convert to RAS coordinate system
+        return np.apply_along_axis(
+            lambda x: x * [-1, -1, 1], 1, transformed_seeds
         )

--- a/junifer/data/coordinates/_ants_coordinates_warper.py
+++ b/junifer/data/coordinates/_ants_coordinates_warper.py
@@ -64,6 +64,8 @@ class ANTsCoordinatesWarper:
             delimiter=",",
             # Add header while saving to make ANTs work
             header="x,y,z",
+            # Remove comment tag for header
+            comments="",
         )
 
         # Create a tempfile for transformed coordinates output

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -362,7 +362,7 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                 seeds = ANTsCoordinatesWarper().warp(
                     seeds=seeds,
                     target_data=target_data,
-                    warp_data=warper_spec,
+                    warp_data=inverse_warper_spec,
                 )
 
         return seeds, labels


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

When computing any marker on coordinates in native space, the coordinates in native space do not match the corresponding landmark in MNI space.

These are two examples in which the left (MNI space) do not match the right (T1w space).

In this first example, the coordinates are off-brain:

![Screenshot 2024-11-06 at 10 04 17 (2)](https://github.com/user-attachments/assets/e3a9c589-4b65-4400-ad82-0df1ecdec433)

In this second example, the coordinates are in the brain, but not in the same landmark:

![Screenshot 2024-11-06 at 10 06 17 (2)](https://github.com/user-attachments/assets/74a3ab21-c27c-42f8-b3c2-d7a5c1c97c81)

 

### Expected Behavior

I expect that the coordinates point to the right landmark.

### Steps To Reproduce

1. With latest junifer (main branch)
2. Modify the `WorkdirManager` code so that temporary directories are not cleaned.
3. Compute (f)ALFF on Aomic's `sub-0001` using `"Power2011"` using this script:
```
# %%
import pickle
from junifer.datagrabber.aomic import DataladAOMICID1000
from junifer.utils import configure_logging
from junifer.pipeline import WorkDirManager

configure_logging(level="DEBUG")

WorkDirManager(
    workdir="/home/fraimondo/dev/scratch/test_junifer_native/temp",
    cleanup=False,
)

element = "sub-0001"
# %% Load data

dg = DataladAOMICID1000(
    native_t1w=True,
    datadir="/home/fraimondo/test_datasets/aomic_id1000/",
    types=["BOLD", "T1w", "Warp"]
)

with dg:
    data = dg[element]

    # %% Read data
    from junifer.datareader import DefaultDataReader

    reader = DefaultDataReader()
    data = reader.fit_transform(data)

    pickle.dump(data, open(f"aomic_{element}_read.pkl", "wb"))
    # # %% Preprocess
    from junifer.preprocess import fMRIPrepConfoundRemover

    confound = fMRIPrepConfoundRemover(
        detrend=True,
        standardize=True,
        strategy={
            "motion": "full",
            "wm_csf": "full",
            "global_signal": "full",
        },
        # masks=["inherit", "compute_epi_mask", {"threshold": 0}],
        masks=["inherit"],
    )

    data = confound.fit_transform(data)

    pickle.dump(data, open(f"aomic_{element}_deconfounded.pkl", "wb"))

    # %% Warp
    from junifer.preprocess import SpaceWarper

    warper = SpaceWarper(reference="T1w", on="BOLD", using="ants")

    data = warper.fit_transform(data)
    pickle.dump(data, open(f"aomic_{element}_warped.pkl", "wb"))
  
    # %%  Compute marker
    # data = pickle.load(open(f"aomic_{element}_warped.pkl", "rb"))
    from junifer.markers import ALFFSpheres


    marker = ALFFSpheres(
        coords="Power2011",
        radius=5,
        allow_overlap=True,
        using="afni",
        agg_method="mean",
        highpass=0.01,
        lowpass=0.08,
        masks="inherit",
    )
    out = marker.fit_transform(data)

    pickle.dump(out, open(f"aomic_{element}_out.pkl", "wb"))
```

4. Check the output and temporary directory and find the pretransformed and transformed coordinates. Visualize them in the MNI and T1w images.

### Environment

```markdown
junifer:
  version: 0.0.6.dev176
python:
  version: 3.12.6
  implementation: CPython
dependencies:
  click: 8.1.7
  numpy: 1.26.4
  scipy: 1.14.1
  datalad: 1.1.3
  pandas: 2.2.2
  nibabel: 5.2.1
  ruamel.yaml: 0.17.40
  looseversion: None
system:
  platform: Linux-6.6.13+bpo-amd64-x86_64-with-glibc2.36
environment:
  PATH:
    /data/group/appliedml/tools/ants_2.5.0/binaries:/home/fraimondo/miniconda3/envs/junifer/bin:/home/fraimondo/miniconda3/condabin:/usr/local/bin:/usr/bin:/bin:/usr/games
```


### Relevant log output

```shell
[WARNING] Requested extension 'next' is not available
2024-11-05 11:23:10,090 - JUNIFER - INFO - ===== Lib Versions =====
2024-11-05 11:23:10,090 - JUNIFER - INFO - numpy: 1.26.4
2024-11-05 11:23:10,090 - JUNIFER - INFO - junifer: 0.0.6.dev176
2024-11-05 11:23:10,090 - JUNIFER - INFO - ========================
2024-11-05 11:23:10,090 - JUNIFER - DEBUG - Initializing PatternDataladDataGrabber
2024-11-05 11:23:10,090 - JUNIFER - DEBUG - 	types = ['BOLD', 'T1w', 'Warp']
2024-11-05 11:23:10,090 - JUNIFER - DEBUG - 	datadir = /home/fraimondo/test_datasets/aomic_id1000/
2024-11-05 11:23:10,090 - JUNIFER - DEBUG - 	uri = https://github.com/OpenNeuroDatasets/ds003097.git
2024-11-05 11:23:10,090 - JUNIFER - DEBUG - 	patterns = {'BOLD': {'pattern': 'derivatives/fmriprep/{subject}/func/{subject}_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz', 'space': 'MNI152NLin2009cAsym', 'mask': {'pattern': 'derivatives/fmriprep/{subject}/func/{subject}_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'confounds': {'pattern': 'derivatives/fmriprep/{subject}/func/{subject}_task-moviewatching_desc-confounds_regressors.tsv', 'format': 'fmriprep'}}, 'T1w': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_desc-preproc_T1w.nii.gz', 'space': 'native', 'mask': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_desc-brain_mask.nii.gz', 'space': 'native'}}, 'VBM_CSF': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_space-MNI152NLin2009cAsym_label-CSF_probseg.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'VBM_GM': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_space-MNI152NLin2009cAsym_label-GM_probseg.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'VBM_WM': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'DWI': {'pattern': 'derivatives/dwipreproc/{subject}/dwi/{subject}_desc-preproc_dwi.nii.gz'}, 'FreeSurfer': {'pattern': 'derivatives/freesurfer/[!f]{subject}/mri/T1.mg[z]', 'aseg': {'pattern': 'derivatives/freesurfer/[!f]{subject}/mri/aseg.mg[z]'}, 'norm': {'pattern': 'derivatives/freesurfer/[!f]{subject}/mri/norm.mg[z]'}, 'lh_white': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/lh.whit[e]'}, 'rh_white': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/rh.whit[e]'}, 'lh_pial': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/lh.pia[l]'}, 'rh_pial': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/rh.pia[l]'}}, 'Warp': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5', 'src': 'MNI152NLin2009cAsym', 'dst': 'native'}}
2024-11-05 11:23:10,090 - JUNIFER - DEBUG - 	replacements = ['subject']
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - 	confounds_format = fmriprep
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `pattern` found for BOLD
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `space` found for BOLD
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Optional key: `mask` found for BOLD
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `pattern` found for BOLD.mask
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `space` found for BOLD.mask
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Optional key: `confounds` found for BOLD
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `pattern` found for BOLD.confounds
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `format` found for BOLD.confounds
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Optional key: `mappings` found for BOLD.confounds
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `pattern` found for T1w
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `space` found for T1w
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Optional key: `mask` found for T1w
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `pattern` found for T1w.mask
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `space` found for T1w.mask
2024-11-05 11:23:10,091 - JUNIFER - DEBUG - Mandatory key: `pattern` found for VBM_CSF
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `space` found for VBM_CSF
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `pattern` found for VBM_GM
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `space` found for VBM_GM
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `pattern` found for VBM_WM
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `space` found for VBM_WM
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `pattern` found for DWI
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `pattern` found for FreeSurfer
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Optional key: `aseg` found for FreeSurfer
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `pattern` found for FreeSurfer.aseg
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Optional key: `norm` found for FreeSurfer
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `pattern` found for FreeSurfer.norm
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Optional key: `lh_white` found for FreeSurfer
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Mandatory key: `pattern` found for FreeSurfer.lh_white
2024-11-05 11:23:10,092 - JUNIFER - DEBUG - Optional key: `rh_white` found for FreeSurfer
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Mandatory key: `pattern` found for FreeSurfer.rh_white
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Optional key: `lh_pial` found for FreeSurfer
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Mandatory key: `pattern` found for FreeSurfer.lh_pial
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Optional key: `rh_pial` found for FreeSurfer
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Mandatory key: `pattern` found for FreeSurfer.rh_pial
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Mandatory key: `pattern` found for Warp
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Mandatory key: `src` found for Warp
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Mandatory key: `dst` found for Warp
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Initializing BaseDataGrabber
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - 	_datadir = /home/fraimondo/test_datasets/aomic_id1000
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - 	types = ['BOLD', 'T1w', 'Warp']
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Initializing PatternDataGrabber
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - 	patterns = {'BOLD': {'pattern': 'derivatives/fmriprep/{subject}/func/{subject}_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz', 'space': 'MNI152NLin2009cAsym', 'mask': {'pattern': 'derivatives/fmriprep/{subject}/func/{subject}_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'confounds': {'pattern': 'derivatives/fmriprep/{subject}/func/{subject}_task-moviewatching_desc-confounds_regressors.tsv', 'format': 'fmriprep'}}, 'T1w': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_desc-preproc_T1w.nii.gz', 'space': 'native', 'mask': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_desc-brain_mask.nii.gz', 'space': 'native'}}, 'VBM_CSF': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_space-MNI152NLin2009cAsym_label-CSF_probseg.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'VBM_GM': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_space-MNI152NLin2009cAsym_label-GM_probseg.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'VBM_WM': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz', 'space': 'MNI152NLin2009cAsym'}, 'DWI': {'pattern': 'derivatives/dwipreproc/{subject}/dwi/{subject}_desc-preproc_dwi.nii.gz'}, 'FreeSurfer': {'pattern': 'derivatives/freesurfer/[!f]{subject}/mri/T1.mg[z]', 'aseg': {'pattern': 'derivatives/freesurfer/[!f]{subject}/mri/aseg.mg[z]'}, 'norm': {'pattern': 'derivatives/freesurfer/[!f]{subject}/mri/norm.mg[z]'}, 'lh_white': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/lh.whit[e]'}, 'rh_white': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/rh.whit[e]'}, 'lh_pial': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/lh.pia[l]'}, 'rh_pial': {'pattern': 'derivatives/freesurfer/[!f]{subject}/surf/rh.pia[l]'}}, 'Warp': {'pattern': 'derivatives/fmriprep/{subject}/anat/{subject}_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5', 'src': 'MNI152NLin2009cAsym', 'dst': 'native'}}
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - 	replacements = ['subject']
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - 	confounds_format = fmriprep
2024-11-05 11:23:10,093 - JUNIFER - DEBUG - Initializing DataladDataGrabber
2024-11-05 11:23:10,094 - JUNIFER - DEBUG - 	uri = https://github.com/OpenNeuroDatasets/ds003097.git
2024-11-05 11:23:10,094 - JUNIFER - DEBUG - 	_rootdir = .
[DEBUG  ] Run ['git', 'version'] (protocol_class=StdOutErrCapture) (cwd=None)
[DEBUG  ] Finished ['git', 'version'] with status 0
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin'] (protocol_class=StdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin'] with status 0
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin', '--file', '/home/fraimondo/test_datasets/aomic_id1000/.datalad/config'] (protocol_class=StdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin', '--file', '/home/fraimondo/test_datasets/aomic_id1000/.datalad/config'] with status 0
2024-11-05 11:23:10,106 - JUNIFER - DEBUG - Dataset already installed
2024-11-05 11:23:10,106 - JUNIFER - DEBUG - Querying https://github.com/OpenNeuroDatasets/ds003097.git for dataset ID
[DEBUG  ] Git clone from https://github.com/OpenNeuroDatasets/ds003097.git to /tmp/tmpuuwkuaq4
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'clone', '--progress', '-n', '--depth=1', 'https://github.com/OpenNeuroDatasets/ds003097.git', '/tmp/tmpuuwkuaq4'] (protocol_class=GitProgress) (cwd=None)
[DEBUG  ] Non-progress stderr: b"Cloning into '/tmp/tmpuuwkuaq4'...\n"
[DEBUG  ] Non-progress stderr: b'remote: Total 362591 (delta 6578), reused 362588 (delta 6578), pack-reused 0 (from 0)        \n'
[DEBUG  ] Finished ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'clone', '--progress', '-n', '--depth=1', 'https://github.com/OpenNeuroDatasets/ds003097.git', '/tmp/tmpuuwkuaq4'] with status 0
[DEBUG  ] Git clone completed
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin'] (protocol_class=StdOutErrCapture) (cwd=/tmp/tmpuuwkuaq4)
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin'] with status 0
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'checkout', 'HEAD', '.datalad/config'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/tmp/tmpuuwkuaq4)
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/tmpuuwkuaq4/.datalad/config'] (protocol_class=StdOutErrCapture) (cwd=/tmp/tmpuuwkuaq4)
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin', '--file', '/tmp/tmpuuwkuaq4/.datalad/config'] with status 0
2024-11-05 11:23:37,338 - JUNIFER - DEBUG - Got remote dataset ID = aefe5438-e93b-11ea-ad4c-8e2245da6db7
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin'] (protocol_class=StdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin'] with status 0
[DEBUG  ] Run ['git', 'config', '-z', '-l', '--show-origin', '--file', '/home/fraimondo/test_datasets/aomic_id1000/.datalad/config'] (protocol_class=StdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Finished ['git', 'config', '-z', '-l', '--show-origin', '--file', '/home/fraimondo/test_datasets/aomic_id1000/.datalad/config'] with status 0
[DEBUG  ] Determined class of decorated function: <class 'datalad.core.local.status.Status'>
[DEBUG  ] Resolved dataset to report status: /home/fraimondo/test_datasets/aomic_id1000
[DEBUG  ] Querying AnnexRepo(/home/fraimondo/test_datasets/aomic_id1000).diffstatus() for paths: None
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'rev-parse', '--quiet', '--verify', 'HEAD^{commit}'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] AnnexRepo(/home/fraimondo/test_datasets/aomic_id1000).get_content_info(...)
[DEBUG  ] Query repo: ['ls-files', '--stage', '-z', '--exclude-standard', '-o', '--directory', '--no-empty-directory']
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'ls-files', '--stage', '-z', '--exclude-standard', '-o', '--directory', '--no-empty-directory'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Done query repo: ['ls-files', '--stage', '-z', '--exclude-standard', '-o', '--directory', '--no-empty-directory']
[DEBUG  ] Done AnnexRepo(/home/fraimondo/test_datasets/aomic_id1000).get_content_info(...)
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'ls-files', '-z', '-m', '-d'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] AnnexRepo(/home/fraimondo/test_datasets/aomic_id1000).get_content_info(...)
[DEBUG  ] Query repo: ['ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l']
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Done query repo: ['ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l']
[DEBUG  ] Done AnnexRepo(/home/fraimondo/test_datasets/aomic_id1000).get_content_info(...)
nothing to save, working tree clean
2024-11-05 11:30:56,369 - JUNIFER - DEBUG - Dataset is clean
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'symbolic-ref', 'HEAD'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', 'rev-parse', '--quiet', '--verify', 'HEAD^{commit}'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
2024-11-05 11:30:56,483 - JUNIFER - INFO - Getting element sub-0001
2024-11-05 11:30:56,484 - JUNIFER - DEBUG - Named element: {'subject': 'sub-0001'}
2024-11-05 11:30:56,484 - JUNIFER - INFO - Resolving path from pattern for BOLD
2024-11-05 11:30:56,486 - JUNIFER - INFO - Resolving path from pattern for BOLD.mask
2024-11-05 11:30:56,487 - JUNIFER - INFO - Resolving path from pattern for BOLD.confounds
2024-11-05 11:30:56,487 - JUNIFER - INFO - Resolving path from pattern for T1w
2024-11-05 11:30:56,488 - JUNIFER - INFO - Resolving path from pattern for T1w.mask
2024-11-05 11:30:56,489 - JUNIFER - INFO - Resolving path from pattern for Warp
2024-11-05 11:30:56,489 - JUNIFER - DEBUG - Getting 6 files using datalad:
2024-11-05 11:30:56,489 - JUNIFER - DEBUG - 	: /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
2024-11-05 11:30:56,490 - JUNIFER - DEBUG - 	: /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_desc-confounds_regressors.tsv
2024-11-05 11:30:56,490 - JUNIFER - DEBUG - 	: /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
2024-11-05 11:30:56,490 - JUNIFER - DEBUG - 	: /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-brain_mask.nii.gz
2024-11-05 11:30:56,490 - JUNIFER - DEBUG - 	: /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-preproc_T1w.nii.gz
2024-11-05 11:30:56,491 - JUNIFER - DEBUG - 	: /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5
[DEBUG  ] Determined class of decorated function: <class 'datalad.distribution.get.Get'>
[DEBUG  ] Resolved dataset to get content of <<[PosixPath('/h++872 chars++5')]>>: /home/fraimondo/test_datasets/aomic_id1000
[DEBUG  ] Determined class of decorated function: <class 'datalad.local.subdatasets.Subdatasets'>
[DEBUG  ] Resolved dataset to report on subdataset(s): /home/fraimondo/test_datasets/aomic_id1000
[DEBUG  ] Query subdatasets of Dataset(/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Determine what files match the query to work with
[DEBUG  ] Run ['git', 'annex', 'version', '--raw'] (protocol_class=StdOutErrCapture) (cwd=None)
[DEBUG  ] Finished ['git', 'annex', 'version', '--raw'] with status 0
[DEBUG  ] Run ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', '-c', 'annex.merge-annex-branches=false', 'annex', 'find', '--not', '--in', '.', '--json', '--json-error-messages', '-c', 'annex.dotfiles=true', '--', 'derivatives/fmriprep/sub-0001/anat/sub-0001_desc-preproc_T1w.nii.gz', 'derivatives/fmriprep/sub-0001/anat/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5', 'derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz', 'derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz', 'derivatives/fmriprep/sub-0001/anat/sub-0001_desc-brain_mask.nii.gz', 'derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_desc-confounds_regressors.tsv'] (protocol_class=AnnexJsonProtocol) (cwd=/home/fraimondo/test_datasets/aomic_id1000)
[DEBUG  ] Finished ['git', '-c', 'diff.ignoreSubmodules=none', '-c', 'core.quotepath=false', '-c', 'annex.merge-annex-branches=false', 'annex', 'find', '--not', '--in', '.', '--json', '--json-error-messages', '-c', 'annex.dotfiles=true', '--', 'derivatives/fmriprep/sub-0001/anat/sub-0001_desc-preproc_T1w.nii.gz', 'derivatives/fmriprep/sub-0001/anat/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5', 'derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz', 'derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz', 'derivatives/fmriprep/sub-0001/anat/sub-0001_desc-brain_mask.nii.gz', 'derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_desc-confounds_regressors.tsv'] with status 0
[DEBUG  ] No files found needing fetching.
[DEBUG  ] already present [get(/home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-preproc_T1w.nii.gz)]
[DEBUG  ] already present [get(/home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5)]
[DEBUG  ] already present [get(/home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz)]
[DEBUG  ] already present [get(/home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz)]
[DEBUG  ] already present [get(/home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-brain_mask.nii.gz)]
[DEBUG  ] already present [get(/home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_desc-confounds_regressors.tsv)]
2024-11-05 11:30:56,561 - JUNIFER - DEBUG - File /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-preproc_T1w.nii.gz was already present
2024-11-05 11:30:56,561 - JUNIFER - DEBUG - File /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 was already present
2024-11-05 11:30:56,561 - JUNIFER - DEBUG - File /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz was already present
2024-11-05 11:30:56,561 - JUNIFER - DEBUG - File /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz was already present
2024-11-05 11:30:56,561 - JUNIFER - DEBUG - File /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-brain_mask.nii.gz was already present
2024-11-05 11:30:56,561 - JUNIFER - DEBUG - File /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_desc-confounds_regressors.tsv was already present
2024-11-05 11:30:56,561 - JUNIFER - DEBUG - Get done
2024-11-05 11:30:56,900 - JUNIFER - INFO - Registering DefaultDataReader in datareader
2024-11-05 11:30:56,900 - JUNIFER - INFO - Reading BOLD.mask from /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz
2024-11-05 11:30:56,900 - JUNIFER - INFO - BOLD.mask is of type NIFTI
2024-11-05 11:30:56,900 - JUNIFER - DEBUG - Calling <function load at 0x1504037cc540> with {}
2024-11-05 11:30:56,902 - JUNIFER - INFO - Reading BOLD.confounds from /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_desc-confounds_regressors.tsv
2024-11-05 11:30:56,902 - JUNIFER - INFO - BOLD.confounds is of type TSV
2024-11-05 11:30:56,902 - JUNIFER - DEBUG - Calling <function read_csv at 0x150404975a80> with {'sep': '\t'}
2024-11-05 11:30:56,916 - JUNIFER - INFO - Reading BOLD from /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/func/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
2024-11-05 11:30:56,916 - JUNIFER - INFO - BOLD is of type NIFTI
2024-11-05 11:30:56,916 - JUNIFER - DEBUG - Calling <function load at 0x1504037cc540> with {}
2024-11-05 11:30:56,918 - JUNIFER - INFO - Reading T1w.mask from /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-brain_mask.nii.gz
2024-11-05 11:30:56,918 - JUNIFER - INFO - T1w.mask is of type NIFTI
2024-11-05 11:30:56,918 - JUNIFER - DEBUG - Calling <function load at 0x1504037cc540> with {}
2024-11-05 11:30:56,920 - JUNIFER - INFO - Reading T1w from /home/fraimondo/test_datasets/aomic_id1000/derivatives/fmriprep/sub-0001/anat/sub-0001_desc-preproc_T1w.nii.gz
2024-11-05 11:30:56,920 - JUNIFER - INFO - T1w is of type NIFTI
2024-11-05 11:30:56,920 - JUNIFER - DEBUG - Calling <function load at 0x1504037cc540> with {}
2024-11-05 11:31:01,281 - JUNIFER - INFO - Registering fMRIPrepConfoundRemover in preprocessing
2024-11-05 11:31:01,282 - JUNIFER - INFO - Preprocessing BOLD
2024-11-05 11:31:01,282 - JUNIFER - DEBUG - Extra data type for preprocess: dict_keys(['T1w', 'Warp'])
2024-11-05 11:31:03,638 - JUNIFER - INFO - No `t_r` specified, using t_r from NIfTI header
2024-11-05 11:31:03,638 - JUNIFER - INFO - Read t_r from NIfTI header: 2.200000047683716
2024-11-05 11:31:03,639 - JUNIFER - DEBUG - Masking with ['inherit']
2024-11-05 11:31:03,639 - JUNIFER - DEBUG - Setting up temporary directory under /home/fraimondo/dev/scratch/test_junifer_native/temp
2024-11-05 11:31:03,640 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv -> Overall
2024-11-05 11:31:03,641 - JUNIFER - DEBUG - Setting up element directory under /home/fraimondo/dev/scratch/test_junifer_native/temp
2024-11-05 11:31:03,642 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta -> Element
2024-11-05 11:31:03,642 - JUNIFER - DEBUG - Setting `BOLD.mask`
2024-11-05 11:31:03,642 - JUNIFER - INFO - Cleaning image using nilearn
2024-11-05 11:31:03,643 - JUNIFER - DEBUG - 	detrend: True
2024-11-05 11:31:03,643 - JUNIFER - DEBUG - 	standardize: True
2024-11-05 11:31:03,643 - JUNIFER - DEBUG - 	low_pass: None
2024-11-05 11:31:03,643 - JUNIFER - DEBUG - 	high_pass: None
2024-11-05 11:31:05,236 - JUNIFER - DEBUG - Adding BOLD to output
2024-11-05 11:31:05,644 - JUNIFER - INFO - Registering SpaceWarper in preprocessing
2024-11-05 11:31:35,855 - JUNIFER - WARNING - /home/fraimondo/dev/tbox/junifer/junifer/pipeline/utils.py:248: RuntimeWarning: ANTs is installed but some of the required commands were not found. These are the results: {'ResampleImage': 'not found', 'antsApplyTransforms': 'not found'}
  warn_with_log(
2024-11-05 11:31:35,855 - JUNIFER - INFO - Preprocessing BOLD
2024-11-05 11:31:35,855 - JUNIFER - DEBUG - Extra data type for preprocess: dict_keys(['T1w', 'Warp'])
2024-11-05 11:31:35,855 - JUNIFER - INFO - Warping to T1w space using SpaceWarper
2024-11-05 11:31:35,855 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta
2024-11-05 11:31:35,857 - JUNIFER - DEBUG - Using ANTs for space warping
2024-11-05 11:31:35,858 - JUNIFER - INFO - ResampleImage command to be executed:
"sub-0001_desc-preproc_T1w.nii.gz"
ResampleImage 3 /home/fraimondo/test_datasets/aomic_id1000/sub-0001_desc-preproc_T1w.nii.gz /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz 3.0x3.0x3.0 0 3 3
2024-11-05 11:31:48,572 - JUNIFER - INFO - ResampleImage command succeeded with the following output:
/home/fraimondo/test_datasets/aomic_id1000/sub-0001_desc-preproc_T1w.nii.gz is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz is a prefix
Singularity args: --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/91/63/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2
Corrected args for ANTS: ResampleImage 3 /data/mount_1/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz /data/mount_2/resampled_reference.nii.gz 3.0x3.0x3.0 0 3 3
Running command: /data/group/appliedml/tools/ants_2.5.0/singularity_cmd exec --cleanenv --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/91/63/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2 /data/group/appliedml/tools/ants_2.5.0/ants_v2.5.0.sif ResampleImage 3 /data/mount_1/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz /data/mount_2/resampled_reference.nii.gz 3.0x3.0x3.0 0 3 3

2024-11-05 11:31:48,573 - JUNIFER - INFO - antsApplyTransforms command to be executed:
antsApplyTransforms -d 3 -e 3 -n LanczosWindowedSinc -i /home/fraimondo/test_datasets/aomic_id1000/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz -r /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz -t /home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/output.nii.gz
2024-11-05 11:37:08,157 - JUNIFER - INFO - antsApplyTransforms command succeeded with the following output:
/home/fraimondo/test_datasets/aomic_id1000/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz is a file
/home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/output.nii.gz is a prefix
Singularity args: --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/wV/mx/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_4
Corrected args for ANTS: antsApplyTransforms -d 3 -e 3 -n LanczosWindowedSinc -i /data/mount_1/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz -r /data/mount_2/resampled_reference.nii.gz -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /data/mount_4/output.nii.gz
Running command: /data/group/appliedml/tools/ants_2.5.0/singularity_cmd exec --cleanenv --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/wV/mx/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_4 /data/group/appliedml/tools/ants_2.5.0/ants_v2.5.0.sif antsApplyTransforms -d 3 -e 3 -n LanczosWindowedSinc -i /data/mount_1/sub-0001_task-moviewatching_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz -r /data/mount_2/resampled_reference.nii.gz -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /data/mount_4/output.nii.gz

2024-11-05 11:37:08,161 - JUNIFER - DEBUG - Adding BOLD to output
2024-11-05 11:37:08,203 - JUNIFER - INFO - Registering SphereAggregation in marker
2024-11-05 11:37:08,205 - JUNIFER - INFO - Registering ALFFSpheres in marker
2024-11-05 11:37:08,206 - JUNIFER - INFO - Computing BOLD
2024-11-05 11:37:08,206 - JUNIFER - DEBUG - Extra data type for feature extraction: dict_keys(['T1w', 'Warp'])
2024-11-05 11:37:08,206 - JUNIFER - INFO - Calculating ALFF / fALFF for spheres
2024-11-05 11:37:08,206 - JUNIFER - DEBUG - Calculating ALFF and fALFF
2024-11-05 11:37:08,206 - JUNIFER - DEBUG - Creating cache for ALFF computation via AFNI
2024-11-05 11:37:08,207 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv
2024-11-05 11:37:11,937 - JUNIFER - INFO - 3dRSFC command to be executed:
3dRSFC -prefix /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/alff_falff -input /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/input.nii -band 0.01 0.08 -no_rsfa -nosat -nodetrend
2024-11-05 11:37:41,528 - JUNIFER - INFO - 3dRSFC command succeeded with the following output:
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/alff_falff is a prefix
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/input.nii is a file
Singularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_2
Corrected args for AFNI: 3dRSFC -prefix /data/mount_1/alff_falff -input /data/mount_2/input.nii -band 0.01 0.08 -no_rsfa -nosat -nodetrend
Running command: /data/group/appliedml/tools/afni_24.1.19/singularity_cmd exec --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_2 /data/group/appliedml/tools/afni_24.1.19/afni_make_build_AFNI_24.1.19.sif 3dRSFC -prefix /data/mount_1/alff_falff -input /data/mount_2/input.nii -band 0.01 0.08 -no_rsfa -nosat -nodetrend
++ 3dRSFC (from 3dBandpass by RW Cox): version THETA: AFNI version=AFNI_24.1.19 (Jun 14 2024) [64-bit]
++ Authored by: PA Taylor
** AFNI converts NIFTI_datatype=64 (FLOAT64) in file /data/mount_2/input.nii to FLOAT32
     Warnings of this type will be muted for this session.
     Set AFNI_NIFTI_TYPE_WARN to YES to see them all, NO to see none.
*+ WARNING:   If you are performing spatial transformations on an oblique dset,
  such as /data/mount_2/input.nii,
  or viewing/combining it with volumes of differing obliquity,
  you should consider running:
     3dWarp -deoblique
  on this and  other oblique datasets in the same session.
 See 3dWarp -help for details.
++ Oblique dataset:/data/mount_2/input.nii is 6.023141 degrees from plumb.
++ Data length = 290  FFT length = 290
 + bandpass: ntime=290 nFFT=290 dt=2.2 dFreq=0.0015674 Nyquist=0.227273 passband indexes=6..51
++ Loading input dataset time series
++ No mask ==> processing all 382925 voxels
++ Bandpassing data time series
 +   -- remove mean
 +   -- FFTs
++ Creating output dataset in memory, then writing it
++ Output dataset /data/mount_1/alff_falff_LFF+orig.BRIK
++ Bandpassing data time series
 +   -- remove mean
++ Creating output dataset 2 in memory
++ Starting the (f)ALaFFel calcs

2024-11-05 11:37:41,528 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta
2024-11-05 11:37:41,529 - JUNIFER - INFO - 3dAFNItoNIFTI command to be executed:
3dAFNItoNIFTI -prefix /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w/alff_0.01_0.08_None_output.nii /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/alff_falff_ALFF+orig.BRIK
2024-11-05 11:37:50,929 - JUNIFER - INFO - 3dAFNItoNIFTI command succeeded with the following output:
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w/alff_0.01_0.08_None_output.nii is a prefix
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/alff_falff_ALFF+orig.BRIK is a file
Singularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_2
Corrected args for AFNI: 3dAFNItoNIFTI -prefix /data/mount_1/alff_0.01_0.08_None_output.nii /data/mount_2/alff_falff_ALFF+orig.BRIK
Running command: /data/group/appliedml/tools/afni_24.1.19/singularity_cmd exec --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_2 /data/group/appliedml/tools/afni_24.1.19/afni_make_build_AFNI_24.1.19.sif 3dAFNItoNIFTI -prefix /data/mount_1/alff_0.01_0.08_None_output.nii /data/mount_2/alff_falff_ALFF+orig.BRIK
++ 3dAFNItoNIFTI: AFNI version=AFNI_24.1.19 (Jun 14 2024) [64-bit]
*+ WARNING:   If you are performing spatial transformations on an oblique dset,
  such as /data/mount_2/alff_falff_ALFF+orig.BRIK,
  or viewing/combining it with volumes of differing obliquity,
  you should consider running:
     3dWarp -deoblique
  on this and  other oblique datasets in the same session.
 See 3dWarp -help for details.
++ Oblique dataset:/data/mount_2/alff_falff_ALFF+orig.BRIK is 6.023141 degrees from plumb.

2024-11-05 11:37:50,930 - JUNIFER - INFO - 3dAFNItoNIFTI command to be executed:
3dAFNItoNIFTI -prefix /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w/falff_0.01_0.08_None_output.nii /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/alff_falff_fALFF+orig.BRIK
2024-11-05 11:38:01,573 - JUNIFER - INFO - 3dAFNItoNIFTI command succeeded with the following output:
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w/falff_0.01_0.08_None_output.nii is a prefix
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e/alff_falff_fALFF+orig.BRIK is a file
Singularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_2
Corrected args for AFNI: 3dAFNItoNIFTI -prefix /data/mount_1/falff_0.01_0.08_None_output.nii /data/mount_2/alff_falff_fALFF+orig.BRIK
Running command: /data/group/appliedml/tools/afni_24.1.19/singularity_cmd exec --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/afni_alff_falffspjg0j9w:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/afni_alff+falff9nbdly1e:/data/mount_2 /data/group/appliedml/tools/afni_24.1.19/afni_make_build_AFNI_24.1.19.sif 3dAFNItoNIFTI -prefix /data/mount_1/falff_0.01_0.08_None_output.nii /data/mount_2/alff_falff_fALFF+orig.BRIK
++ 3dAFNItoNIFTI: AFNI version=AFNI_24.1.19 (Jun 14 2024) [64-bit]
*+ WARNING:   If you are performing spatial transformations on an oblique dset,
  such as /data/mount_2/alff_falff_fALFF+orig.BRIK,
  or viewing/combining it with volumes of differing obliquity,
  you should consider running:
     3dWarp -deoblique
  on this and  other oblique datasets in the same session.
 See 3dWarp -help for details.
++ Oblique dataset:/data/mount_2/alff_falff_fALFF+orig.BRIK is 6.023141 degrees from plumb.

2024-11-05 11:38:01,599 - JUNIFER - DEBUG - Sphere aggregation using mean
2024-11-05 11:38:01,607 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv
2024-11-05 11:38:01,607 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta
2024-11-05 11:38:01,610 - JUNIFER - DEBUG - Using ANTs for coordinates transformation
2024-11-05 11:38:01,615 - JUNIFER - INFO - antsApplyTransformsToPoints command to be executed:
antsApplyTransformsToPoints -d 3 -p 1 -f 0 -i /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates03pg_fuo/pretransform_coordinates.csv -o /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatestdyr5io3/coordinates_transformed.csv -t /home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5;
2024-11-05 11:38:11,929 - JUNIFER - INFO - antsApplyTransformsToPoints command succeeded with the following output:
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates03pg_fuo/pretransform_coordinates.csv is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatestdyr5io3/coordinates_transformed.csv is a prefix
/home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 is a file
Singularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates03pg_fuo:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatestdyr5io3:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3
Corrected args for ANTS: antsApplyTransformsToPoints -d 3 -p 1 -f 0 -i /data/mount_1/pretransform_coordinates.csv -o /data/mount_2/coordinates_transformed.csv -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5
Running command: /data/group/appliedml/tools/ants_2.5.0/singularity_cmd exec --cleanenv --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates03pg_fuo:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatestdyr5io3:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 /data/group/appliedml/tools/ants_2.5.0/ants_v2.5.0.sif antsApplyTransformsToPoints -d 3 -p 1 -f 0 -i /data/mount_1/pretransform_coordinates.csv -o /data/mount_2/coordinates_transformed.csv -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5

2024-11-05 11:38:11,931 - JUNIFER - DEBUG - Masking with inherit
2024-11-05 11:38:11,932 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv
2024-11-05 11:38:11,932 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta
2024-11-05 11:38:11,940 - JUNIFER - DEBUG - Using ANTs for mask warping
2024-11-05 11:38:11,942 - JUNIFER - INFO - antsApplyTransforms command to be executed:
antsApplyTransforms -d 3 -e 3 -n 'GenericLabel[NearestNeighbor]' -i /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/maskssgpc42as/prewarp_mask.nii.gz -r /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz -t /home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/masksh0jb15ju/mask_warped.nii.gz
2024-11-05 11:38:21,697 - JUNIFER - INFO - antsApplyTransforms command succeeded with the following output:
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/maskssgpc42as/prewarp_mask.nii.gz is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz is a file
/home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/masksh0jb15ju/mask_warped.nii.gz is a prefix
Singularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/maskssgpc42as:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/masksh0jb15ju:/data/mount_4
Corrected args for ANTS: antsApplyTransforms -d 3 -e 3 -n GenericLabel[NearestNeighbor] -i /data/mount_1/prewarp_mask.nii.gz -r /data/mount_2/resampled_reference.nii.gz -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /data/mount_4/mask_warped.nii.gz
Running command: /data/group/appliedml/tools/ants_2.5.0/singularity_cmd exec --cleanenv --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/maskssgpc42as:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/masksh0jb15ju:/data/mount_4 /data/group/appliedml/tools/ants_2.5.0/ants_v2.5.0.sif antsApplyTransforms -d 3 -e 3 -n GenericLabel[NearestNeighbor] -i /data/mount_1/prewarp_mask.nii.gz -r /data/mount_2/resampled_reference.nii.gz -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /data/mount_4/mask_warped.nii.gz

2024-11-05 11:38:21,698 - JUNIFER - DEBUG - Masking
2024-11-05 11:38:22,638 - JUNIFER - WARNING - /home/fraimondo/miniconda3/envs/junifer/lib/python3.12/site-packages/numpy/core/fromnumeric.py:3504: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,

2024-11-05 11:38:22,640 - JUNIFER - WARNING - /home/fraimondo/miniconda3/envs/junifer/lib/python3.12/site-packages/numpy/core/_methods.py:121: RuntimeWarning: invalid value encountered in divide
  ret = um.true_divide(

2024-11-05 11:38:22,644 - JUNIFER - DEBUG - Sphere aggregation using mean
2024-11-05 11:38:22,646 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv
2024-11-05 11:38:22,647 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta
2024-11-05 11:38:22,650 - JUNIFER - DEBUG - Using ANTs for coordinates transformation
2024-11-05 11:38:22,651 - JUNIFER - INFO - antsApplyTransformsToPoints command to be executed:
antsApplyTransformsToPoints -d 3 -p 1 -f 0 -i /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates5hfj5d4j/pretransform_coordinates.csv -o /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatesqemgqris/coordinates_transformed.csv -t /home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5;
2024-11-05 11:38:33,675 - JUNIFER - INFO - antsApplyTransformsToPoints command succeeded with the following output:
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates5hfj5d4j/pretransform_coordinates.csv is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatesqemgqris/coordinates_transformed.csv is a prefix
/home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 is a file
Singularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates5hfj5d4j:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatesqemgqris:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3
Corrected args for ANTS: antsApplyTransformsToPoints -d 3 -p 1 -f 0 -i /data/mount_1/pretransform_coordinates.csv -o /data/mount_2/coordinates_transformed.csv -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5
Running command: /data/group/appliedml/tools/ants_2.5.0/singularity_cmd exec --cleanenv --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/coordinates5hfj5d4j:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/coordinatesqemgqris:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 /data/group/appliedml/tools/ants_2.5.0/ants_v2.5.0.sif antsApplyTransformsToPoints -d 3 -p 1 -f 0 -i /data/mount_1/pretransform_coordinates.csv -o /data/mount_2/coordinates_transformed.csv -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5

2024-11-05 11:38:33,677 - JUNIFER - DEBUG - Masking with inherit
2024-11-05 11:38:33,677 - JUNIFER - DEBUG - Creating temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv
2024-11-05 11:38:33,679 - JUNIFER - DEBUG - Creating element temporary directory at /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta
2024-11-05 11:38:33,686 - JUNIFER - DEBUG - Using ANTs for mask warping
2024-11-05 11:38:33,687 - JUNIFER - INFO - antsApplyTransforms command to be executed:
antsApplyTransforms -d 3 -e 3 -n 'GenericLabel[NearestNeighbor]' -i /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/masksdreztg7o/prewarp_mask.nii.gz -r /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz -t /home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/maskso_3or_bg/mask_warped.nii.gz
2024-11-05 11:38:43,446 - JUNIFER - INFO - antsApplyTransforms command succeeded with the following output:
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/masksdreztg7o/prewarp_mask.nii.gz is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_/resampled_reference.nii.gz is a file
/home/fraimondo/test_datasets/aomic_id1000/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 is a file
/home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/maskso_3or_bg/mask_warped.nii.gz is a prefix
Singularity args: --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/masksdreztg7o:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/maskso_3or_bg:/data/mount_4
Corrected args for ANTS: antsApplyTransforms -d 3 -e 3 -n GenericLabel[NearestNeighbor] -i /data/mount_1/prewarp_mask.nii.gz -r /data/mount_2/resampled_reference.nii.gz -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /data/mount_4/mask_warped.nii.gz
Running command: /data/group/appliedml/tools/ants_2.5.0/singularity_cmd exec --cleanenv --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpt2qgzhuv/masksdreztg7o:/data/mount_1 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/ants_warperlzyoyrg_:/data/mount_2 --bind /home/fraimondo/test_datasets/aomic_id1000/.git/annex/objects/Zf/zk/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5:/data/mount_3 --bind /home/fraimondo/dev/scratch/test_junifer_native/temp/tmpqlhylwta/maskso_3or_bg:/data/mount_4 /data/group/appliedml/tools/ants_2.5.0/ants_v2.5.0.sif antsApplyTransforms -d 3 -e 3 -n GenericLabel[NearestNeighbor] -i /data/mount_1/prewarp_mask.nii.gz -r /data/mount_2/resampled_reference.nii.gz -t /data/mount_3/sub-0001_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5 -o /data/mount_4/mask_warped.nii.gz

2024-11-05 11:38:43,449 - JUNIFER - DEBUG - Masking
2024-11-05 11:38:44,396 - JUNIFER - WARNING - /home/fraimondo/miniconda3/envs/junifer/lib/python3.12/site-packages/numpy/core/fromnumeric.py:3504: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,

2024-11-05 11:38:44,397 - JUNIFER - WARNING - /home/fraimondo/miniconda3/envs/junifer/lib/python3.12/site-packages/numpy/core/_methods.py:121: RuntimeWarning: invalid value encountered in divide
  ret = um.true_divide(

2024-11-05 11:38:44,401 - JUNIFER - INFO - No storage specified, returning dictionary
2024-11-05 11:38:44,402 - JUNIFER - INFO - No storage specified, returning dictionary
2024-11-05 11:38:44,404 - JUNIFER - DEBUG - Cleaning up dataset
2024-11-05 11:38:44,405 - JUNIFER - DEBUG - Dropping files that were downloaded
2024-11-05 11:38:44,405 - JUNIFER - DEBUG - Dataset state restored
2024-11-05 11:38:44,574 - JUNIFER - DEBUG - Clearing cache for ALFF computation via AFNI
```


### Anything else?

_No response_