### PR TITLE
[BUG]: `compute_brain_mask` fails to find `Warp` object

### DIFF
--- a/docs/changes/newsfragments/394.bugfix
+++ b/docs/changes/newsfragments/394.bugfix
@@ -1,0 +1,1 @@
+Refactor ``compute_brain_mask``'s interface and internals to not fail during native space warping by `Synchon Mandal`_

--- a/junifer/data/masks/tests/test_masks.py
+++ b/junifer/data/masks/tests/test_masks.py
@@ -64,8 +64,8 @@ def test_compute_brain_mask(mask_type: str, threshold: float) -> None:
         element_data = DefaultDataReader().fit_transform(dg["sub-01"])
         mask = compute_brain_mask(
             target_data=element_data["BOLD"],
-            extra_input=None,
             mask_type=mask_type,
+            threshold=threshold,
         )
         assert isinstance(mask, nib.nifti1.Nifti1Image)
 
@@ -104,7 +104,6 @@ def test_compute_brain_mask_for_native(mask_type: str) -> None:
         )
         mask = compute_brain_mask(
             target_data=element_data["BOLD"],
-            extra_input=None,
             mask_type=mask_type,
         )
         assert isinstance(mask, nib.nifti1.Nifti1Image)


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

An error occurs when using a spacewarper and then a confound remover preprocessor that uses the `compute_brain_mask` function.

Basically, it complains that the `Warp` object was not passed

### Expected Behavior

I would expect the MNI2009c.... mask to be warped to the native space.

### Steps To Reproduce

1. With junifer latest
2. Run this yaml with `--element 100206`
```yaml
workdir: /tmp

with:
  - ../external/juni-farm/juni_farm/datagrabber/hcp_ya_confounds_cat.py

datagrabber:
    kind: MultipleHCP
    ica_fix: true
    tasks:
      - REST1
      - REST2

preprocess:
  - kind: SpaceWarper
    reference: T1w
    on: BOLD
    using: fsl
  - kind: fMRIPrepConfoundRemover
    detrend: true
    standardize: true
    strategy:
        wm_csf: full
        global_signal: full
    masks:
      - compute_brain_mask:
        - mask_type: gm
markers:
  - name: ALFF-Power2011-5mm_native
    kind: ALFFSpheres
    coords: "Power2011"
    using: afni
    highpass: 0.01
    lowpass: 0.08
    tr: 0.72
    agg_method: mean
    radius: 5 
    allow_overlap: true
    masks: 
      - inherit
  - name: SphereSize-Power2011-5mm_native
    kind: ALFFSpheres
    coords: "Power2011"
    using: afni
    highpass: 0.01
    lowpass: 0.08
    tr: 0.72
    agg_method: count
    radius: 5
    allow_overlap: true
    masks: 
      - inherit
  - name: ALFF-Power2011-10mm_native
    kind: ALFFSpheres
    coords: "Power2011"
    using: afni
    highpass: 0.01
    lowpass: 0.08
    tr: 0.72
    agg_method: mean
    radius: 10
    allow_overlap: true
    masks: 
      - inherit
  - name: SphereSize-Power2011-10mm_native
    kind: ALFFSpheres
    coords: "Power2011"
    using: afni
    highpass: 0.01
    lowpass: 0.08
    tr: 0.72
    agg_method: count
    radius: 10
    allow_overlap: true
    masks: 
      - inherit

storage:
  kind: HDF5FeatureStorage
  uri: /data/project/SPP2041/results/fraimondo/brain_size_project/storage/hcp_native_icbm152_mask_falff/hcp_native_icbm152_mask_falff.hdf5

queue:
  jobname: hcp_native_icbm152_mask_falff
  kind: HTCondor
  env:
    kind: conda
    name: junifer
  mem: 20G
  cpus: 1
  disk: 10G
  pre_run: |
    # Enable FSL
    source /data/group/appliedml/tools/fsl_6.0.4-patched2/fsl.sh
    # Enable AFNI
    source /data/group/appliedml/tools/afni_24.1.19/afni.sh
    # Enable ANTS
    source /data/group/appliedml/tools/ants_2.5.0/ants.sh
  verbose: info
  collect: yes
```


