### PR TITLE
[ENH]: Raise/warn if element is not ran

### DIFF
--- a/docs/changes/newsfragments/319.enh
+++ b/docs/changes/newsfragments/319.enh
@@ -1,0 +1,1 @@
+Raise error when partial or complete element selectors are invalid when running the pipeline by `Synchon Mandal`_

--- a/junifer/api/functions.py
+++ b/junifer/api/functions.py
@@ -20,7 +20,13 @@ from ..pipeline import (
 )
 from ..preprocess import BasePreprocessor
 from ..storage import BaseFeatureStorage
-from ..typing import DataGrabberLike, MarkerLike, PreprocessorLike, StorageLike
+from ..typing import (
+    DataGrabberLike,
+    Elements,
+    MarkerLike,
+    PreprocessorLike,
+    StorageLike,
+)
 from ..utils import logger, raise_error, warn_with_log, yaml
 
 
@@ -121,7 +127,7 @@ def run(
     markers: list[dict],
     storage: dict,
     preprocessors: Optional[list[dict]] = None,
-    elements: Optional[list[tuple[str, ...]]] = None,
+    elements: Optional[Elements] = None,
 ) -> None:
     """Run the pipeline on the selected element.
 
@@ -147,7 +153,7 @@ def run(
         List of preprocessors to use. Each preprocessor is a dict with at
         least a key ``kind`` specifying the preprocessor to use. All other keys
         are passed to the preprocessor constructor (default None).
-    elements : list of tuple or None, optional
+    elements : list or None, optional
         Element(s) to process. Will be used to index the DataGrabber
         (default None).
 
@@ -257,7 +263,7 @@ def queue(
     kind: str,
     jobname: str = "junifer_job",
     overwrite: bool = False,
-    elements: Optional[list[tuple[str, ...]]] = None,
+    elements: Optional[Elements] = None,
     **kwargs: Union[str, int, bool, dict, tuple, list],
 ) -> None:
     """Queue a job to be executed later.
@@ -272,7 +278,7 @@ def queue(
         The name of the job (default "junifer_job").
     overwrite : bool, optional
         Whether to overwrite if job directory already exists (default False).
-    elements : list of tuple or None, optional
+    elements : list or None, optional
         Element(s) to process. Will be used to index the DataGrabber
         (default None).
     **kwargs : dict
@@ -355,7 +361,7 @@ def queue(
                 elements = dg.get_elements()
     # Listify elements
     if not isinstance(elements, list):
-        elements: list[Union[str, tuple]] = [elements]
+        elements: Elements = [elements]
 
     # Check job queueing system
     adapter = None
@@ -420,7 +426,7 @@ def reset(config: dict) -> None:
 
 def list_elements(
     datagrabber: dict,
-    elements: Optional[list[tuple[str, ...]]] = None,
+    elements: Optional[Elements] = None,
 ) -> str:
     """List elements of the datagrabber filtered using `elements`.
 
@@ -430,7 +436,7 @@ def list_elements(
         DataGrabber to index. Must have a key ``kind`` with the kind of
         DataGrabber to use. All other keys are passed to the DataGrabber
         constructor.
-    elements : list of tuple or None, optional
+    elements : list or None, optional
         Element(s) to filter using. Will be used to index the DataGrabber
         (default None).
 

--- a/junifer/api/queue_context/gnu_parallel_local_adapter.py
+++ b/junifer/api/queue_context/gnu_parallel_local_adapter.py
@@ -6,8 +6,9 @@
 import shutil
 import textwrap
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
+from ...typing import Elements
 from ...utils import logger, make_executable, raise_error, run_ext_cmd
 from .queue_context_adapter import QueueContextAdapter
 
@@ -63,7 +64,7 @@ class GnuParallelLocalAdapter(QueueContextAdapter):
         job_name: str,
         job_dir: Path,
         yaml_config_path: Path,
-        elements: list[Union[str, tuple]],
+        elements: Elements,
         pre_run: Optional[str] = None,
         pre_collect: Optional[str] = None,
         env: Optional[dict[str, str]] = None,

--- a/junifer/api/queue_context/htcondor_adapter.py
+++ b/junifer/api/queue_context/htcondor_adapter.py
@@ -6,8 +6,9 @@
 import shutil
 import textwrap
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
+from ...typing import Elements
 from ...utils import logger, make_executable, raise_error, run_ext_cmd
 from .queue_context_adapter import QueueContextAdapter
 
@@ -81,7 +82,7 @@ class HTCondorAdapter(QueueContextAdapter):
         job_name: str,
         job_dir: Path,
         yaml_config_path: Path,
-        elements: list[Union[str, tuple]],
+        elements: Elements,
         pre_run: Optional[str] = None,
         pre_collect: Optional[str] = None,
         env: Optional[dict[str, str]] = None,

--- a/junifer/api/tests/test_functions.py
+++ b/junifer/api/tests/test_functions.py
@@ -58,7 +58,7 @@ _bids_ses_datagrabber = {
 @pytest.fixture
 def datagrabber() -> dict[str, str]:
     """Return a datagrabber as a dictionary."""
-    return _datagrabber
+    return _datagrabber.copy()
 
 
 @pytest.fixture

--- a/junifer/cli/parser.py
+++ b/junifer/cli/parser.py
@@ -214,7 +214,7 @@ def _parse_elements_file(filepath: Path) -> Elements:
 
     Returns
     -------
-    list of tuple of str
+    list
         The element(s) as list.
 
     """
@@ -228,5 +228,8 @@ def _parse_elements_file(filepath: Path) -> Elements:
     )
     # Remove trailing whitespace in cell entries
     csv_df_trimmed = csv_df.apply(lambda x: x.str.strip())
-    # Convert to list of tuple of str
-    return list(map(tuple, csv_df_trimmed.to_numpy()))
+    # Convert to list of tuple of str if more than one column else flatten
+    if len(csv_df_trimmed.columns) == 1:
+        return csv_df_trimmed.to_numpy().flatten().tolist()
+    else:
+        return list(map(tuple, csv_df_trimmed.to_numpy()))

--- a/junifer/cli/parser.py
+++ b/junifer/cli/parser.py
@@ -12,6 +12,7 @@ from typing import Union
 
 import pandas as pd
 
+from ..typing import Elements
 from ..utils import logger, raise_error, warn_with_log, yaml
 
 
@@ -142,7 +143,7 @@ def parse_yaml(filepath: Union[str, Path]) -> dict:  # noqa: C901
 
 def parse_elements(
     element: tuple[str, ...], config: dict
-) -> Union[list[tuple[str, ...]], None]:
+) -> Union[Elements, None]:
     """Parse elements from cli.
 
     Parameters
@@ -203,7 +204,7 @@ def parse_elements(
     return elements
 
 
-def _parse_elements_file(filepath: Path) -> list[tuple[str, ...]]:
+def _parse_elements_file(filepath: Path) -> Elements:
     """Parse elements from file.
 
     Parameters

