### PR TITLE
[BUG]: Cannot fetch Power2011 coordinates

### DIFF
--- a/docs/changes/newsfragments/431.bugfix
+++ b/docs/changes/newsfragments/431.bugfix
@@ -1,0 +1,1 @@
+Fix coordinates fetching for Power and Dosenbach from ``junifer-data`` by `Synchon Mandal`_

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -47,83 +47,85 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
         self._builtin.update(
             {
                 "CogAC": {
-                    "file_path_suffix": "CogAC_VOIs.txt",
+                    "file_path_suffix": "CogAC/CogAC_VOIs.txt",
                     "space": "MNI",
                 },
                 "CogAR": {
-                    "file_path_suffix": "CogAR_VOIs.txt",
+                    "file_path_suffix": "CogAR/CogAR_VOIs.txt",
                     "space": "MNI",
                 },
                 "DMNBuckner": {
-                    "file_path_suffix": "DMNBuckner_VOIs.txt",
+                    "file_path_suffix": "DMNBuckner/DMNBuckner_VOIs.txt",
                     "space": "MNI",
                 },
                 "eMDN": {
-                    "file_path_suffix": "eMDN_VOIs.txt",
+                    "file_path_suffix": "eMDN/eMDN_VOIs.txt",
                     "space": "MNI",
                 },
                 "Empathy": {
-                    "file_path_suffix": "Empathy_VOIs.txt",
+                    "file_path_suffix": "Empathy/Empathy_VOIs.txt",
                     "space": "MNI",
                 },
                 "eSAD": {
-                    "file_path_suffix": "eSAD_VOIs.txt",
+                    "file_path_suffix": "eSAD/eSAD_VOIs.txt",
                     "space": "MNI",
                 },
                 "extDMN": {
-                    "file_path_suffix": "extDMN_VOIs.txt",
+                    "file_path_suffix": "extDMN/extDMN_VOIs.txt",
                     "space": "MNI",
                 },
                 "Motor": {
-                    "file_path_suffix": "Motor_VOIs.txt",
+                    "file_path_suffix": "Motor/Motor_VOIs.txt",
                     "space": "MNI",
                 },
                 "MultiTask": {
-                    "file_path_suffix": "MultiTask_VOIs.txt",
+                    "file_path_suffix": "MultiTask/MultiTask_VOIs.txt",
                     "space": "MNI",
                 },
                 "PhysioStress": {
-                    "file_path_suffix": "PhysioStress_VOIs.txt",
+                    "file_path_suffix": "PhysioStress/PhysioStress_VOIs.txt",
                     "space": "MNI",
                 },
                 "Rew": {
-                    "file_path_suffix": "Rew_VOIs.txt",
+                    "file_path_suffix": "Rew/Rew_VOIs.txt",
                     "space": "MNI",
                 },
                 "Somatosensory": {
-                    "file_path_suffix": "Somatosensory_VOIs.txt",
+                    "file_path_suffix": "Somatosensory/Somatosensory_VOIs.txt",
                     "space": "MNI",
                 },
                 "ToM": {
-                    "file_path_suffix": "ToM_VOIs.txt",
+                    "file_path_suffix": "ToM/ToM_VOIs.txt",
                     "space": "MNI",
                 },
                 "VigAtt": {
-                    "file_path_suffix": "VigAtt_VOIs.txt",
+                    "file_path_suffix": "VigAtt/VigAtt_VOIs.txt",
                     "space": "MNI",
                 },
                 "WM": {
-                    "file_path_suffix": "WM_VOIs.txt",
+                    "file_path_suffix": "WM/WM_VOIs.txt",
                     "space": "MNI",
                 },
                 "Power": {
-                    "file_path_suffix": "Power2011_MNI_VOIs.txt",
+                    "file_path_suffix": "Power/Power2011_MNI_VOIs.txt",
                     "space": "MNI",
                 },
                 "Power2011": {
-                    "file_path_suffix": "Power2011_MNI_VOIs.txt",
+                    "file_path_suffix": "Power/Power2011_MNI_VOIs.txt",
                     "space": "MNI",
                 },
                 "Dosenbach": {
-                    "file_path_suffix": "Dosenbach2010_MNI_VOIs.txt",
+                    "file_path_suffix": "Dosenbach/Dosenbach2010_MNI_VOIs.txt",
                     "space": "MNI",
                 },
                 "Power2013": {
-                    "file_path_suffix": "Power2013_MNI_VOIs.tsv",
+                    "file_path_suffix": "Power/Power2013_MNI_VOIs.tsv",
                     "space": "MNI",
                 },
                 "AutobiographicalMemory": {
-                    "file_path_suffix": "AutobiographicalMemory_VOIs.txt",
+                    "file_path_suffix": (
+                        "AutobiographicalMemory/AutobiographicalMemory_VOIs.txt"
+                    ),
                     "space": "MNI",
                 },
             }
@@ -277,7 +279,7 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
         if t_coord.get("file_path_suffix") is not None:
             # Set file path to retrieve
             coords_file_path = Path(
-                f"coordinates/{name}/{t_coord['file_path_suffix']}"
+                f"coordinates/{t_coord['file_path_suffix']}"
             )
             logger.debug(f"Loading coordinates: `{name}`")
             # Load via pandas


### PR DESCRIPTION
### Is there an existing issue for this?

- [x] I have searched the existing issues

### Current Behavior

When trying to fetch Power2011 coordinates, I get a datalad error:

```
RuntimeError: Failed to get file from dataset: [{'action': 'get', 'path': '/home/fraimondo/junifer_data/v1/coordinates/Power2011/Power2011_MNI_VOIs.txt', 'status': 'impossible', 'refds': '/home/fraimondo/junifer_data/v1', 'message': 'path does not exist'}]
```

Indeed it seems that the issue comes from the name:

https://github.com/juaml/junifer/blob/1b2072ef4e6c08d1f84ea4f1ddc5aee079d3d84e/junifer/data/coordinates/_coordinates.py#L279-L281

It expects Power2011 as the `name`, but junifer-data has it as Power only.

### Expected Behavior

I expect the Power 2011 coordinates to be loaded.

### Steps To Reproduce

1. With junifer main branch.
2. Run
``` Python
from junifer.data import get_data
get_data("coordinates", "Power2011", target_data=None)
```

### Environment

```markdown
junifer:
  version: 0.0.6.dev502
python:
  version: 3.12.7
  implementation: CPython
dependencies:
  click: 8.1.7
  numpy: 1.26.4
  scipy: 1.14.1
  datalad: 1.1.4
  pandas: 2.2.3
  nibabel: 5.3.2
  ruamel.yaml: 0.18.6
  looseversion: None
system:
  platform: Linux-6.12.9+bpo-amd64-x86_64-with-glibc2.36
environment:
  PATH: 
    /home/fraimondo/miniforge3/envs/junifer_dev/bin:/home/fraimondo/.local/bin:/home/fraimondo/miniforge3/condabin:/usr/local/bin:/home/fraimondo/miniforge3/condabin:/home/fraimondo/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/games
```

### Relevant log output

```shell

```

### Anything else?

_No response_