### PR TITLE
[CI]: Adapt usage of `junifer-data` for Docker images

### DIFF
--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -44,8 +44,8 @@ RUN apt-get update && \
     libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-# Add xfms
-COPY --from=ghcr.io/juaml/human-template-xfms:main /opt/xfms /root/junifer/data/xfms
+# Add junifer-data
+COPY --from=ghcr.io/juaml/junifer-data:v1 /opt/junifer-data /root/junifer_data/v1
 
 # Add ANTs
 COPY --from=antsx/ants:latest /opt/ants /opt/ants

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -13,8 +13,9 @@ RUN apt-get update && \
     bc \
     && rm -rf /var/lib/apt/lists/*
 
-# Add xfms
-COPY --from=ghcr.io/juaml/human-template-xfms:main /opt/xfms /root/junifer/data/xfms
+# Add junifer-data
+COPY --from=ghcr.io/juaml/junifer-data:v1 /opt/junifer-data /root/junifer_data/v1
+
 # Add ANTs
 COPY --from=antsx/ants:latest /opt/ants /opt/ants
 # Set env vars for ANTs

--- a/docs/changes/newsfragments/427.misc
+++ b/docs/changes/newsfragments/427.misc
@@ -1,0 +1,1 @@
+Use ``junifer-data`` in CI images by `Synchon Mandal`_


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR removes `xfms` and adds `junifer-data` for CI images.