### PR TITLE
Use hexsha to verify junifer-data integrity

### DIFF
--- a/docs/changes/newsfragments/434.enh
+++ b/docs/changes/newsfragments/434.enh
@@ -1,0 +1,1 @@
+Add commit SHA check for ``junifer_data`` to simplify data fetching by `Fede Raimondo`_

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -15,7 +15,7 @@ from numpy.typing import ArrayLike
 from ...utils import logger, raise_error
 from ...utils.singleton import Singleton
 from ..pipeline_data_registry_base import BasePipelineDataRegistry
-from ..utils import JUNIFER_DATA_VERSION, get_dataset_path, get_native_warper
+from ..utils import JUNIFER_DATA_PARAMS, get_dataset_path, get_native_warper
 from ._ants_coordinates_warper import ANTsCoordinatesWarper
 from ._fsl_coordinates_warper import FSLCoordinatesWarper
 
@@ -287,7 +287,7 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                 get(
                     file_path=coords_file_path,
                     dataset_path=get_dataset_path(),
-                    tag=JUNIFER_DATA_VERSION,
+                    **JUNIFER_DATA_PARAMS,
                 ),
                 sep="\t",
                 header=None,

--- a/junifer/data/masks/_masks.py
+++ b/junifer/data/masks/_masks.py
@@ -28,7 +28,7 @@ from ...utils.singleton import Singleton
 from ..pipeline_data_registry_base import BasePipelineDataRegistry
 from ..template_spaces import get_template
 from ..utils import (
-    JUNIFER_DATA_VERSION,
+    JUNIFER_DATA_PARAMS,
     closest_resolution,
     get_dataset_path,
     get_native_warper,
@@ -745,7 +745,7 @@ def _load_vickery_patil_mask(
     return get(
         file_path=Path(f"masks/Vickery-Patil/{mask_fname}"),
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
 
 
@@ -778,7 +778,7 @@ def _load_ukb_mask(name: str) -> Path:
     return get(
         file_path=Path(f"masks/UKB/{mask_fname}"),
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
 
 

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -19,7 +19,7 @@ from ...utils import logger, raise_error, warn_with_log
 from ...utils.singleton import Singleton
 from ..pipeline_data_registry_base import BasePipelineDataRegistry
 from ..utils import (
-    JUNIFER_DATA_VERSION,
+    JUNIFER_DATA_PARAMS,
     closest_resolution,
     get_dataset_path,
     get_native_warper,
@@ -639,13 +639,13 @@ def _retrieve_schaefer(
         file_path=path_prefix / f"Schaefer2018_{n_rois}Parcels_{yeo_networks}"
         f"Networks_order_FSLMNI152_{resolution}mm.nii.gz",
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
     parcellation_label_path = get(
         file_path=path_prefix
         / f"Schaefer2018_{n_rois}Parcels_{yeo_networks}Networks_order.txt",
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
 
     # Load labels
@@ -764,13 +764,13 @@ def _retrieve_tian(
         parcellation_img_path = get(
             file_path=parcellation_fname,
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         parcellation_label_path = get(
             file_path=parcellation_fname_base_3T
             / f"Tian_Subcortex_S{scale}_3T_label.txt",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         # Load labels
         labels = pd.read_csv(parcellation_label_path, sep=" ", header=None)[
@@ -783,7 +783,7 @@ def _retrieve_tian(
                 f"Tian_Subcortex_S{scale}_{magneticfield}.nii.gz"
             ),
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         # define 7T labels (b/c currently no labels file available for 7T)
         scale7Trois = {1: 16, 2: 34, 3: 54, 4: 62}
@@ -855,12 +855,12 @@ def _retrieve_suit(
     parcellation_img_path = get(
         file_path=path_prefix / f"SUIT_{space}Space_{resolution}mm.nii",
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
     parcellation_label_path = get(
         file_path=path_prefix / f"SUIT_{space}Space_{resolution}mm.tsv",
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
 
     # Load labels
@@ -938,20 +938,20 @@ def _retrieve_aicha(
     parcellation_img_path = get(
         file_path=path_prefix / "AICHA.nii",
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
     # Conditional label file fetch
     if version == 1:
         parcellation_label_path = get(
             file_path=path_prefix / "AICHA_vol1.txt",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
     elif version == 2:
         parcellation_label_path = get(
             file_path=path_prefix / "AICHA_vol3.txt",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
 
     # Load labels
@@ -1055,12 +1055,12 @@ def _retrieve_shen(
         parcellation_img_path = get(
             file_path=path_prefix / f"fconn_atlas_{n_rois}_{resolution}mm.nii",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         parcellation_label_path = get(
             file_path=path_prefix / f"Group_seg{n_rois}_BAindexing_setA.txt",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         labels = (
             pd.read_csv(
@@ -1077,14 +1077,14 @@ def _retrieve_shen(
             file_path=path_prefix
             / f"shen_{resolution}mm_268_parcellation.nii.gz",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         labels = list(range(1, 269))
     elif year == 2019:
         parcellation_img_path = get(
             file_path=path_prefix / "Shen_1mm_368_parcellation.nii.gz",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         labels = list(range(1, 369))
 
@@ -1174,13 +1174,13 @@ def _retrieve_yan(
                 f"{resolution}mm.nii.gz"
             ),
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         parcellation_label_path = get(
             file_path=path_prefix
             / f"{n_rois}Parcels_Yeo2011_{yeo_networks}Networks_LUT.txt",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
     elif kong_networks:
         # Check kong_networks value
@@ -1199,13 +1199,13 @@ def _retrieve_yan(
                 f"{resolution}mm.nii.gz"
             ),
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
         parcellation_label_path = get(
             file_path=path_prefix
             / f"{n_rois}Parcels_Kong2022_{kong_networks}Networks_LUT.txt",
             dataset_path=get_dataset_path(),
-            tag=JUNIFER_DATA_VERSION,
+            **JUNIFER_DATA_PARAMS,
         )
 
     # Load label file
@@ -1272,7 +1272,7 @@ def _retrieve_brainnetome(
             f"BNA-maxprob-thr{threshold}-{resolution}mm.nii.gz"
         ),
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
 
     # Load labels

--- a/junifer/data/template_spaces.py
+++ b/junifer/data/template_spaces.py
@@ -12,7 +12,7 @@ from junifer_data import get
 from templateflow import api as tflow
 
 from ..utils import logger, raise_error
-from .utils import JUNIFER_DATA_VERSION, closest_resolution, get_dataset_path
+from .utils import JUNIFER_DATA_PARAMS, closest_resolution, get_dataset_path
 
 
 __all__ = ["get_template", "get_xfm"]
@@ -40,7 +40,7 @@ def get_xfm(src: str, dst: str) -> Path:  # pragma: no cover
     return get(
         file_path=xfm_file_path,
         dataset_path=get_dataset_path(),
-        tag=JUNIFER_DATA_VERSION,
+        **JUNIFER_DATA_PARAMS,
     )
 
 

--- a/junifer/data/utils.py
+++ b/junifer/data/utils.py
@@ -14,6 +14,8 @@ from ..utils import config, logger, raise_error
 
 
 __all__ = [
+    "JUNIFER_DATA_HEXSHA",
+    "JUNIFER_DATA_PARAMS",
     "JUNIFER_DATA_VERSION",
     "closest_resolution",
     "get_dataset_path",
@@ -23,6 +25,14 @@ __all__ = [
 
 # junifer-data version constant
 JUNIFER_DATA_VERSION = "1"
+
+# junifer-data hexsha constant
+JUNIFER_DATA_HEXSHA = "e9aecf7b5a2fff82de00d265e02afde42a448647"
+
+JUNIFER_DATA_PARAMS = {
+    "tag": JUNIFER_DATA_VERSION,
+    "hexsha": JUNIFER_DATA_HEXSHA,
+}
 
 
 def closest_resolution(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "lazy_loader==0.4",
     "importlib_metadata; python_version<'3.9'",
     "looseversion==1.3.0; python_version>='3.12'",
-    "junifer_data==1.1.0",
+    "junifer_data==1.2.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This PR will implement a hexsha check using junifer data.

This way, if the expected version and hexsha pair do not match in junifer data, an error will be raised.

It might look like an overkill, but junifer-data is now a key component that will definitely affect the computation if modified.