### PR TITLE
[ENH]: Prepare Junifer for extension support

### DIFF
--- a/junifer/cli/__init__.py
+++ b/junifer/cli/__init__.py
@@ -3,7 +3,22 @@
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+import sys
+
 import lazy_loader as lazy
 
 
+if sys.version_info < (3, 11):  # pragma: no cover
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+
 __getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)
+
+
+# Register extensions
+from .cli import cli
+
+for ep in entry_points(group="junifer.ext"):
+    cli.add_command(ep.load(), name=ep.name)

--- a/junifer/cli/cli.py
+++ b/junifer/cli/cli.py
@@ -111,7 +111,9 @@ def _validate_verbose(
     )
 
 
-@click.group()
+@click.group
+@click.version_option()
+@click.help_option()
 def cli() -> None:  # pragma: no cover
     """JUelich NeuroImaging FEature extractoR."""
 


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [X] I understand this is not a marker or dataset request

### Which feature do you want to include?

If I install `junilog` or `junifer-data`, I would like to call them using `junifer log` or `junifer data`, through the junifer click group.

### How do you imagine this integrated in junifer?

1- On importing junifer, we "import and register all extensions"
2- Each extensions provides a "group name" and registers this group under the junifer click group.

### Do you have a sample code that implements this outside of junifer?

_No response_

### Anything else to say?

_No response_