--- a/junifer/datagrabber/base.py
+++ b/junifer/datagrabber/base.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Union
 
 from ..pipeline import UpdateMetaMixin
+from ..typing import Element, Elements
 from ..utils import logger, raise_error
 
 
@@ -67,9 +68,7 @@ class BaseDataGrabber(ABC, UpdateMetaMixin):
         """
         yield from self.get_elements()
 
-    def __getitem__(
-        self, element: Union[str, tuple[str, ...]]
-    ) -> dict[str, dict]:
+    def __getitem__(self, element: Element) -> dict[str, dict]:
         """Enable indexing support.
 
         Parameters
@@ -137,13 +136,13 @@ class BaseDataGrabber(ABC, UpdateMetaMixin):
         """
         return self._datadir
 
-    def filter(self, selection: list[Union[str, tuple[str]]]) -> Iterator:
+    def filter(self, selection: Elements) -> Iterator:
         """Filter elements to be grabbed.
 
         Parameters
         ----------
-        selection : list of str or tuple
-            The list of partial element key values to filter using.
+        selection : list
+            The list of partial or complete element selectors to filter using.
 
         Yields
         ------
@@ -152,7 +151,7 @@ class BaseDataGrabber(ABC, UpdateMetaMixin):
 
         """
 
-        def filter_func(element: Union[str, tuple[str]]) -> bool:
+        def filter_func(element: Element) -> bool:
             """Filter element based on selection.
 
             Parameters
@@ -201,15 +200,14 @@ class BaseDataGrabber(ABC, UpdateMetaMixin):
         )  # pragma: no cover
 
     @abstractmethod