### Environment

```markdown
junifer:
  version: 0.0.6.dev201
python:
  version: 3.12.7
  implementation: CPython
dependencies:
  click: 8.1.7
  numpy: 1.26.4
  scipy: 1.14.1
  datalad: 1.1.3
  pandas: 2.2.3
  nibabel: 5.3.2
  ruamel.yaml: 0.18.6
  looseversion: None
system:
  platform: Linux-6.6.13+bpo-amd64-x86_64-with-glibc2.36
environment:
  PATH:
    /home/fraimondo/miniforge3/envs/junifer/bin:/home/fraimondo/.local/bin:/usr/local/bin:/home/fraimondo/miniforge3/condabin:/home/fraimondo/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/games
```


### Relevant log output

```shell

2024-11-12 15:50:48,797 - JUNIFER - DEBUG - Adding BOLD to output
2024-11-12 15:50:48,797 [   DEBUG] Adding BOLD to output
2024-11-12 15:50:48,797 - JUNIFER - INFO - Preprocessing data with fMRIPrepConfoundRemover
2024-11-12 15:50:48,797 [    INFO] Preprocessing data with fMRIPrepConfoundRemover
2024-11-12 15:50:48,797 - JUNIFER - INFO - Preprocessing BOLD
2024-11-12 15:50:48,797 [    INFO] Preprocessing BOLD
2024-11-12 15:50:48,797 - JUNIFER - DEBUG - Extra data type for preprocess: dict_keys(['T1w', 'Warp'])
2024-11-12 15:50:48,797 [   DEBUG] Extra data type for preprocess: dict_keys(['T1w', 'Warp'])
2024-11-12 15:51:27,445 - JUNIFER - INFO - No `t_r` specified, using t_r from NIfTI header
2024-11-12 15:51:27,445 [    INFO] No `t_r` specified, using t_r from NIfTI header
2024-11-12 15:51:27,445 - JUNIFER - INFO - Read t_r from NIfTI header: 0.7200000286102295
2024-11-12 15:51:27,445 [    INFO] Read t_r from NIfTI header: 0.7200000286102295
2024-11-12 15:51:27,445 - JUNIFER - DEBUG - Masking with ['compute_brain_mask']
2024-11-12 15:51:27,445 [   DEBUG] Masking with ['compute_brain_mask']
2024-11-12 15:51:27,445 - JUNIFER - DEBUG - Computing brain mask
2024-11-12 15:51:27,445 [   DEBUG] Computing brain mask
2024-11-12 15:51:27,445 - JUNIFER - ERROR - No extra input provided, requires `Warp` data type to infer target template space.
2024-11-12 15:51:27,445 [   ERROR] No extra input provided, requires `Warp` data type to infer target template space.
Traceback (most recent call last):
  File "/home/fraimondo/miniforge3/envs/junifer/bin/junifer", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/cli/cli.py", line 145, in run
    cli_func.run(
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/api/functions.py", line 198, in run
    mc.fit(datagrabber_object[t_element])
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/pipeline/marker_collection.py", line 98, in fit
    data = preprocessor.fit_transform(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/pipeline/pipeline_step_mixin.py", line 246, in fit_transform
    return self._fit_transform(input=input, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/preprocess/base.py", line 195, in _fit_transform
    t_out, t_extra_input = self.preprocess(
                           ^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/preprocess/confounds/fmriprep_confound_remover.py", line 549, in preprocess
    mask_img = get_data(
               ^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/data/_dispatch.py", line 96, in get_data
    return MaskRegistry().get(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/data/masks/_masks.py", line 468, in get
    mask_img = mask_object(target_data, **mask_params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/data/masks/_masks.py", line 103, in compute_brain_mask
    raise_error(
  File "/home/fraimondo/miniforge3/envs/junifer/lib/python3.12/site-packages/junifer/utils/logging.py", line 330, in raise_error
    raise klass(msg)
ValueError: No extra input provided, requires `Warp` data type to infer target template space.
```


### Anything else?

_No response_