### PR TITLE
[ENH]: Introduce `BOLD.reference` nested data type

### DIFF
--- a/docs/changes/newsfragments/407.feature
+++ b/docs/changes/newsfragments/407.feature
@@ -1,0 +1,1 @@
+Introduce ``BOLD.reference`` nested type and adapt :class:`.SpaceWarper` and necessary data components by `Fede Raimondo`_

--- a/junifer/data/coordinates/_fsl_coordinates_warper.py
+++ b/junifer/data/coordinates/_fsl_coordinates_warper.py
@@ -69,7 +69,7 @@ class FSLCoordinatesWarper:
             f"{pretransform_coordinates_path.resolve()}",
             "| img2imgcoord -mm",
             f"-src {target_data['path'].resolve()}",
-            f"-dest {target_data['reference_path'].resolve()}",
+            f"-dest {target_data['reference']['path'].resolve()}",
             f"-warp {warp_data['path'].resolve()}",
             f"> {transformed_coords_path.resolve()};",
             f"sed -i 1d {transformed_coords_path.resolve()}",

--- a/junifer/data/masks/_ants_mask_warper.py
+++ b/junifer/data/masks/_ants_mask_warper.py
@@ -49,9 +49,10 @@ class ANTsMaskWarper:
             It should be empty string if ``dst="T1w"``.
         dst : str
             The data type or template space to warp to.
-            `"T1w"` is the only allowed data type and it uses the resampled T1w
-            found in ``target_data.reference_path``. The ``"reference_path"``
-            key is added when :class:`.SpaceWarper` is used.
+            `"native"` is the only allowed data type and it uses the resampled
+            T1w found in ``target_data.reference``. The
+            ``"reference"`` key is added when :class:`.SpaceWarper` is
+            used or if the data is provided native space.
         target_data : dict
             The corresponding item of the data object to which the mask
             will be applied.
@@ -87,6 +88,10 @@ class ANTsMaskWarper:
             # Warp data check
             if warp_data is None:
                 raise_error("No `warp_data` provided")
+            if "reference" not in target_data:
+                raise_error("No `reference` provided")
+            if "path" not in target_data["reference"]:
+                raise_error("No `path` provided in `reference`")
 
             logger.debug("Using ANTs for mask transformation")
 
@@ -104,7 +109,7 @@ class ANTsMaskWarper:
                 "-n 'GenericLabel[NearestNeighbor]'",
                 f"-i {prewarp_mask_path.resolve()}",
                 # use resampled reference
-                f"-r {target_data['reference_path'].resolve()}",
+                f"-r {target_data['reference']['path'].resolve()}",
                 f"-t {warp_data['path'].resolve()}",
                 f"-o {warped_mask_path.resolve()}",
             ]

--- a/junifer/data/masks/_fsl_mask_warper.py
+++ b/junifer/data/masks/_fsl_mask_warper.py
@@ -74,7 +74,7 @@ class FSLMaskWarper:
             "--interp=nn",
             f"-i {prewarp_mask_path.resolve()}",
             # use resampled reference
-            f"-r {target_data['reference_path'].resolve()}",
+            f"-r {target_data['reference']['path'].resolve()}",
             f"-w {warp_data['path'].resolve()}",
             f"-o {warped_mask_path.resolve()}",
         ]

--- a/junifer/data/parcellations/_ants_parcellation_warper.py
+++ b/junifer/data/parcellations/_ants_parcellation_warper.py
@@ -50,8 +50,9 @@ class ANTsParcellationWarper:
         dst : str
             The data type or template space to warp to.
             `"T1w"` is the only allowed data type and it uses the resampled T1w
-            found in ``target_data.reference_path``. The ``"reference_path"``
-            key is added when :class:`.SpaceWarper` is used.
+            found in ``target_data.reference``. The ``"reference"``
+            key is added if the :class:`.SpaceWarper` is used or if the
+            data is provided in native space.
         target_data : dict
             The corresponding item of the data object to which the parcellation
             will be applied.
@@ -87,6 +88,10 @@ class ANTsParcellationWarper:
             # Warp data check
             if warp_data is None:
                 raise_error("No `warp_data` provided")
+            if "reference" not in target_data:
+                raise_error("No `reference` provided")
+            if "path" not in target_data["reference"]:
+                raise_error("No `path` provided in `reference`")
 
             logger.debug("Using ANTs for parcellation transformation")
 
@@ -108,7 +113,7 @@ class ANTsParcellationWarper:
                 "-n 'GenericLabel[NearestNeighbor]'",
                 f"-i {prewarp_parcellation_path.resolve()}",
                 # use resampled reference
-                f"-r {target_data['reference_path'].resolve()}",
+                f"-r {target_data['reference']['path'].resolve()}",
                 f"-t {warp_data['path'].resolve()}",
                 f"-o {warped_parcellation_path.resolve()}",
             ]

--- a/junifer/data/parcellations/_fsl_parcellation_warper.py
+++ b/junifer/data/parcellations/_fsl_parcellation_warper.py
@@ -78,7 +78,7 @@ class FSLParcellationWarper:
             "--interp=nn",
             f"-i {prewarp_parcellation_path.resolve()}",
             # use resampled reference
-            f"-r {target_data['reference_path'].resolve()}",
+            f"-r {target_data['reference']['path'].resolve()}",
             f"-w {warp_data['path'].resolve()}",
             f"-o {warped_parcellation_path.resolve()}",
         ]

--- a/junifer/datagrabber/pattern_validation_mixin.py
+++ b/junifer/datagrabber/pattern_validation_mixin.py
@@ -33,6 +33,8 @@ PATTERNS_SCHEMA = {
                 "mandatory": ["pattern", "format"],
                 "optional": ["mappings"],
             },
+            "reference": {"mandatory": ["pattern"], "optional": []},
+            "prewarp_space": {"mandatory": [], "optional": []},
         },
     },
     "Warp": {

--- a/junifer/preprocess/warping/_ants_warper.py
+++ b/junifer/preprocess/warping/_ants_warper.py
@@ -59,7 +59,7 @@ class ANTsWarper:
         -------
         dict
             The ``input`` dictionary with modified ``data`` and ``space`` key
-            values and new ``reference_path`` key whose value points to the
+            values and new ``reference`` key whose value points to the
             reference file used for warping.
 
         Raises
@@ -129,7 +129,7 @@ class ANTsWarper:
             # Load nifti
             input["data"] = nib.load(apply_transforms_out_path)
             # Save resampled reference path
-            input["reference_path"] = resample_image_out_path
+            input["reference"] = {"path": resample_image_out_path}
             # Keep pre-warp space for further operations
             input["prewarp_space"] = input["space"]
             # Use reference input's space as warped input's space

--- a/junifer/preprocess/warping/_fsl_warper.py
+++ b/junifer/preprocess/warping/_fsl_warper.py
@@ -55,7 +55,7 @@ class FSLWarper:
         -------
         dict
             The ``input`` dictionary with modified ``data`` and ``space`` key
-            values and new ``reference_path`` key whose value points to the
+            values and new ``reference`` key whose value points to the
             reference file used for warping.
 
         Raises
@@ -116,7 +116,7 @@ class FSLWarper:
         # Load nifti
         input["data"] = nib.load(applywarp_out_path)
         # Save resampled reference path
-        input["reference_path"] = flirt_out_path
+        input["reference"] = {"path": flirt_out_path}
         # Keep pre-warp space for further operations
         input["prewarp_space"] = input["space"]
         # Use reference input's space as warped input's space


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR introduces `reference` as a nested type of `BOLD` allowing to be specified either as part of a DataGrabber's `patterns` or added via `SpaceWarper`.