### PR TITLE
[BUG]: External dependencies not found despite being there

### DIFF
--- a/docs/changes/newsfragments/385.bugfix
+++ b/docs/changes/newsfragments/385.bugfix
@@ -1,0 +1,1 @@
+Use correct return code for ANTs commands while checking presence of external commands by `Synchon Mandal`_

--- a/junifer/pipeline/utils.py
+++ b/junifer/pipeline/utils.py
@@ -237,7 +237,7 @@ def _check_ants(commands: Optional[list[str]] = None) -> bool:
                 shell=True,  # is unsafe but kept for resolution via PATH
                 check=False,
             )
-            command_found = command_process.returncode == 0
+            command_found = command_process.returncode == 1
             commands_found_results[command] = (
                 "found" if command_found else "not found"
             )


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

There's a warning that some external commands are not available (e.g. ANTs' `ResampleImage`) but in the end it works.

### Expected Behavior

I would expect the warning to not be there.

### Steps To Reproduce

1. In juseless, run any yaml

### Environment

```markdown
junifer:
  version: 0.0.6.dev176
python:
  version: 3.12.6
  implementation: CPython
dependencies:
  click: 8.1.7
  numpy: 1.26.4
  scipy: 1.14.1
  datalad: 1.1.3
  pandas: 2.2.2
  nibabel: 5.2.1
  ruamel.yaml: 0.17.40
  looseversion: None
system:
  platform: Linux-6.6.13+bpo-amd64-x86_64-with-glibc2.36
environment:
  PATH:
    /data/group/appliedml/tools/ants_2.5.0/binaries:/home/fraimondo/miniconda3/envs/junifer/bin:/home/fraimondo/miniconda3/condabin:/usr/local/bin:/usr/bin:/bin:/usr/games
```


### Relevant log output

```shell
2024-10-24 10:35:45,780 [ WARNING] /home/fraimondo/miniconda3/envs/junifer/lib/python3.12/site-packages/junifer/pipeline/utils.py:248: RuntimeWarning: ANTs is installed but some of the required commands were not found. These are the results: {'ResampleImage': 'not found', 'antsApplyTransforms': 'not found'}
  warn_with_log(

2024-10-24 10:35:45,780 - JUNIFER - INFO - Preprocessing BOLD
2024-10-24 10:35:45,780 [    INFO] Preprocessing BOLD
2024-10-24 10:35:45,780 - JUNIFER - INFO - Warping to T1w space using SpaceWarper
2024-10-24 10:35:45,780 [    INFO] Warping to T1w space using SpaceWarper
2024-10-24 10:35:45,781 - JUNIFER - INFO - ResampleImage command to be executed:
ResampleImage 3 /tmp/tmpl7l_8aka/datadir/.git/annex/objects/91/63/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz /tmp/tmp_t5pk2tp/ants_warperpjn8gvog/resampled_reference.nii.gz 3.0x3.0x3.0 0 3 3
2024-10-24 10:35:45,781 [    INFO] ResampleImage command to be executed:
ResampleImage 3 /tmp/tmpl7l_8aka/datadir/.git/annex/objects/91/63/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz /tmp/tmp_t5pk2tp/ants_warperpjn8gvog/resampled_reference.nii.gz 3.0x3.0x3.0 0 3 3
2024-10-24 10:35:59,993 - JUNIFER - INFO - ResampleImage command succeeded with the following output:
/tmp/tmpl7l_8aka/datadir/.git/annex/objects/91/63/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz/MD5E-s31808414--24945231a2d73d0d08c4e402abd2f866.nii.gz is a file
```


### Anything else?

Indeed the issue seems to be that sometimes the commands output a non-zero status just because the parameters were not set correctly:

```
(junifer)juseless ➜  junifer git:(main) ResampleImage
Singularity args:
Corrected args for ANTS: ResampleImage
Running command: /data/group/appliedml/tools/ants_2.5.0/singularity_cmd exec --cleanenv  /data/group/appliedml/tools/ants_2.5.0/ants_v2.5.0.sif ResampleImage
Usage: ResampleImage imageDimension inputImage outputImage MxNxO [size=1,spacing=0] [interpolate type] [pixeltype]
  Interpolation type:
    0. linear (default)
    1. nn
    2. gaussian [sigma=imageSpacing] [alpha=1.0]
    3. windowedSinc [type = 'c'osine, 'w'elch, 'b'lackman, 'l'anczos, 'h'amming]
    4. B-Spline [order=3]
 pixeltype  :  TYPE
  0  :  char
  1  :  unsigned char
  2  :  short
  3  :  unsigned short
  4  :  int
  5  :  unsigned int
  6  :  float (default)
  7  :  double
(junifer)juseless ➜  junifer git:(main) echo $?
1
```

And we are checking only for zero commands:

https://github.com/juaml/junifer/blob/299b4549c87b98c809c5f3cae18443e0ad364e13/junifer/pipeline/utils.py#L232-L243