### PR TITLE
[MAINT]: Bump `junifer-data` version to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
         jq
     - name: Copy junifer-data directory
       run: |
-        mkdir -p $HOME/junifer_data/v1
-        cp -ar /root/junifer_data/v1/. $HOME/junifer_data/v1/
+        mkdir -p $HOME/junifer_data/v2
+        cp -ar /root/junifer_data/v2/. $HOME/junifer_data/v2/
     - name: Checkout repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -39,8 +39,8 @@ jobs:
         jq
     - name: Copy junifer-data directory
       run: |
-        mkdir -p $HOME/junifer_data/v1
-        cp -ar /root/junifer_data/v1/. $HOME/junifer_data/v1/
+        mkdir -p $HOME/junifer_data/v2
+        cp -ar /root/junifer_data/v2/. $HOME/junifer_data/v2/
     - name: Checkout repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,8 @@ jobs:
         jq
     - name: Copy junifer-data directory
       run: |
-        mkdir -p $HOME/junifer_data/v1
-        cp -ar /root/junifer_data/v1/. $HOME/junifer_data/v1/
+        mkdir -p $HOME/junifer_data/v2
+        cp -ar /root/junifer_data/v2/. $HOME/junifer_data/v2/
     - name: Checkout repository
       uses: actions/checkout@v4
       with:

--- a/docs/builtin.rst
+++ b/docs/builtin.rst
@@ -640,6 +640,15 @@ Available
        | Meta-analysis.
        | Journal of Cognitive Neuroscience, Volume 21(3), Pages 489–510 (2009).
        | https://doi.org/10.1162/jocn.2008.21029
+   * - | Functionally-constrained ROIs from non-cortical structures from
+       | Seitzman et al. (2020)
+     - ``Seitzman2018``
+     - 0.0.6
+     - | Seitzman, B. A., Gratton, C., Marek, S. et al.
+       | A set of functionally-defined brain regions with improved representation
+       | of the subcortex and cerebellum.
+       | NeuroImage, Volume 206 (2020).
+       | https://doi.org/10.1016/j.neuroimage.2019.116290
 
 
 Planned

--- a/docs/changes/newsfragments/437.misc
+++ b/docs/changes/newsfragments/437.misc
@@ -1,1 +1,1 @@
-Bump ``junifer-data`` to ``v2``, remove ``Power`` and add ``Seitzman2018`` to :class:`.CoordinatesRegistry` by `Synchon Mandal`_
+Bump ``junifer-data`` to ``v2`` for CI workflows, remove ``Power`` and add ``Seitzman2018`` to :class:`.CoordinatesRegistry` by `Synchon Mandal`_

--- a/docs/changes/newsfragments/437.misc
+++ b/docs/changes/newsfragments/437.misc
@@ -1,0 +1,1 @@
+Bump ``junifer-data`` to ``v2``, remove ``Power`` and add ``Seitzman2018`` to :class:`.CoordinatesRegistry` by `Synchon Mandal`_

--- a/junifer/data/coordinates/_coordinates.py
+++ b/junifer/data/coordinates/_coordinates.py
@@ -106,10 +106,6 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     "file_path_suffix": "WM/WM_VOIs.txt",
                     "space": "MNI",
                 },
-                "Power": {
-                    "file_path_suffix": "Power/Power2011_MNI_VOIs.txt",
-                    "space": "MNI",
-                },
                 "Power2011": {
                     "file_path_suffix": "Power/Power2011_MNI_VOIs.txt",
                     "space": "MNI",
@@ -122,6 +118,10 @@ class CoordinatesRegistry(BasePipelineDataRegistry, metaclass=Singleton):
                     "file_path_suffix": (
                         "AutobiographicalMemory/AutobiographicalMemory_VOIs.txt"
                     ),
+                    "space": "MNI",
+                },
+                "Seitzman2018": {
+                    "file_path_suffix": "Seitzman/Seitzman2018_MNI_VOIs.txt",
                     "space": "MNI",
                 },
             }

--- a/junifer/data/utils.py
+++ b/junifer/data/utils.py
@@ -24,10 +24,10 @@ __all__ = [
 
 
 # junifer-data version constant
-JUNIFER_DATA_VERSION = "1"
+JUNIFER_DATA_VERSION = "2"
 
 # junifer-data hexsha constant
-JUNIFER_DATA_HEXSHA = "e9aecf7b5a2fff82de00d265e02afde42a448647"
+JUNIFER_DATA_HEXSHA = "015712689254c052fa64bca19f0f2da342e664ac"
 
 JUNIFER_DATA_PARAMS = {
     "tag": JUNIFER_DATA_VERSION,


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR bumps `junifer-data` to v2. Removes `Power` and adds `Seitzman2018` to `CoordinatesRegistry`.