### PR TITLE
[ENH]: Move data downloading/handling to `junifer-data` package.

### DIFF
--- a/junifer/cli/tests/test_cli_utils.py
+++ b/junifer/cli/tests/test_cli_utils.py
@@ -77,7 +77,6 @@ def test_get_dependency_information_long() -> None:
         "templateflow",
         "lapy",
         "lazy_loader",
-        "junifer_data",
     ]
     for key in dependency_list:
         assert key in dependency_information_keys

--- a/junifer/cli/tests/test_cli_utils.py
+++ b/junifer/cli/tests/test_cli_utils.py
@@ -48,6 +48,7 @@ def test_get_dependency_information_short() -> None:
         "lapy",
         "lazy_loader",
         "looseversion",
+        "junifer_data",
     ]
 
     if sys.version_info < (3, 11):
@@ -76,6 +77,7 @@ def test_get_dependency_information_long() -> None:
         "templateflow",
         "lapy",
         "lazy_loader",
+        "junifer_data",
     ]
     for key in dependency_list:
         assert key in dependency_information_keys

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -4,16 +4,18 @@
 #          Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
+from junifer_data import get
 from numpy.typing import ArrayLike
 
 from ...utils import logger, raise_error
 from ...utils.singleton import Singleton
 from ..pipeline_data_registry_base import BasePipelineDataRegistry
-from ..utils import check_dataset, fetch_file_via_datalad, get_native_warper
+from ..utils import JUNIFER_DATA_VERSION, get_dataset_path, get_native_warper
 from ._ants_coordinates_warper import ANTsCoordinatesWarper
 from ._fsl_coordinates_warper import FSLCoordinatesWarper
 
@@ -273,23 +275,17 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
 
         # Load data for in-built ones
         if t_coord.get("file_path_suffix") is not None:
-            # Get dataset
-            dataset = check_dataset()
             # Set file path to retrieve
