### PR TITLE
[ENH]: Allow `workdir` to forward parameters from YAML

### DIFF
--- a/docs/changes/newsfragments/402.change
+++ b/docs/changes/newsfragments/402.change
@@ -1,0 +1,1 @@
+Allow ``workdir`` to also be a mapping in YAML, with ``path`` and ``cleanup`` keys by `Synchon Mandal`_

--- a/docs/changes/newsfragments/402.enh
+++ b/docs/changes/newsfragments/402.enh
@@ -1,0 +1,1 @@
+Allow ``workdir`` mapping form in YAML for easy debugging of single element ``run`` by disabling cleanup of :class:`junifer.pipeline.WorkDirManager` by `Synchon Mandal`_

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -297,6 +297,15 @@ def queue(
             shutil.rmtree(jobdir)
     jobdir.mkdir(exist_ok=True, parents=True)
 
+    # Check workdir config
+    if isinstance(config["workdir"], dict):
+        if not config["workdir"]["cleanup"]:
+            warn_with_log(
+                "`workdir.cleanup` will be set to True when queueing"
+            )
+        # Set cleanup
+        config["workdir"]["cleanup"] = True
+
     # Load modules
     if "with" in config:
         to_load = config["with"]

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -143,7 +143,7 @@ def run(
         Storage to use. Must have a key ``kind`` with the kind of
         storage to use. All other keys are passed to the storage
         constructor.
-    preprocessors : list of dict, optional
+    preprocessors : list of dict or None, optional
         List of preprocessors to use. Each preprocessor is a dict with at
         least a key ``kind`` specifying the preprocessor to use. All other keys
         are passed to the preprocessor constructor (default None).

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -121,7 +121,7 @@ def run(
     markers: list[dict],
     storage: dict,
     preprocessors: Optional[list[dict]] = None,
-    elements: Union[str, list[Union[str, tuple]], tuple, None] = None,
+    elements: Optional[list[tuple[str, ...]]] = None,
 ) -> None:
     """Run the pipeline on the selected element.
 
@@ -147,7 +147,7 @@ def run(
         List of preprocessors to use. Each preprocessor is a dict with at
         least a key ``kind`` specifying the preprocessor to use. All other keys
         are passed to the preprocessor constructor (default None).
-    elements : str or tuple or list of str or tuple, optional
+    elements : list of tuple or None, optional
         Element(s) to process. Will be used to index the DataGrabber
         (default None).
 

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -298,13 +298,14 @@ def queue(
     jobdir.mkdir(exist_ok=True, parents=True)
 
     # Check workdir config
-    if isinstance(config["workdir"], dict):
-        if not config["workdir"]["cleanup"]:
-            warn_with_log(
-                "`workdir.cleanup` will be set to True when queueing"
-            )
-        # Set cleanup
-        config["workdir"]["cleanup"] = True
+    if "workdir" in config:
+        if isinstance(config["workdir"], dict):
+            if not config["workdir"]["cleanup"]:
+                warn_with_log(
+                    "`workdir.cleanup` will be set to True when queueing"
+                )
+            # Set cleanup
+            config["workdir"]["cleanup"] = True
 
     # Load modules
     if "with" in config:

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -243,7 +243,7 @@ def queue(
     kind: str,
     jobname: str = "junifer_job",
     overwrite: bool = False,
-    elements: Union[str, list[Union[str, tuple]], tuple, None] = None,
+    elements: Optional[list[tuple[str, ...]]] = None,
     **kwargs: Union[str, int, bool, dict, tuple, list],
 ) -> None:
     """Queue a job to be executed later.
@@ -258,7 +258,7 @@ def queue(
         The name of the job (default "junifer_job").
     overwrite : bool, optional
         Whether to overwrite if job directory already exists (default False).
-    elements : str or tuple or list of str or tuple, optional
+    elements : list of tuple or None, optional
         Element(s) to process. Will be used to index the DataGrabber
         (default None).
     **kwargs : dict
@@ -405,7 +405,7 @@ def reset(config: dict) -> None:
 
 def list_elements(
     datagrabber: dict,
-    elements: Union[str, list[Union[str, tuple]], tuple, None] = None,
+    elements: Optional[list[tuple[str, ...]]] = None,
 ) -> str:
     """List elements of the datagrabber filtered using `elements`.
 
@@ -415,7 +415,7 @@ def list_elements(
         DataGrabber to index. Must have a key ``kind`` with the kind of
         DataGrabber to use. All other keys are passed to the DataGrabber
         constructor.
-    elements : str or tuple or list of str or tuple, optional
+    elements : list of tuple or None, optional
         Element(s) to filter using. Will be used to index the DataGrabber
         (default None).
 

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -158,7 +158,7 @@ def run(
 
     """
     # Conditional to handle workdir config
-    if isinstance(workdir, str | Path):
+    if isinstance(workdir, (str, Path)):
         if isinstance(workdir, str):
             workdir = {"workdir": Path(workdir), "cleanup": True}
         else:

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -116,7 +116,7 @@ def test_run_single_element_with_preprocessing(
     storage["uri"] = str((tmp_path / "out.sqlite").resolve())
     # Run operations
     run(
-        workdir=tmp_path,
+        workdir={"path": tmp_path, "cleanup": False},
         datagrabber={
             "kind": "PartlyCloudyTestingDataGrabber",
             "reduce_confounds": False,
@@ -287,7 +287,10 @@ def test_queue_correct_yaml_config(
             queue(
                 config={
                     "with": "junifer.testing.registry",
-                    "workdir": str(tmp_path.resolve()),
+                    "workdir": {
+                        "path": str(tmp_path.resolve()),
+                        "cleanup": True,
+                    },
                     "datagrabber": datagrabber,
                     "markers": markers,
                     "storage": storage,
@@ -448,7 +451,13 @@ def test_queue_with_imports(
         (tmp_path / "a.py").touch()
         with caplog.at_level(logging.DEBUG):
             queue(
-                config={"with": with_},
+                config={
+                    "with": with_,
+                    "workdir": {
+                        "path": str(tmp_path.resolve()),
+                        "cleanup": False,
+                    },
+                },
                 kind="HTCondor",
                 jobname="with_import_check",
                 elements=[("sub-001",)],

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -88,7 +88,7 @@ def test_run_single_element(
         datagrabber=datagrabber,
         markers=markers,
         storage=storage,
-        elements=["sub-01"],
+        elements=[("sub-01",)],
     )
     # Check files
     files = list(tmp_path.glob("*.sqlite"))
@@ -128,7 +128,7 @@ def test_run_single_element_with_preprocessing(
                 "kind": "fMRIPrepConfoundRemover",
             }
         ],
-        elements=["sub-01"],
+        elements=[("sub-01",)],
     )
     # Check files
     files = list(tmp_path.glob("*.sqlite"))
@@ -164,7 +164,7 @@ def test_run_multi_element_multi_output(
         datagrabber=datagrabber,
         markers=markers,
         storage=storage,
-        elements=["sub-01", "sub-03"],
+        elements=[("sub-01",), ("sub-03",)],
     )
     # Check files
     files = list(tmp_path.glob("*.sqlite"))
@@ -200,7 +200,7 @@ def test_run_multi_element_single_output(
         datagrabber=datagrabber,
         markers=markers,
         storage=storage,
-        elements=["sub-01", "sub-03"],
+        elements=[("sub-01",), ("sub-03",)],
     )
     # Check files
     files = list(tmp_path.glob("*.sqlite"))
@@ -342,7 +342,7 @@ def test_queue_invalid_job_queue(
         with monkeypatch.context() as m:
             m.chdir(tmp_path)
             queue(
-                config={"elements": ["sub-001"]},
+                config={"elements": [("sub-001",)]},
                 kind="ABC",
             )
 
@@ -366,13 +366,13 @@ def test_queue_assets_disallow_overwrite(
             m.chdir(tmp_path)
             # First generate assets
             queue(
-                config={"elements": ["sub-001"]},
+                config={"elements": [("sub-001",)]},
                 kind="HTCondor",
                 jobname="prevent_overwrite",
             )
             # Re-run to trigger error
             queue(
-                config={"elements": ["sub-001"]},
+                config={"elements": [("sub-001",)]},
                 kind="HTCondor",
                 jobname="prevent_overwrite",
             )
@@ -399,14 +399,14 @@ def test_queue_assets_allow_overwrite(
         m.chdir(tmp_path)
         # First generate assets
         queue(
-            config={"elements": ["sub-001"]},
+            config={"elements": [("sub-001",)]},
             kind="HTCondor",
             jobname="allow_overwrite",
         )
         with caplog.at_level(logging.INFO):
             # Re-run to overwrite
             queue(
-                config={"elements": ["sub-001"]},
+                config={"elements": [("sub-001",)]},
                 kind="HTCondor",
                 jobname="allow_overwrite",
                 overwrite=True,
@@ -451,7 +451,7 @@ def test_queue_with_imports(
                 config={"with": with_},
                 kind="HTCondor",
                 jobname="with_import_check",
-                elements="sub-001",
+                elements=[("sub-001",)],
             )
             assert "Copying" in caplog.text
             assert "Queue done" in caplog.text
@@ -465,10 +465,8 @@ def test_queue_with_imports(
 @pytest.mark.parametrize(
     "elements",
     [
-        "sub-001",
-        ["sub-001"],
-        ["sub-001", "sub-002"],
-        ("sub-001", "ses-001"),
+        [("sub-001",)],
+        [("sub-001",), ("sub-002",)],
         [("sub-001", "ses-001")],
         [("sub-001", "ses-001"), ("sub-001", "ses-002")],
     ],
@@ -477,7 +475,7 @@ def test_queue_with_elements(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
-    elements: Union[str, list[Union[str, tuple[str]]], tuple[str]],
+    elements: list[tuple[str, ...]],
 ) -> None:
     """Test queue with elements.
 
@@ -489,7 +487,7 @@ def test_queue_with_elements(
         The pytest.MonkeyPatch object.
     caplog : pytest.LogCaptureFixture
         The pytest.LogCaptureFixture object.
-    elements : str of list of str
+    elements : list of tuple
         The parametrized elements for the queue.
 
     """
@@ -562,7 +560,7 @@ def test_reset_run(
         datagrabber=datagrabber,
         markers=markers,
         storage=storage,
-        elements=["sub-01"],
+        elements=[("sub-01",)],
     )
     # Reset operation
     reset(config={"storage": storage})
@@ -642,13 +640,13 @@ def test_reset_queue(
 @pytest.mark.parametrize(
     "elements",
     [
-        ["sub-01"],
+        [("sub-01",)],
         None,
     ],
 )
 def test_list_elements(
     datagrabber: dict[str, str],
-    elements: Optional[list[str]],
+    elements: Optional[list[tuple[str, ...]]],
 ) -> None:
     """Test elements listing.
 

--- a/junifer/cli/cli.py
+++ b/junifer/cli/cli.py
@@ -117,15 +117,16 @@ def run(
     filepath : click.Path
         The filepath to the configuration file.
     element : tuple of str
-        The element to operate on.
+        The element(s) to operate on.
     verbose : click.Choice
         The verbosity level: warning, info or debug (default "info").
 
     """
+    # Setup logging
     configure_logging(level=verbose)
     # TODO(synchon): add validation
     # Parse YAML
-    config = parse_yaml(filepath)  # type: ignore
+    config = parse_yaml(filepath)
     # Retrieve working directory
     workdir = config["workdir"]
     # Fetch datagrabber
@@ -179,9 +180,12 @@ def collect(filepath: click.Path, verbose: Union[str, int]) -> None:
         The verbosity level: warning, info or debug (default "info").
 
     """
+    # Setup logging
     configure_logging(level=verbose)
     # TODO: add validation
-    config = parse_yaml(filepath)  # type: ignore
+    # Parse YAML
+    config = parse_yaml(filepath)
+    # Fetch storage
     storage = config["storage"]
     # Perform operation
     cli_func.collect(storage=storage)
@@ -206,7 +210,7 @@ def collect(filepath: click.Path, verbose: Union[str, int]) -> None:
 )
 def queue(
     filepath: click.Path,
-    element: str,
+    element: tuple[str],
     overwrite: bool,
     submit: bool,
     verbose: Union[str, int],
@@ -219,8 +223,8 @@ def queue(
     ----------
     filepath : click.Path
         The filepath to the configuration file.
-    element : str
-        The element to operate using.
+    element : tuple of str
+        The element(s) to operate on.
     overwrite : bool
         Whether to overwrite existing directory.
     submit : bool
@@ -228,15 +232,26 @@ def queue(
     verbose : click.Choice
         The verbosity level: warning, info or debug (default "info").
 
+    Raises
+    ------
+    ValueError
+        If no ``queue`` section is found in the YAML.
+
     """
+    # Setup logging
     configure_logging(level=verbose)
     # TODO: add validation
+    # Parse YAML
     config = parse_yaml(filepath)  # type: ignore
-    elements = parse_elements(element, config)
+    # Check queue section
     if "queue" not in config:
         raise_error(f"No queue configuration found in {filepath}.")
+    # Parse elements
+    elements = parse_elements(element, config)
+    # Separate out queue section
     queue_config = config.pop("queue")
     kind = queue_config.pop("kind")
+    # Perform operation
     cli_func.queue(
         config=config,
         kind=kind,
@@ -366,6 +381,7 @@ def reset(
         The verbosity level: warning, info or debug (default "info").
 
     """
+    # Setup logging
     configure_logging(level=verbose)
     # Parse YAML
     config = parse_yaml(filepath)
@@ -408,7 +424,7 @@ def list_elements(
     filepath : click.Path
         The filepath to the configuration file.
     element : tuple of str
-        The element to operate on.
+        The element(s) to operate on.
     output_file : click.Path or None
         The path to write the output to. If not None, writing to
         stdout is not performed.
@@ -416,9 +432,10 @@ def list_elements(
         The verbosity level: warning, info or debug (default "info").
 
     """
+    # Setup logging
     configure_logging(level=verbose)
     # Parse YAML
-    config = parse_yaml(filepath)  # type: ignore
+    config = parse_yaml(filepath)
     # Fetch datagrabber
     datagrabber = config["datagrabber"]
     # Parse elements

--- a/junifer/cli/parser.py
+++ b/junifer/cli/parser.py
@@ -140,7 +140,9 @@ def parse_yaml(filepath: Union[str, Path]) -> dict:  # noqa: C901
     return contents
 
 
-def parse_elements(element: tuple[str], config: dict) -> Union[list, None]:
+def parse_elements(
+    element: tuple[str, ...], config: dict
+) -> Union[list[tuple[str, ...]], None]:
     """Parse elements from cli.
 
     Parameters
@@ -170,7 +172,7 @@ def parse_elements(element: tuple[str], config: dict) -> Union[list, None]:
     """
     logger.debug(f"Parsing elements: {element}")
     # Early return None to continue with all elements
-    if len(element) == 0:
+    if not element:
         return None
     # Check if the element is a file for single element;
     # if yes, then parse elements from it

--- a/junifer/pipeline/workdir_manager.py
+++ b/junifer/pipeline/workdir_manager.py
@@ -30,6 +30,9 @@ class WorkDirManager(metaclass=Singleton):
     workdir : str or pathlib.Path, optional
         The path to the super-directory. If None, "TMPDIR/junifer" is used
         where TMPDIR is the platform-dependent temporary directory.
+    cleanup : bool, optional
+        If False, the directories are not cleaned up after the object is
+        destroyed. This is useful for debugging purposes (default True).
 
     Attributes
     ----------
@@ -39,14 +42,11 @@ class WorkDirManager(metaclass=Singleton):
         The path to the element directory.
     root_tempdir : pathlib.Path or None
         The path to the root temporary directory.
-    cleanup : bool, optional
-        If False, the directories are not cleaned up after the object is
-        destroyed. This is useful for debugging purposes (default True).
 
     """
 
     def __init__(
-        self, workdir: Optional[Union[str, Path]] = None, cleanup=True
+        self, workdir: Optional[Union[str, Path]] = None, cleanup: bool = True
     ) -> None:
         """Initialize the class."""
         self._workdir = Path(workdir) if isinstance(workdir, str) else workdir


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR allows `workdir` to be a mapping with `path` and `cleanup` keys in the YAML, which are then forwarded with checks to initialize `WorkDirManager` for debug cases with single element.