### PR TITLE
Power2011 and Power2013 files contain the same coordinates with mismatched ROI numbering

### DIFF
--- a/docs/builtin.rst
+++ b/docs/builtin.rst
@@ -631,14 +631,6 @@ Available
        | Prediction of Individual Brain Maturity Using fMRI
        | Science, Volume 329(5997), Pages 1358-1361 (2010).
        | https://doi.org/10.1126/science.1194144
-   * - Areal functional network from Power et al. (2013)
-     - ``Power2013``
-     - 0.0.4
-     - | Power, J. D., Schlaggar, B. L., Lessov-Schlaggar, C. N., &
-       | Petersen, S. E.
-       | Evidence for hubs in human functional brain networks.
-       | Neuron, Volume 79(4), Pages 798–813 (2013).
-       | https://doi.org/10.1016/j.neuron.2013.07.035
    * - Autobiographical Memory from Spreng et al. (2009)
      - ``AutobiographicalMemory``
      - 0.0.4

--- a/docs/changes/newsfragments/436.bugfix
+++ b/docs/changes/newsfragments/436.bugfix
@@ -1,0 +1,1 @@
+Remove ``Power2013`` from :class:`.CoordinatesRegistry` by `Synchon Mandal`_

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -118,10 +118,6 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     "file_path_suffix": "Dosenbach/Dosenbach2010_MNI_VOIs.txt",
                     "space": "MNI",
                 },
-                "Power2013": {
-                    "file_path_suffix": "Power/Power2013_MNI_VOIs.tsv",
-                    "space": "MNI",
-                },
                 "AutobiographicalMemory": {
                     "file_path_suffix": (
                         "AutobiographicalMemory/AutobiographicalMemory_VOIs.txt"


### PR DESCRIPTION
`Power2011_MNI_VOIs.txt` and `Power2013_MNI_VOIs.tsv` contain the same coordinates with different ROI numbers. This creates the illusion that they are different when they are not and leads to dissimilarities, e.g. when computing FC, simply because of the ROI ordering.

I would suggest deleting the `Power2013_MNI_VOIs.tsv`, since Power et al., 2013 did not introduce new coordinates but reused the ones from Power et al. (2011) with unmatching ROI numbering.

**From Method section of Power et al. (2013)**
> **Node Definitions** 
> For the areal network, a collection of 264 ROIs defined in Power et al. (2011) were used as network nodes [...]