-            coords_file_path = (
-                dataset.pathobj
-                / "coordinates"
-                / name
-                / t_coord["file_path_suffix"]
+            coords_file_path = Path(
+                f"coordinates/{name}/{t_coord['file_path_suffix']}"
             )
-            logger.debug(
-                f"Loading coordinates `{name}` from: "
-                f"{coords_file_path.absolute()!s}"
-            )
+            logger.debug(f"Loading coordinates: `{name}`")
             # Load via pandas
             df_coords = pd.read_csv(
-                fetch_file_via_datalad(
-                    dataset=dataset, file_path=coords_file_path
+                get(
+                    file_path=coords_file_path,
+                    dataset_path=get_dataset_path(),
+                    tag=JUNIFER_DATA_VERSION,
                 ),
                 sep="\t",
                 header=None,

--- a/junifer/data/masks/tests/test_masks.py
+++ b/junifer/data/masks/tests/test_masks.py
@@ -26,7 +26,6 @@ from junifer.data.masks._masks import (
     _load_ukb_mask,
     _load_vickery_patil_mask,
 )
-from junifer.data.utils import check_dataset
 from junifer.datagrabber import DMCC13Benchmark
 from junifer.datareader import DefaultDataReader
 from junifer.testing.datagrabbers import (
@@ -283,9 +282,7 @@ def test_vickery_patil(
 def test_vickery_patil_error() -> None:
     """Test error for Vickery-Patil mask."""
     with pytest.raises(ValueError, match=r"find a Vickery-Patil mask "):
-        _load_vickery_patil_mask(
-            dataset=check_dataset(), name="wrong", resolution=2.0
-        )
+        _load_vickery_patil_mask(name="wrong", resolution=2.0)
 
 
 def test_ukb() -> None:
@@ -300,7 +297,7 @@ def test_ukb() -> None:
 def test_ukb_error() -> None:
     """Test error for UKB mask."""
     with pytest.raises(ValueError, match=r"find a UKB mask "):
-        _load_ukb_mask(dataset=check_dataset(), name="wrong")
+        _load_ukb_mask(name="wrong")
 
 
 def test_get() -> None:

--- a/junifer/data/parcellations/tests/test_parcellations.py
+++ b/junifer/data/parcellations/tests/test_parcellations.py
@@ -24,7 +24,6 @@ from junifer.data.parcellations._parcellations import (
     _retrieve_tian,
     _retrieve_yan,
 )
-from junifer.data.utils import check_dataset
 from junifer.datareader import DefaultDataReader
 from junifer.pipeline.utils import _check_ants
 from junifer.testing.datagrabbers import (
@@ -335,7 +334,6 @@ def test_retrieve_schaefer_incorrect_n_rois() -> None:
     """Test retrieve Schaefer with incorrect ROIs."""
     with pytest.raises(ValueError, match=r"The parameter `n_rois`"):
         _retrieve_schaefer(
-            dataset=check_dataset(),
             resolution=1,
             n_rois=101,
             yeo_networks=7,
@@ -346,7 +344,6 @@ def test_retrieve_schaefer_incorrect_yeo_networks() -> None:
     """Test retrieve Schaefer with incorrect Yeo networks."""
     with pytest.raises(ValueError, match=r"The parameter `yeo_networks`"):
         _retrieve_schaefer(
-            dataset=check_dataset(),
             resolution=1,
             n_rois=100,
             yeo_networks=8,
@@ -384,7 +381,7 @@ def test_suit(space_key: str, space: str) -> None:
 def test_retrieve_suit_incorrect_space() -> None:
     """Test retrieve SUIT with incorrect space."""
     with pytest.raises(ValueError, match=r"The parameter `space`"):
-        _retrieve_suit(dataset=check_dataset(), resolution=1.0, space="wrong")
+        _retrieve_suit(resolution=1.0, space="wrong")
 
 
 @pytest.mark.parametrize(
@@ -512,13 +509,10 @@ def test_tian_7T_6thgeneration(scale: int, n_label: int) -> None:
 def test_retrieve_tian_incorrect_space() -> None:
     """Test retrieve tian with incorrect space."""
     with pytest.raises(ValueError, match=r"The parameter `space`"):
-        _retrieve_tian(
-            dataset=check_dataset(), resolution=1, scale=1, space="wrong"
-        )
+        _retrieve_tian(resolution=1, scale=1, space="wrong")
 
     with pytest.raises(ValueError, match=r"MNI152NLin6Asym"):
         _retrieve_tian(
-            dataset=check_dataset(),
             resolution=1,
             scale=1,
             magneticfield="7T",
@@ -530,7 +524,6 @@ def test_retrieve_tian_incorrect_magneticfield() -> None:
     """Test retrieve tian with incorrect magneticfield."""
     with pytest.raises(ValueError, match=r"The parameter `magneticfield`"):
         _retrieve_tian(
-            dataset=check_dataset(),
             resolution=1,
             scale=1,
             magneticfield="wrong",
@@ -541,7 +534,6 @@ def test_retrieve_tian_incorrect_scale(tmp_path: Path) -> None:
     """Test retrieve tian with incorrect scale."""
     with pytest.raises(ValueError, match=r"The parameter `scale`"):
         _retrieve_tian(
-            dataset=check_dataset(),
             resolution=1,
             scale=5,
             space="MNI152NLin6Asym",
@@ -577,7 +569,6 @@ def test_retrieve_aicha_incorrect_version() -> None:
     """Test retrieve AICHA with incorrect version."""
     with pytest.raises(ValueError, match="The parameter `version`"):
         _retrieve_aicha(
-            dataset=check_dataset(),
             version=100,
         )
 
@@ -639,7 +630,6 @@ def test_retrieve_shen_incorrect_year() -> None:
     """Test retrieve Shen with incorrect year."""
     with pytest.raises(ValueError, match="The parameter `year`"):
         _retrieve_shen(
-            dataset=check_dataset(),
             year=1969,
         )
 
@@ -648,7 +638,6 @@ def test_retrieve_shen_incorrect_n_rois() -> None:
     """Test retrieve Shen with incorrect ROIs."""
     with pytest.raises(ValueError, match="The parameter `n_rois`"):
         _retrieve_shen(
-            dataset=check_dataset(),
             year=2015,
             n_rois=10,
         )
@@ -691,7 +680,6 @@ def test_retrieve_shen_incorrect_param_combo(
     """
     with pytest.raises(ValueError, match="The parameter combination"):
         _retrieve_shen(
-            dataset=check_dataset(),
             resolution=resolution,
             year=year,
             n_rois=n_rois,
@@ -819,7 +807,6 @@ def test_retrieve_yan_incorrect_networks() -> None:
         ValueError, match="Either one of `yeo_networks` or `kong_networks`"
     ):
         _retrieve_yan(
-            dataset=check_dataset(),
             n_rois=31418,
             yeo_networks=100,
             kong_networks=100,
@@ -829,7 +816,6 @@ def test_retrieve_yan_incorrect_networks() -> None:
         ValueError, match="Either one of `yeo_networks` or `kong_networks`"
     ):
         _retrieve_yan(
-            dataset=check_dataset(),
             n_rois=31418,
             yeo_networks=None,
             kong_networks=None,
@@ -840,7 +826,6 @@ def test_retrieve_yan_incorrect_n_rois() -> None:
     """Test retrieve Yan with incorrect ROIs."""
     with pytest.raises(ValueError, match="The parameter `n_rois`"):
         _retrieve_yan(
-            dataset=check_dataset(),
             n_rois=31418,
             yeo_networks=7,
         )
@@ -850,7 +835,6 @@ def test_retrieve_yan_incorrect_yeo_networks() -> None:
     """Test retrieve Yan with incorrect Yeo networks."""
     with pytest.raises(ValueError, match="The parameter `yeo_networks`"):
         _retrieve_yan(
-            dataset=check_dataset(),
             n_rois=100,
             yeo_networks=27,
         )
@@ -860,7 +844,6 @@ def test_retrieve_yan_incorrect_kong_networks() -> None:
     """Test retrieve Yan with incorrect Kong networks."""
     with pytest.raises(ValueError, match="The parameter `kong_networks`"):
         _retrieve_yan(
-            dataset=check_dataset(),
             n_rois=100,
             kong_networks=27,
         )
@@ -922,7 +905,6 @@ def test_retrieve_brainnetome_incorrect_threshold() -> None:
     """Test retrieve Brainnetome with incorrect threshold."""
     with pytest.raises(ValueError, match="The parameter `threshold`"):
         _retrieve_brainnetome(
-            dataset=check_dataset(),
             threshold=100,
         )
 

--- a/junifer/data/template_spaces.py
+++ b/junifer/data/template_spaces.py
@@ -8,10 +8,11 @@ from typing import Any, Optional, Union
 
 import nibabel as nib
 import numpy as np
+from junifer_data import get
 from templateflow import api as tflow
 
 from ..utils import logger, raise_error
-from .utils import check_dataset, closest_resolution, fetch_file_via_datalad
+from .utils import JUNIFER_DATA_VERSION, closest_resolution, get_dataset_path
 
 
 __all__ = ["get_template", "get_xfm"]
@@ -33,17 +34,14 @@ def get_xfm(src: str, dst: str) -> Path:  # pragma: no cover
         The path to the transformation file.
 
     """
-    # Get dataset
-    dataset = check_dataset()
     # Set file path to retrieve
-    xfm_file_path = (
-        dataset.pathobj
-        / "xfms"
-        / f"{src}_to_{dst}"
-        / f"{src}_to_{dst}_Composite.h5"
-    )
+    xfm_file_path = Path(f"xfms/{src}_to_{dst}/{src}_to_{dst}_Composite.h5")
     # Retrieve file
-    return fetch_file_via_datalad(dataset=dataset, file_path=xfm_file_path)
+    return get(
+        file_path=xfm_file_path,
+        dataset_path=get_dataset_path(),
+        tag=JUNIFER_DATA_VERSION,
+    )
 
 
 def get_template(

--- a/junifer/data/utils.py
+++ b/junifer/data/utils.py
@@ -22,7 +22,7 @@ __all__ = [
 
 
 # junifer-data version constant
-JUNIFER_DATA_VERSION = "1.0.0"
+JUNIFER_DATA_VERSION = "1"
 
 
 def closest_resolution(

--- a/junifer/data/utils.py
+++ b/junifer/data/utils.py
@@ -8,19 +8,21 @@ from collections.abc import MutableMapping
 from pathlib import Path
 from typing import Optional, Union
 
-import datalad.api as dl
 import numpy as np
-from datalad.support.exceptions import IncompleteResultsError
 
 from ..utils import config, logger, raise_error
 
 
 __all__ = [
-    "check_dataset",
+    "JUNIFER_DATA_VERSION",
     "closest_resolution",
-    "fetch_file_via_datalad",
+    "get_dataset_path",
     "get_native_warper",
 ]
+
+
+# junifer-data version constant
+JUNIFER_DATA_VERSION = "1.0.0"
 
 
 def closest_resolution(
@@ -124,94 +126,17 @@ def get_native_warper(
     return possible_warpers[0]
 
 
-def check_dataset() -> dl.Dataset:
-    """Get or install junifer-data dataset.
+def get_dataset_path() -> Optional[Path]:
+    """Get junifer-data dataset path.
 
     Returns
     -------
-    datalad.api.Dataset
-        The junifer-data dataset.
-
-    Raises
-    ------
-    RuntimeError
-        If there is a problem cloning the dataset.
+    pathlib.Path or None
+        Path to the dataset or None.
 
     """
-    # Check config and set default if not passed
-    data_dir = config.get("data.location")
-    if data_dir is not None:
-        data_dir = Path(data_dir)
-    else:
-        data_dir = Path().home() / "junifer_data"
-
-    # Check if the dataset is installed at storage path;
-    # else clone a fresh copy
-    if dl.Dataset(data_dir).is_installed():
-        logger.debug(f"Found existing junifer-data at: {data_dir.resolve()}")
-        return dl.Dataset(data_dir)
-    else:
-        logger.debug(f"Cloning junifer-data to: {data_dir.resolve()}")
-        # Clone dataset
-        try:
-            dataset = dl.clone(
-                "https://github.com/juaml/junifer-data.git",
-                path=data_dir,
-                result_renderer="disabled",
-            )
-        except IncompleteResultsError as e:
-            raise_error(
-                msg=f"Failed to clone junifer-data: {e.failed}",
-                klass=RuntimeError,
-            )
-        else:
-            logger.debug(
-                f"Successfully cloned junifer-data to: "
-                f"{data_dir.resolve()}"
-            )
-            return dataset
-
-
-def fetch_file_via_datalad(dataset: dl.Dataset, file_path: Path) -> Path:
-    """Fetch `file_path` from `dataset` via datalad.
-
-    Parameters
-    ----------
-    dataset : datalad.api.Dataset
-        The datalad dataset to fetch files from.
-    file_path : pathlib.Path
-        The file path to fetch.
-
-    Returns
-    -------
-    pathlib.Path
-        Resolved fetched file path.
-
-    Raises
-    ------
-    RuntimeError
-        If there is a problem fetching the file.
-
-    """
-    try:
-        got = dataset.get(file_path, result_renderer="disabled")
-    except IncompleteResultsError as e:
-        raise_error(
-            msg=f"Failed to get file from dataset: {e.failed}",
-            klass=RuntimeError,
-        )
-    else:
-        got_path = Path(got[0]["path"])
-        # Conditional logging based on file fetch
-        status = got[0]["status"]
-        if status == "ok":
-            logger.info(f"Successfully fetched file: {got_path.resolve()}")
-            return got_path
-        elif status == "notneeded":
-            logger.debug(f"Found existing file: {got_path.resolve()}")
-            return got_path
-        else:
-            raise_error(
-                msg=f"Failed to fetch file: {got_path.resolve()}",
-                klass=RuntimeError,
-            )
+    return (
+        Path(config.get("data.location"))
+        if config.get("data.location") is not None
+        else None
+    )

--- a/junifer/typing/_typing.py
+++ b/junifer/typing/_typing.py
@@ -63,6 +63,6 @@ MarkerInOutMappings = MutableMapping[str, MutableMapping[str, str]]
 DataGrabberPatterns = dict[
     str, Union[dict[str, str], Sequence[dict[str, str]]]
 ]
-ConfigVal = Union[bool, int, float]
+ConfigVal = Union[bool, int, float, str]
 Element = Union[str, tuple[str, ...]]
 Elements = Sequence[Element]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "lazy_loader==0.4",
     "importlib_metadata; python_version<'3.9'",
     "looseversion==1.3.0; python_version>='3.12'",
+    "junifer_data==1.0.0",
 ]
 dynamic = ["version"]
 
@@ -212,6 +213,7 @@ known-third-party = [
     "brainprint",
     "lapy",
     "pytest",
+    "junifer_data",
 ]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "lazy_loader==0.4",
     "importlib_metadata; python_version<'3.9'",
     "looseversion==1.3.0; python_version>='3.12'",
-    "junifer_data==1.0.0",
+    "junifer_data==1.1.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

Currently, Junifer is handling the data, downloading from various sources. Ideally, this should be centralized and versiones.

### How do you imagine this integrated in junifer?

1. Junifer uses the `junifer-data` API.
2. `junifer-data` keeps a datalad dataset with all data objects, including externals. Each commit to this datasets has a tag.
3. `junifer` knows exactly which is the tag that we are dealing with, so each junifer version will always work with the same data files.
4. We have a command `download` or similar that makes junifer download all (or the requested) files to be used later on with the `run` command.

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_