### PR TITLE
[ENH]: Support "xi" correlation metric for functional connectivity

### DIFF
--- a/docs/changes/newsfragments/333.enh
+++ b/docs/changes/newsfragments/333.enh
@@ -1,0 +1,1 @@
+Add support for Chatterjee's xi correlation in :class:`.JuniferConnectivityMeasure` by `Synchon Mandal`_

--- a/junifer/external/nilearn/junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/junifer_connectivity_measure.py
@@ -327,8 +327,9 @@ class JuniferConnectivityMeasure(ConnectivityMeasure):
             "precision"}, optional
         The matrix kind. The default value uses Pearson's correlation.
         If ``"spearman correlation"`` is used, the data will be ranked before
-        estimating the covariance. For the use of ``"tangent"`` see [1]_
-        (default "correlation").
+        estimating the covariance. For ``"xi correlation"``, the coefficient
+        is not symmetric and should be interpreted as a measure of dependence
+        [2]_ . For the use of ``"tangent"`` see [1]_ (default "correlation").
     vectorize : bool, optional
         If True, connectivity matrices are reshaped into 1D arrays and only
         their flattened lower triangular parts are returned (default False).
@@ -373,6 +374,12 @@ class JuniferConnectivityMeasure(ConnectivityMeasure):
            in computer science, Pages 200-208. Berlin, Heidelberg, 2010.
            Springer.
            doi:10/cn2h9c.
+
+    .. [2] Chatterjee, S.
+           A new coefficient of correlation.
+           Journal of the American Statistical Association 116.536 (2021):
+           2009-2022.
+           doi:10.1080/01621459.2020.1758115.
 
     """
 

--- a/junifer/external/nilearn/junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/junifer_connectivity_measure.py
@@ -3,6 +3,7 @@
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+import sys
 from itertools import product
 from typing import Callable, Optional
 
@@ -430,6 +431,14 @@ class JuniferConnectivityMeasure(ConnectivityMeasure):
 
             connectivities = [cov_to_corr(cov) for cov in covariances_std]
         elif self.kind == "xi correlation":
+            if sys.version_info < (3, 10):  # pragma: no cover
+                raise_error(
+                    klass=RuntimeError,
+                    msg=(
+                        "scipy.stats.chatterjeexi is available from "
+                        "scipy 1.15.0 and that requires Python 3.10 and above."
+                    ),
+                )
             connectivities = []
             for x in X:
                 n_rois = x.shape[1]

--- a/junifer/external/nilearn/junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/junifer_connectivity_measure.py
@@ -447,6 +447,7 @@ class JuniferConnectivityMeasure(ConnectivityMeasure):
                 allowed_kinds = (
                     "correlation",
                     "partial correlation",
+                    "spearman correlation",
                     "xi correlation",
                     "tangent",
                     "covariance",

--- a/junifer/external/nilearn/junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/junifer_connectivity_measure.py
@@ -447,8 +447,6 @@ class JuniferConnectivityMeasure(ConnectivityMeasure):
                 allowed_kinds = (
                     "correlation",
                     "partial correlation",
-                    "spearman correlation",
-                    "xi correlation",
                     "tangent",
                     "covariance",
                     "precision",

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -12,7 +12,11 @@ import numpy as np
 import pytest
 from nilearn.connectome.connectivity_matrices import sym_matrix_to_vec
 from nilearn.tests.test_signal import generate_signals
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import (
+    assert_allclose,
+    assert_array_almost_equal,
+    assert_array_equal,
+)
 from pandas import DataFrame
 from scipy import linalg
 from sklearn.covariance import EmpiricalCovariance, LedoitWolf
@@ -1089,3 +1093,23 @@ def test_connectivity_measure_standardize(
         ).fit_transform(signals)
         for m in record:
             assert match not in m.message
+
+
+def test_xi_correlation() -> None:
+    """Check xi correlation according to paper."""
+    rng = np.random.default_rng(25982435982346983)
+    x = rng.random(size=10)
+    y = rng.random(size=10)
+    arr = np.column_stack((x, y))
+    expected = np.array(
+        [
+            [
+                [1.0, -0.3030303],
+                [-0.18181818, 1.0],
+            ]
+        ]
+    )
+    got = JuniferConnectivityMeasure(kind="xi correlation").fit_transform(
+        [arr]
+    )
+    assert_allclose(expected, got)

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -646,8 +646,8 @@ def test_connectivity_measure_generic(
     if sys.version_info < (3, 10) and kind == "xi correlation":
         with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             connectivities = conn_measure.fit_transform(signals)
-    else:
-        connectivities = conn_measure.fit_transform(signals)
+
+    connectivities = conn_measure.fit_transform(signals)
     # Generic
     assert isinstance(connectivities, np.ndarray)
     assert len(connectivities) == len(covs)
@@ -837,8 +837,8 @@ def test_connectivity_measure_check_mean(
     if sys.version_info < (3, 10) and kind == "xi correlation":
         with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             conn_measure.fit_transform(signals)
-    else:
-        conn_measure.fit_transform(signals)
+
+    conn_measure.fit_transform(signals)
 
     assert (conn_measure.mean_).shape == (N_FEATURES, N_FEATURES)
 
@@ -877,8 +877,7 @@ def test_connectivity_measure_check_vectorization_option(
     if sys.version_info < (3, 10) and kind == "xi correlation":
         with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             vectorized_connectivities = conn_measure.fit_transform(signals)
-    else:
-        vectorized_connectivities = conn_measure.fit_transform(signals)
+    vectorized_connectivities = conn_measure.fit_transform(signals)
 
     assert_array_almost_equal(
         vectorized_connectivities, sym_matrix_to_vec(connectivities)
@@ -1121,13 +1120,7 @@ def test_xi_correlation() -> None:
             ]
         ]
     )
-    if sys.version_info < (3, 10):
-        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
-            got = JuniferConnectivityMeasure(
-                kind="xi correlation"
-            ).fit_transform([arr])
-    else:
-        got = JuniferConnectivityMeasure(kind="xi correlation").fit_transform(
-            [arr]
-        )
+    got = JuniferConnectivityMeasure(kind="xi correlation").fit_transform(
+        [arr]
+    )
     assert_allclose(expected, got)

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -4,7 +4,6 @@
 # License: AGPL
 
 import copy
-import sys
 import warnings
 from math import cosh, exp, log, sinh, sqrt
 from typing import TYPE_CHECKING, Optional, Union
@@ -643,11 +642,8 @@ def test_connectivity_measure_generic(
     conn_measure = JuniferConnectivityMeasure(
         kind=kind, cov_estimator=cov_estimator
     )
-    if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
-            connectivities = conn_measure.fit_transform(signals)
-
     connectivities = conn_measure.fit_transform(signals)
+
     # Generic
     assert isinstance(connectivities, np.ndarray)
     assert len(connectivities) == len(covs)
@@ -834,10 +830,6 @@ def test_connectivity_measure_check_mean(
 
     """
     conn_measure = JuniferConnectivityMeasure(kind=kind)