-    def get_elements(self) -> list[Union[str, tuple[str]]]:
+    def get_elements(self) -> Elements:
         """Get elements.
 
         Returns
         -------
         list
-            List of elements that can be grabbed. The elements can be strings,
-            tuples or any object that will be then used as a key to index the
-            DataGrabber.
+            List of elements that can be grabbed. The elements can be strings
+            or tuples of strings to index the DataGrabber.
 
         """
         raise_error(

--- a/junifer/datagrabber/datalad_base.py
+++ b/junifer/datagrabber/datalad_base.py
@@ -17,6 +17,7 @@ from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.gitrepo import GitRepo
 
 from ..pipeline import WorkDirManager
+from ..typing import Element
 from ..utils import config, logger, raise_error, warn_with_log
 from .base import BaseDataGrabber
 
@@ -312,7 +313,7 @@ class DataladDataGrabber(BaseDataGrabber):
                 logger.debug(f"Dropping {f}")
                 self._dataset.drop(f, result_renderer="disabled")
 
-    def __getitem__(self, element: Union[str, tuple]) -> dict:
+    def __getitem__(self, element: Element) -> dict:
         """Implement single element indexing in the Datalad database.
 
         It will first obtain the paths from the parent class and then
@@ -320,11 +321,11 @@ class DataladDataGrabber(BaseDataGrabber):
 
         Parameters
         ----------
-        element : str or tuple
+        element : str or tuple of str
             The element to be indexed. If one string is provided, it is
             assumed to be a tuple with only one item. If a tuple is provided,
             each item in the tuple is the value for the replacement string
-            specified in "replacements".
+            specified in ``"replacements"``.
 
         Returns
         -------

--- a/junifer/datagrabber/pattern.py
+++ b/junifer/datagrabber/pattern.py
@@ -13,7 +13,7 @@ from typing import Optional, Union
 import numpy as np
 
 from ..api.decorators import register_datagrabber
-from ..typing import DataGrabberPatterns
+from ..typing import DataGrabberPatterns, Elements
 from ..utils import logger, raise_error
 from .base import BaseDataGrabber
 from .pattern_validation_mixin import PatternValidationMixin
@@ -367,7 +367,7 @@ class PatternDataGrabber(BaseDataGrabber, PatternValidationMixin):
         """
         return self.replacements
 
-    def get_item(self, **element: str) -> dict[str, dict]:
+    def get_item(self, **element: dict) -> dict[str, dict]:
         """Implement single element indexing for the datagrabber.
 
         This method constructs a real path to the requested item's data, by
@@ -450,7 +450,7 @@ class PatternDataGrabber(BaseDataGrabber, PatternValidationMixin):
 
         return out
 
-    def get_elements(self) -> list:
+    def get_elements(self) -> Elements:
         """Implement fetching list of elements in the dataset.
 
         It will use regex to search for "replacements" in the "patterns" and

--- a/junifer/typing/__init__.pyi
+++ b/junifer/typing/__init__.pyi
@@ -10,6 +10,8 @@ __all__ = [
     "MarkerInOutMappings",
     "DataGrabberPatterns",
     "ConfigVal",
+    "Element",
+    "Elements",
 ]
 
 from ._typing import (
@@ -24,4 +26,6 @@ from ._typing import (
     MarkerInOutMappings,
     DataGrabberPatterns,
     ConfigVal,
+    Element,
+    Elements,
 )

--- a/junifer/typing/_typing.py
+++ b/junifer/typing/_typing.py
@@ -24,6 +24,8 @@ __all__ = [
     "DataGrabberLike",
     "DataGrabberPatterns",
     "Dependencies",
+    "Element",
+    "Elements",
     "ExternalDependencies",
     "MarkerInOutMappings",
     "MarkerLike",
@@ -62,3 +64,5 @@ DataGrabberPatterns = dict[
     str, Union[dict[str, str], Sequence[dict[str, str]]]
 ]
 ConfigVal = Union[bool, int, float]
+Element = Union[str, tuple[str, ...]]
+Elements = Sequence[Element]


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

I just did this:

```
  patterns:
    VBM_GM: 
        pattern: derivatives/fmriprep/sub-{subject}/anat/sub-{subject}_space-MNI152NLin2009cAsym_label-GM_probseg.nii.gz
        space: MNI152NLin2009cAsym
  replacements: 
    - subject
```

and then tried to run junifer with `--element sub-0001`. 

The issue (which take me a lot of time to solve) is that `sub-0001` is not in the _elements_ list, since the replacement is without the `sub-` prefix.

Now, there was no issue/warning from the run function. It cloned the dataset, did nothing and dropped the dataset.



### How do you imagine this integrated in junifer?

We should implement a check in which if some of the elements in the list is not selected by the filter, there's a warning/error.

Exactly here is where we pass through the filter.

https://github.com/juaml/junifer/blob/a9e799caa3433d3d4eaa633d4565771b8eb297f6/junifer/api/functions.py#L170-L178

We should somehow keep a list of "unselected" elements so we can raise the warning.

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_