### PR TITLE
[ENH]: Refactor Preprocessors to sync data and their paths

### DIFF
--- a/docs/changes/newsfragments/408.enh
+++ b/docs/changes/newsfragments/408.enh
@@ -1,0 +1,1 @@
+Update Preprocessors to sync data their paths so that the results are idempotent by `Synchon Mandal`_

--- a/docs/changes/newsfragments/408.feature
+++ b/docs/changes/newsfragments/408.feature
@@ -1,0 +1,1 @@
+Allow masks to be warped, if found, in :class:`.SpaceWarper` by `Synchon Mandal`_

--- a/junifer/preprocess/smoothing/smoothing.py
+++ b/junifer/preprocess/smoothing/smoothing.py
@@ -164,12 +164,9 @@ class Smoothing(BasePreprocessor):
         elif self.using == "fsl":
             preprocessor = FSLSmoothing()
         # Smooth
-        output = preprocessor.preprocess(  # type: ignore
-            data=input["data"],
+        input = preprocessor.preprocess(
+            input=input,
             **self.smoothing_params,
         )
-
-        # Modify target data
-        input["data"] = output
 
         return input, None

--- a/junifer/preprocess/warping/_ants_warper.py
+++ b/junifer/preprocess/warping/_ants_warper.py
@@ -58,9 +58,7 @@ class ANTsWarper:
         Returns
         -------
         dict
-            The ``input`` dictionary with modified ``data`` and ``space`` key
-            values and new ``reference`` key whose value points to the
-            reference file used for warping.
+            The ``input`` dictionary with updated values.
 
         Raises
         ------
@@ -110,7 +108,7 @@ class ANTsWarper:
             run_ext_cmd(name="ResampleImage", cmd=resample_image_cmd)
 
             # Create a tempfile for warped output
-            apply_transforms_out_path = element_tempdir / "output.nii.gz"
+            apply_transforms_out_path = element_tempdir / "warped_data.nii.gz"
             # Set antsApplyTransforms command
             apply_transforms_cmd = [
                 "antsApplyTransforms",
@@ -126,14 +124,21 @@ class ANTsWarper:
             # Call antsApplyTransforms
             run_ext_cmd(name="antsApplyTransforms", cmd=apply_transforms_cmd)
 
-            # Load nifti
-            input["data"] = nib.load(apply_transforms_out_path)
-            # Save resampled reference path
-            input["reference"] = {"path": resample_image_out_path}
-            # Keep pre-warp space for further operations
-            input["prewarp_space"] = input["space"]
-            # Use reference input's space as warped input's space
-            input["space"] = extra_input["T1w"]["space"]
+            logger.debug("Updating warped data")
+            input.update(
+                {
+                    # Update path to sync with "data"
+                    "path": apply_transforms_out_path,
+                    # Load nifti
+                    "data": nib.load(apply_transforms_out_path),
+                    # Use reference input's space as warped input's space
+                    "space": extra_input["T1w"]["space"],
+                    # Save resampled reference path
+                    "reference": {"path": resample_image_out_path},
+                    # Keep pre-warp space for further operations
+                    "prewarp_space": input["space"],
+                }
+            )
 
         # Template space warping
         else:
@@ -149,16 +154,15 @@ class ANTsWarper:
                 target_data=input,
                 extra_input=None,
             )
-
-            # Create component-scoped tempdir
-            tempdir = WorkDirManager().get_tempdir(prefix="ants_warper")
             # Save template
-            template_space_img_path = tempdir / f"{reference}_T1w.nii.gz"
+            template_space_img_path = (
+                element_tempdir / f"{reference}_T1w.nii.gz"
+            )
             nib.save(template_space_img, template_space_img_path)
 
             # Create a tempfile for warped output
             warped_output_path = element_tempdir / (
-                f"data_warped_from_{input['space']}_to_" f"{reference}.nii.gz"
+                f"warped_data_from_{input['space']}_to_{reference}.nii.gz"
             )
 
             # Set antsApplyTransforms command
@@ -175,14 +179,21 @@ class ANTsWarper:
             # Call antsApplyTransforms
             run_ext_cmd(name="antsApplyTransforms", cmd=apply_transforms_cmd)
 
-            # Delete tempdir
-            WorkDirManager().delete_tempdir(tempdir)
+            logger.debug("Updating warped data")
+            input.update(
+                {
+                    # Update path to sync with "data"
+                    "path": warped_output_path,
+                    # Load nifti
+                    "data": nib.load(warped_output_path),
+                    # Update warped input's space
+                    "space": reference,
+                    # Save reference path
+                    "reference": {"path": template_space_img_path},
+                    # Keep pre-warp space for further operations
+                    "prewarp_space": input["space"],
+                }
+            )
 
-            # Modify target data
-            input["data"] = nib.load(warped_output_path)
-            # Keep pre-warp space for further operations
-            input["prewarp_space"] = input["space"]
-            # Update warped input's space
-            input["space"] = reference
 
         return input

--- a/junifer/preprocess/warping/_fsl_warper.py
+++ b/junifer/preprocess/warping/_fsl_warper.py
@@ -54,9 +54,7 @@ class FSLWarper:
         Returns
         -------
         dict
-            The ``input`` dictionary with modified ``data`` and ``space`` key
-            values and new ``reference`` key whose value points to the
-            reference file used for warping.
+            The ``input`` dictionary with updated values.
 
         Raises
         ------
@@ -100,26 +98,35 @@ class FSLWarper:
         run_ext_cmd(name="flirt", cmd=flirt_cmd)
 
         # Create a tempfile for warped output
-        applywarp_out_path = element_tempdir / "output.nii.gz"
+        applywarp_out_path = element_tempdir / "warped_data.nii.gz"
         # Set applywarp command
         applywarp_cmd = [
             "applywarp",
             "--interp=spline",
             f"-i {input['path'].resolve()}",
-            f"-r {flirt_out_path.resolve()}",  # use resampled reference
+            # use resampled reference
+            f"-r {flirt_out_path.resolve()}",
             f"-w {warp_file_path.resolve()}",
             f"-o {applywarp_out_path.resolve()}",
         ]
         # Call applywarp
         run_ext_cmd(name="applywarp", cmd=applywarp_cmd)
 
-        # Load nifti
-        input["data"] = nib.load(applywarp_out_path)
-        # Save resampled reference path
-        input["reference"] = {"path": flirt_out_path}
-        # Keep pre-warp space for further operations
-        input["prewarp_space"] = input["space"]
-        # Use reference input's space as warped input's space
-        input["space"] = extra_input["T1w"]["space"]
+        logger.debug("Updating warped data")
+        input.update(
+            {
+                # Update path to sync with "data"
+                "path": applywarp_out_path,
+                # Load nifti
+                "data": nib.load(applywarp_out_path),
+                # Use reference input's space as warped input's space
+                "space": extra_input["T1w"]["space"],
+                # Save resampled reference path
+                "reference": {"path": flirt_out_path},
+                # Keep pre-warp space for further operations
+                "prewarp_space": input["space"],
+            }
+        )
+
 
         return input


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR refactors Preprocessors to sync data and their paths so that the results are idempotent. This also adds support for warping masks, if present, in `SpaceWarper`.