### PR TITLE
[ENH]: Introduce `ConfigManager`

### DIFF
--- a/docs/changes/newsfragments/401.feature
+++ b/docs/changes/newsfragments/401.feature
@@ -1,0 +1,1 @@
+Introduce :class:`junifer.utils.ConfigManager` singleton class to manage global configuration by `Fede Raimondo`_

--- a/junifer/api/decorators.py
+++ b/junifer/api/decorators.py
@@ -13,8 +13,8 @@ from ..typing import DataGrabberLike, MarkerLike, PreprocessorLike, StorageLike
 __all__ = [
     "register_datagrabber",
     "register_datareader",
-    "register_preprocessor",
     "register_marker",
+    "register_preprocessor",
     "register_storage",
 ]
 

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -24,7 +24,7 @@ from ..typing import DataGrabberLike, MarkerLike, PreprocessorLike, StorageLike
 from ..utils import logger, raise_error, yaml
 
 
-__all__ = ["run", "collect", "queue", "reset", "list_elements"]
+__all__ = ["collect", "list_elements", "queue", "reset", "run"]
 
 
 def _get_datagrabber(datagrabber_config: dict) -> DataGrabberLike:

--- a/junifer/cli/cli.py
+++ b/junifer/cli/cli.py
@@ -29,19 +29,19 @@ from .utils import (
 
 
 __all__ = [
-    "cli",
-    "run",
-    "collect",
-    "queue",
-    "wtf",
-    "selftest",
-    "reset",
-    "list_elements",
-    "setup",
     "afni_docker",
-    "fsl_docker",
     "ants_docker",
+    "cli",
+    "collect",
     "freesurfer_docker",
+    "fsl_docker",
+    "list_elements",
+    "queue",
+    "reset",
+    "run",
+    "selftest",
+    "setup",
+    "wtf",
 ]
 
 

--- a/junifer/cli/parser.py
+++ b/junifer/cli/parser.py
@@ -15,7 +15,7 @@ import pandas as pd
 from ..utils import logger, raise_error, warn_with_log, yaml
 
 
-__all__ = ["parse_yaml", "parse_elements"]
+__all__ = ["parse_elements", "parse_yaml"]
 
 
 def parse_yaml(filepath: Union[str, Path]) -> dict:  # noqa: C901

--- a/junifer/data/_dispatch.py
+++ b/junifer/data/_dispatch.py
@@ -25,11 +25,11 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "deregister_data",
     "get_data",
     "list_data",
     "load_data",
     "register_data",
-    "deregister_data",
 ]
 
 

--- a/junifer/data/masks/_masks.py
+++ b/junifer/data/masks/_masks.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from nibabel.nifti1 import Nifti1Image
 
 
-__all__ = ["compute_brain_mask", "MaskRegistry"]
+__all__ = ["MaskRegistry", "compute_brain_mask"]
 
 
 # Path to the masks

--- a/junifer/data/template_spaces.py
+++ b/junifer/data/template_spaces.py
@@ -16,7 +16,7 @@ from ..utils import logger, raise_error
 from .utils import closest_resolution
 
 