-    if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
-            conn_measure.fit_transform(signals)
-
     conn_measure.fit_transform(signals)
 
     assert (conn_measure.mean_).shape == (N_FEATURES, N_FEATURES)
@@ -874,9 +866,6 @@ def test_connectivity_measure_check_vectorization_option(
     conn_measure = JuniferConnectivityMeasure(kind=kind)
     connectivities = conn_measure.fit_transform(signals)
     conn_measure = JuniferConnectivityMeasure(vectorize=True, kind=kind)
-    if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
-            vectorized_connectivities = conn_measure.fit_transform(signals)
     vectorized_connectivities = conn_measure.fit_transform(signals)
 
     assert_array_almost_equal(

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -644,7 +644,7 @@ def test_connectivity_measure_generic(
         kind=kind, cov_estimator=cov_estimator
     )
     if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
+        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             connectivities = conn_measure.fit_transform(signals)
 
     connectivities = conn_measure.fit_transform(signals)
@@ -835,7 +835,7 @@ def test_connectivity_measure_check_mean(
     """
     conn_measure = JuniferConnectivityMeasure(kind=kind)
     if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
+        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             conn_measure.fit_transform(signals)
 
     conn_measure.fit_transform(signals)
@@ -875,7 +875,7 @@ def test_connectivity_measure_check_vectorization_option(
     connectivities = conn_measure.fit_transform(signals)
     conn_measure = JuniferConnectivityMeasure(vectorize=True, kind=kind)
     if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
+        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             vectorized_connectivities = conn_measure.fit_transform(signals)
     vectorized_connectivities = conn_measure.fit_transform(signals)
 

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -4,6 +4,7 @@
 # License: AGPL
 
 import copy
+import sys
 import warnings
 from math import cosh, exp, log, sinh, sqrt
 from typing import TYPE_CHECKING, Optional, Union
@@ -1094,6 +1095,25 @@ def test_connectivity_measure_standardize(
             assert match not in m.message
 
 
+@pytest.mark.skipif(
+    sys.version_info > (3, 9),
+    reason="will have correct scipy version so no error",
+)
+def test_xi_correlation_error() -> None:
+    """Check xi correlation according to paper."""
+    with pytest.raises(RuntimeError, match="scipy.stats.chatterjeexi"):
+        JuniferConnectivityMeasure(kind="xi correlation").fit_transform(
+            np.zeros((2, 2))
+        )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason=(
+        "needs scipy 1.15.0 and above which in turn requires "
+        "python 3.10 and above"
+    ),
+)
 def test_xi_correlation() -> None:
     """Check xi correlation according to paper."""
     rng = np.random.default_rng(25982435982346983)

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -4,6 +4,7 @@
 # License: AGPL
 
 import copy
+import sys
 import warnings
 from math import cosh, exp, log, sinh, sqrt
 from typing import TYPE_CHECKING, Optional, Union
@@ -642,8 +643,11 @@ def test_connectivity_measure_generic(
     conn_measure = JuniferConnectivityMeasure(
         kind=kind, cov_estimator=cov_estimator
     )
-    connectivities = conn_measure.fit_transform(signals)
+    if sys.version_info < (3, 10) and kind == "xi correlation":
+        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
+            connectivities = conn_measure.fit_transform(signals)
 
+    connectivities = conn_measure.fit_transform(signals)
     # Generic
     assert isinstance(connectivities, np.ndarray)
     assert len(connectivities) == len(covs)
@@ -830,6 +834,10 @@ def test_connectivity_measure_check_mean(
 
     """
     conn_measure = JuniferConnectivityMeasure(kind=kind)
+    if sys.version_info < (3, 10) and kind == "xi correlation":
+        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
+            conn_measure.fit_transform(signals)
+
     conn_measure.fit_transform(signals)
 
     assert (conn_measure.mean_).shape == (N_FEATURES, N_FEATURES)
@@ -866,6 +874,9 @@ def test_connectivity_measure_check_vectorization_option(
     conn_measure = JuniferConnectivityMeasure(kind=kind)
     connectivities = conn_measure.fit_transform(signals)
     conn_measure = JuniferConnectivityMeasure(vectorize=True, kind=kind)
+    if sys.version_info < (3, 10) and kind == "xi correlation":
+        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
+            vectorized_connectivities = conn_measure.fit_transform(signals)
     vectorized_connectivities = conn_measure.fit_transform(signals)
 
     assert_array_almost_equal(

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -644,7 +644,7 @@ def test_connectivity_measure_generic(
         kind=kind, cov_estimator=cov_estimator
     )
     if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
+        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
             connectivities = conn_measure.fit_transform(signals)
 
     connectivities = conn_measure.fit_transform(signals)
@@ -835,7 +835,7 @@ def test_connectivity_measure_check_mean(
     """
     conn_measure = JuniferConnectivityMeasure(kind=kind)
     if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
+        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
             conn_measure.fit_transform(signals)
 
     conn_measure.fit_transform(signals)
@@ -875,7 +875,7 @@ def test_connectivity_measure_check_vectorization_option(
     connectivities = conn_measure.fit_transform(signals)
     conn_measure = JuniferConnectivityMeasure(vectorize=True, kind=kind)
     if sys.version_info < (3, 10) and kind == "xi correlation":
-        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
+        with pytest.raises(RuntimeError, msg="scipy 1.15.0"):
             vectorized_connectivities = conn_measure.fit_transform(signals)
     vectorized_connectivities = conn_measure.fit_transform(signals)
 

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -76,7 +76,6 @@ CONNECTIVITY_KINDS = (
     "precision",
     "partial correlation",
     "spearman correlation",
-    "xi correlation",
 )
 
 N_FEATURES = 49
@@ -834,7 +833,7 @@ def test_connectivity_measure_check_mean(
 
     assert (conn_measure.mean_).shape == (N_FEATURES, N_FEATURES)
 
-    if kind not in ("tangent", "xi correlation"):
+    if kind != "tangent":
         assert_array_almost_equal(
             conn_measure.mean_,
             np.mean(conn_measure.transform(signals), axis=0),

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -646,8 +646,8 @@ def test_connectivity_measure_generic(
     if sys.version_info < (3, 10) and kind == "xi correlation":
         with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             connectivities = conn_measure.fit_transform(signals)
-
-    connectivities = conn_measure.fit_transform(signals)
+    else:
+        connectivities = conn_measure.fit_transform(signals)
     # Generic
     assert isinstance(connectivities, np.ndarray)
     assert len(connectivities) == len(covs)
@@ -837,8 +837,8 @@ def test_connectivity_measure_check_mean(
     if sys.version_info < (3, 10) and kind == "xi correlation":
         with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             conn_measure.fit_transform(signals)
-
-    conn_measure.fit_transform(signals)
+    else:
+        conn_measure.fit_transform(signals)
 
     assert (conn_measure.mean_).shape == (N_FEATURES, N_FEATURES)
 
@@ -877,7 +877,8 @@ def test_connectivity_measure_check_vectorization_option(
     if sys.version_info < (3, 10) and kind == "xi correlation":
         with pytest.raises(RuntimeError, match="scipy 1.15.0"):
             vectorized_connectivities = conn_measure.fit_transform(signals)
-    vectorized_connectivities = conn_measure.fit_transform(signals)
+    else:
+        vectorized_connectivities = conn_measure.fit_transform(signals)
 
     assert_array_almost_equal(
         vectorized_connectivities, sym_matrix_to_vec(connectivities)
@@ -1120,7 +1121,13 @@ def test_xi_correlation() -> None:
             ]
         ]
     )
-    got = JuniferConnectivityMeasure(kind="xi correlation").fit_transform(
-        [arr]
-    )
+    if sys.version_info < (3, 10):
+        with pytest.raises(RuntimeError, match="scipy 1.15.0"):
+            got = JuniferConnectivityMeasure(
+                kind="xi correlation"
+            ).fit_transform([arr])
+    else:
+        got = JuniferConnectivityMeasure(kind="xi correlation").fit_transform(
+            [arr]
+        )
     assert_allclose(expected, got)

--- a/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
+++ b/junifer/external/nilearn/tests/test_junifer_connectivity_measure.py
@@ -72,6 +72,7 @@ CONNECTIVITY_KINDS = (
     "precision",
     "partial correlation",
     "spearman correlation",
+    "xi correlation",
 )
 
 N_FEATURES = 49
@@ -829,7 +830,7 @@ def test_connectivity_measure_check_mean(
 
     assert (conn_measure.mean_).shape == (N_FEATURES, N_FEATURES)
 
-    if kind != "tangent":
+    if kind not in ("tangent", "xi correlation"):
         assert_array_almost_equal(
             conn_measure.mean_,
             np.mean(conn_measure.transform(signals), axis=0),

--- a/junifer/markers/functional_connectivity/functional_connectivity_base.py
+++ b/junifer/markers/functional_connectivity/functional_connectivity_base.py
@@ -143,14 +143,17 @@ class FunctionalConnectivityBase(BaseMarker):
             },
         )
         # Create dictionary for output
+        labels = aggregation["aggregation"]["col_names"]
         return {
             "functional_connectivity": {
                 "data": connectivity.fit_transform(
                     [aggregation["aggregation"]["data"]]
                 )[0],
-                # Create column names
-                "row_names": aggregation["aggregation"]["col_names"],
-                "col_names": aggregation["aggregation"]["col_names"],
-                "matrix_kind": "tril",
+                "row_names": labels,
+                "col_names": labels,
+                # xi correlation coefficient is not symmetric
+                "matrix_kind": (
+                    "full" if self.conn_method == "xi correlation" else "tril"
+                ),
             },
         }


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

Adapt https://github.com/czbiohub-sf/xicor to be used as a correlation metric for functional connectivity markers.

### How do you imagine this integrated in junifer?

As an option for nilearn's ConnectivityMeasure.

### Do you have a sample code that implements this outside of junifer?

```shell
https://github.com/czbiohub-sf/xicor
```


### Anything else to say?

_No response_