-__all__ = ["get_xfm", "get_template"]
+__all__ = ["get_template", "get_xfm"]
 
 
 def get_xfm(

--- a/junifer/stats.py
+++ b/junifer/stats.py
@@ -13,7 +13,7 @@ from scipy.stats.mstats import winsorize
 from .utils import logger, raise_error
 
 
-__all__ = ["get_aggfunc_by_name", "count", "winsorized_mean", "select"]
+__all__ = ["count", "get_aggfunc_by_name", "select", "winsorized_mean"]
 
 
 def get_aggfunc_by_name(

--- a/junifer/storage/utils.py
+++ b/junifer/storage/utils.py
@@ -15,11 +15,11 @@ from ..utils.logging import logger, raise_error
 
 
 __all__ = [
-    "get_dependency_version",
-    "process_meta",
     "element_to_prefix",
-    "store_matrix_checks",
+    "get_dependency_version",
     "matrix_to_vector",
+    "process_meta",
+    "store_matrix_checks",
 ]
 
 

--- a/junifer/testing/datagrabbers.py
+++ b/junifer/testing/datagrabbers.py
@@ -15,8 +15,8 @@ from ..datagrabber.base import BaseDataGrabber
 
 __all__ = [
     "OasisVBMTestingDataGrabber",
-    "SPMAuditoryTestingDataGrabber",
     "PartlyCloudyTestingDataGrabber",
+    "SPMAuditoryTestingDataGrabber",
 ]
 
 

--- a/junifer/typing/__init__.pyi
+++ b/junifer/typing/__init__.pyi
@@ -9,6 +9,7 @@ __all__ = [
     "ExternalDependencies",
     "MarkerInOutMappings",
     "DataGrabberPatterns",
+    "ConfigVal",
 ]
 
 from ._typing import (
@@ -22,4 +23,5 @@ from ._typing import (
     ExternalDependencies,
     MarkerInOutMappings,
     DataGrabberPatterns,
+    ConfigVal,
 )

--- a/junifer/typing/_typing.py
+++ b/junifer/typing/_typing.py
@@ -19,16 +19,16 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    "DataGrabberLike",
-    "PreprocessorLike",
-    "MarkerLike",
-    "StorageLike",
-    "PipelineComponent",
-    "Dependencies",
     "ConditionalDependencies",
+    "DataGrabberLike",
+    "DataGrabberPatterns",
+    "Dependencies",
     "ExternalDependencies",
     "MarkerInOutMappings",
-    "DataGrabberPatterns",
+    "MarkerLike",
+    "PipelineComponent",
+    "PreprocessorLike",
+    "StorageLike",
 ]
 
 

--- a/junifer/typing/_typing.py
+++ b/junifer/typing/_typing.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ConditionalDependencies",
+    "ConfigVal",
     "DataGrabberLike",
     "DataGrabberPatterns",
     "Dependencies",
@@ -60,3 +61,4 @@ MarkerInOutMappings = MutableMapping[str, MutableMapping[str, str]]
 DataGrabberPatterns = dict[
     str, Union[dict[str, str], Sequence[dict[str, str]]]
 ]
+ConfigVal = Union[bool, int, float]

--- a/junifer/utils/__init__.pyi
+++ b/junifer/utils/__init__.pyi
@@ -13,6 +13,6 @@ __all__ = [
 
 from .fs import make_executable
 from .logging import configure_logging, logger, raise_error, warn_with_log
-from .config import config, ConfigManager
+from ._config import config, ConfigManager
 from .helpers import run_ext_cmd, deep_update
 from ._yaml import yaml

--- a/junifer/utils/__init__.pyi
+++ b/junifer/utils/__init__.pyi
@@ -1,6 +1,7 @@
 __all__ = [
     "make_executable",
     "configure_logging",
+    "config",
     "logger",
     "raise_error",
     "warn_with_log",
@@ -11,5 +12,6 @@ __all__ = [
 
 from .fs import make_executable
 from .logging import configure_logging, logger, raise_error, warn_with_log
+from .config import config
 from .helpers import run_ext_cmd, deep_update
 from ._yaml import yaml

--- a/junifer/utils/__init__.pyi
+++ b/junifer/utils/__init__.pyi
@@ -8,10 +8,11 @@ __all__ = [
     "run_ext_cmd",
     "deep_update",
     "yaml",
+    "ConfigManager",
 ]
 
 from .fs import make_executable
 from .logging import configure_logging, logger, raise_error, warn_with_log
-from .config import config
+from .config import config, ConfigManager
 from .helpers import run_ext_cmd, deep_update
 from ._yaml import yaml

--- a/junifer/utils/_config.py
+++ b/junifer/utils/_config.py
@@ -5,8 +5,9 @@
 # License: AGPL
 
 import os
-from typing import Any
+from typing import Optional
 
+from ..typing import ConfigVal
 from .logging import logger
 from .singleton import Singleton
 
@@ -27,16 +28,21 @@ class ConfigManager(metaclass=Singleton):
     def __init__(self) -> None:
         """Initialize the class."""
         self._config = {}
+        # Initial setup from process env
+        self._reload()
+
+    def _reload(self) -> None:
+        """Reload env vars."""
         for t_var in os.environ:
             if t_var.startswith("JUNIFER_"):
-                varname = t_var.replace("JUNIFER_", "")
-                varname = varname.lower()
-                varname = varname.replace("_", ".")
+                # Set correct type
                 var_value = os.environ[t_var]
+                # bool
                 if var_value.lower() == "true":
                     var_value = True
                 elif var_value.lower() == "false":
                     var_value = False
+                # numeric
                 else:
                     try:
                         var_value = int(var_value)
@@ -45,43 +51,59 @@ class ConfigManager(metaclass=Singleton):
                             var_value = float(var_value)
                         except ValueError:
                             pass
-                logger.debug(
-                    f"Setting {varname} from environment to "
-                    f"{var_value} (type: {type(var_value)})"
+                # Set value
+                var_name = (
+                    t_var.replace("JUNIFER_", "").lower().replace("_", ".")
                 )
-                self._config[varname] = var_value
+                logger.debug(
+                    f"Setting `{var_name}` from environment to "
+                    f"`{var_value}` (type: {type(var_value)})"
+                )
+                self._config[var_name] = var_value
 
-    def get(self, key: str, default: Any = None) -> Any:
+    def get(self, key: str, default: Optional[ConfigVal] = None) -> ConfigVal:
         """Get configuration parameter.
 
         Parameters
         ----------
         key : str
-            The configuration key.
-        default : any, optional
+            The configuration key to get.
+        default : bool or int or float or None, optional
             The default value to return if the key is not found (default None).
 
         Returns
         -------
-        any
+        bool or int or float
             The configuration value.
 
         """
         return self._config.get(key, default)
 
-    def set(self, key: str, value: Any) -> None:
+    def set(self, key: str, val: ConfigVal) -> None:
         """Set configuration parameter.
 
         Parameters
         ----------
         key : str
-            The configuration key.
-        value : any
-            The configuration value.
+            The configuration key to set.
+        val : bool or int or float
+            The value to set ``key`` to.
 
         """
-        logger.debug(f"Setting {key} to {value}")
-        self._config[key] = value
+        logger.debug(f"Setting `{key}` to `{val}` (type: {type(val)})")
+        self._config[key] = val
+
+    def delete(self, key: str) -> None:
+        """Delete configuration parameter.
+
+        Parameters
+        ----------
+        key : str
+            The configuration key to delete.
+
+        """
+        logger.debug(f"Deleting `{key}` from config")
+        _ = self._config.pop(key)
 
 
 # Initialize here to access from anywhere

--- a/junifer/utils/config.py
+++ b/junifer/utils/config.py
@@ -27,12 +27,25 @@ class ConfigManager(metaclass=Singleton):
             if t_var.startswith("JUNIFER_"):
                 varname = t_var.replace("JUNIFER_", "")
                 varname = varname.lower()
-                varname.replace("_", ".")
+                varname = varname.replace("_", ".")
+                var_value = os.environ[t_var]
+                if var_value.lower() == "true":
+                    var_value = True
+                elif var_value.lower() == "false":
+                    var_value = False
+                else:
+                    try:
+                        var_value = int(var_value)
+                    except ValueError:
+                        try:
+                            var_value = float(var_value)
+                        except ValueError:
+                            pass
                 logger.debug(
                     f"Setting {varname} from environment to "
-                    f"{os.environ[t_var]}"
+                    f"{var_value} (type: {type(var_value)})"
                 )
-                self._config[varname] = os.environ[t_var]
+                self._config[varname] = var_value
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get configuration parameter.

--- a/junifer/utils/config.py
+++ b/junifer/utils/config.py
@@ -1,0 +1,71 @@
+"""Provide junifer global configuration."""
+
+# Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
+#          Synchon Mandal <s.mandal@fz-juelich.de>
+# License: AGPL
+import os
+from typing import Any
+
+from .logging import logger
+from .singleton import Singleton
+
+
+class ConfigManager(metaclass=Singleton):
+    """Manage configuration parameters.
+
+    Attributes
+    ----------
+    _config : dict
+        Configuration parameters.
+
+    """
+
+    def __init__(self) -> None:
+        """Initialize the class."""
+        self._config = {}
+        for t_var in os.environ:
+            if t_var.startswith("JUNIFER_"):
+                varname = t_var.replace("JUNIFER_", "")
+                varname = varname.lower()
+                varname.replace("_", ".")
+                logger.debug(
+                    f"Setting {varname} from environment to "
+                    f"{os.environ[t_var]}"
+                )
+                self._config[varname] = os.environ[t_var]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get configuration parameter.
+
+        Parameters
+        ----------
+        key : str
+            The configuration key.
+
+        default : Any, optional
+            The default value to return if the key is not found (default None).
+
+        Returns
+        -------
+        Any
+            The configuration value.
+
+        """
+        return self._config.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        """Set configuration parameter.
+
+        Parameters
+        ----------
+        key : str
+            The configuration key.
+        value : Any
+            The configuration value.
+
+        """
+        logger.debug(f"Setting {key} to {value}")
+        self._config[key] = value
+
+
+config = ConfigManager()

--- a/junifer/utils/config.py
+++ b/junifer/utils/config.py
@@ -3,11 +3,15 @@
 # Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
+
 import os
 from typing import Any
 
 from .logging import logger
 from .singleton import Singleton
+
+
+__all__ = ["ConfigManager", "config"]
 
 
 class ConfigManager(metaclass=Singleton):
@@ -54,13 +58,12 @@ class ConfigManager(metaclass=Singleton):
         ----------
         key : str
             The configuration key.
-
-        default : Any, optional
+        default : any, optional
             The default value to return if the key is not found (default None).
 
         Returns
         -------
-        Any
+        any
             The configuration value.
 
         """
@@ -73,7 +76,7 @@ class ConfigManager(metaclass=Singleton):
         ----------
         key : str
             The configuration key.
-        value : Any
+        value : any
             The configuration value.
 
         """
@@ -81,4 +84,5 @@ class ConfigManager(metaclass=Singleton):
         self._config[key] = value
 
 
+# Initialize here to access from anywhere
 config = ConfigManager()

--- a/junifer/utils/helpers.py
+++ b/junifer/utils/helpers.py
@@ -10,7 +10,7 @@ import sys
 from .logging import logger, raise_error
 
 
-__all__ = ["run_ext_cmd", "deep_update"]
+__all__ = ["deep_update", "run_ext_cmd"]
 
 
 def run_ext_cmd(name: str, cmd: list[str]) -> None:

--- a/junifer/utils/logging.py
+++ b/junifer/utils/logging.py
@@ -24,9 +24,9 @@ import datalad
 
 __all__ = [
     "WrapStdOut",
+    "configure_logging",
     "get_versions",
     "log_versions",
-    "configure_logging",
     "raise_error",
     "warn_with_log",
 ]

--- a/junifer/utils/singleton.py
+++ b/junifer/utils/singleton.py
@@ -8,7 +8,7 @@ from abc import ABCMeta
 from typing import Any, ClassVar
 
 
-__all__ = ["Singleton", "ABCSingleton"]
+__all__ = ["ABCSingleton", "Singleton"]
 
 
 class Singleton(type):

--- a/junifer/utils/tests/test_config.py
+++ b/junifer/utils/tests/test_config.py
@@ -5,7 +5,7 @@
 # License: AGPL
 
 from junifer.utils import config
-from junifer.utils.config import ConfigManager
+from junifer.utils._config import ConfigManager
 
 
 def test_config_manager_singleton() -> None:

--- a/junifer/utils/tests/test_config.py
+++ b/junifer/utils/tests/test_config.py
@@ -1,0 +1,27 @@
+"""Provide tests for ConfigManager."""
+
+# Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
+#          Synchon Mandal <s.mandal@fz-juelich.de>
+# License: AGPL
+
+from junifer.utils import config
+from junifer.utils.config import ConfigManager
+
+
+def test_config_manager_singleton() -> None:
+    """Test that ConfigManager is a singleton."""
+    config_mgr_1 = ConfigManager()
+    config_mgr_2 = ConfigManager()
+    assert id(config_mgr_1) == id(config_mgr_2)
+
+
+def test_config_manager_get_set() -> None:
+    """Test config getting and setting for ConfigManager."""
+    # Get non-existing with default
+    assert "mystery_machine" == config.get(
+        key="scooby", default="mystery_machine"
+    )
+    # Set
+    config.set(key="scooby", value="doo")
+    # Get existing
+    assert "doo" == config.get("scooby")

--- a/junifer/utils/tests/test_config.py
+++ b/junifer/utils/tests/test_config.py
@@ -4,6 +4,11 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+import os
+
+import pytest
+
+from junifer.typing import ConfigVal
 from junifer.utils import config
 from junifer.utils._config import ConfigManager
 
@@ -15,13 +20,40 @@ def test_config_manager_singleton() -> None:
     assert id(config_mgr_1) == id(config_mgr_2)
 
 
-def test_config_manager_get_set() -> None:
-    """Test config getting and setting for ConfigManager."""
+def test_config_manager() -> None:
+    """Test config operations for ConfigManager."""
     # Get non-existing with default
-    assert "mystery_machine" == config.get(
-        key="scooby", default="mystery_machine"
-    )
+    assert config.get(key="scooby") is None
     # Set
-    config.set(key="scooby", value="doo")
+    config.set(key="scooby", val=True)
     # Get existing
-    assert "doo" == config.get("scooby")
+    assert config.get("scooby")
+    # Delete
+    config.delete("scooby")
+    # Get non-existing with default
+    assert config.get(key="scooby") is None
+
+
+@pytest.mark.parametrize(
+    "val, expected_val",
+    [("TRUE", True), ("FALSE", False), ("1", 1), ("0.0", 0.0)],
+)
+def test_config_manager_env_reload(val: str, expected_val: ConfigVal) -> None:
+    """Test config parsing from env reload.
+
+    Parameters
+    ----------
+    val : str
+        The parametrized values.
+    expected_val : bool or int or float
+        The parametrized expected value.
+
+    """
+    # Set env var
+    os.environ["JUNIFER_TESTME"] = val
+    # Check
+    config._reload()
+    assert config.get("testme") == expected_val
+    # Cleanup
+    del os.environ["JUNIFER_TESTME"]
+    config.delete("testme")


### PR DESCRIPTION
The idea of this PR is to provide two functions `junifer.utils.config.get` and `junifer.utils.config.set` which can be retrieved at any moment, allowing for run-wide configuration options that can be set to control internal behaviour of junifer.

On intialization, the enviroment variables that start with `JUNIFER_` will also be set.

E.g.:

In order to test/debug, we might already have a dataset cloned with some files already present. Currently, junifer will try to check if the dataset id matches with the URL and if also if the dataset is dirty.

By setting `datagrabber.skipdirtycheck` and `datagrabber.skipidcheck`, we can avoid cloning and checking, which are long operations on big datasets.