### PR TITLE
[ENH]: Add `TemporalSlicer`

### DIFF
--- a/docs/builtin.rst
+++ b/docs/builtin.rst
@@ -163,6 +163,10 @@ Available
        | ``fMRIPrep``-ed data
      - In Progress
      - :gh:`161`
+   * - ``TemporalSlicer``
+     - Slice ``BOLD`` data temporally
+     - | Done
+     - :gh:`443`
 
 
 ..

--- a/docs/changes/newsfragments/443.feature
+++ b/docs/changes/newsfragments/443.feature
@@ -1,0 +1,1 @@
+Introduce :class:`.TemporalSlicer` preprocessor for temporally slicing BOLD data by `Synchon Mandal`_

--- a/junifer/pipeline/pipeline_component_registry.py
+++ b/junifer/pipeline/pipeline_component_registry.py
@@ -75,6 +75,7 @@ class PipelineComponentRegistry(metaclass=Singleton):
                 "Smoothing": "Smoothing",
                 "SpaceWarper": "SpaceWarper",
                 "fMRIPrepConfoundRemover": "fMRIPrepConfoundRemover",
+                "TemporalSlicer": "TemporalSlicer",
             },
             "marker": {
                 "ALFFParcels": "ALFFParcels",

--- a/junifer/preprocess/__init__.pyi
+++ b/junifer/preprocess/__init__.pyi
@@ -3,9 +3,11 @@ __all__ = [
     "fMRIPrepConfoundRemover",
     "SpaceWarper",
     "Smoothing",
+    "TemporalSlicer",
 ]
 
 from .base import BasePreprocessor
 from .confounds import fMRIPrepConfoundRemover
 from .warping import SpaceWarper
 from .smoothing import Smoothing
+from ._temporal_slicer import TemporalSlicer

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -11,7 +11,7 @@ import nilearn.image as nimg
 from ..api.decorators import register_preprocessor
 from ..pipeline import WorkDirManager
 from ..typing import Dependencies
-from ..utils import logger
+from ..utils import logger, raise_error
 from .base import BasePreprocessor
 
 
@@ -101,11 +101,33 @@ class TemporalSlicer(BasePreprocessor):
             Extra "helper" data types as dictionary to add to the Junifer Data
             object.
 
+        Raises
+        ------
+        RuntimeError
+            If no time slicing will be performed.
+
         """
         logger.debug("Temporal slicing")
 
         # Get BOLD data
         bold_img = input["data"]
+
+        # Check if slicing is not required
+        if self.start == 0:
+            if (
+                self.stop is None
+                or self.stop == -1
+                or self.stop == bold_img.shape[3]
+            ):
+                raise_error(
+                    "No temporal slicing will be performed as "
+                    f"`start` = {self.start} and "
+                    f"`stop` = {self.stop}, hence you "
+                    "should remove the TemporalSlicer from the preprocess "
+                    "step.",
+                    klass=RuntimeError,
+                )
+
         # Set t_r
         t_r = self.t_r
         if t_r is None:

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -125,14 +125,11 @@ class TemporalSlicer(BasePreprocessor):
 
         # Get BOLD data
         bold_img = input["data"]
+        time_dim = bold_img.shape[3]
 
         # Check if slicing is not required
         if self.start == 0:
-            if (
-                self.stop is None
-                or self.stop == -1
-                or self.stop == bold_img.shape[3]
-            ):
+            if self.stop is None or self.stop == -1 or self.stop == time_dim:
                 raise_error(
                     "No temporal slicing will be performed as "
                     f"`start` = {self.start} and "
@@ -169,11 +166,11 @@ class TemporalSlicer(BasePreprocessor):
             if self.duration is not None:
                 stop = self.start + self.duration
             else:
-                stop = bold_img.shape[3]
+                stop = time_dim
         else:
             # Calculate stop index if going from end
             if self.stop < 0:
-                stop = bold_img.shape[3] + 1 + self.stop
+                stop = time_dim + 1 + self.stop
             else:
                 stop = self.stop
         # Slice image after converting slice range from seconds to indices

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -33,7 +33,7 @@ class TemporalSlicer(BasePreprocessor):
     duration : float or None, optional
         Time duration to add to ``start``, in second. If None, ``stop`` is
         respected, else error is raised.
-    t_r : float, optional
+    t_r : float or None, optional
         Repetition time, in second (sampling period).
         If None, it will use t_r from nifti header (default None).
 

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -1,0 +1,140 @@
+"""Provide class for temporal slicing."""
+
+# Authors: Synchon Mandal <s.mandal@fz-juelich.de>
+# License: AGPL
+
+from typing import Any, ClassVar, Optional
+
+import nibabel as nib
+import nilearn.image as nimg
+
+from ..api.decorators import register_preprocessor
+from ..pipeline import WorkDirManager
+from ..typing import Dependencies
+from ..utils import logger
+from .base import BasePreprocessor
+
+
+__all__ = ["TemporalSlicer"]
+
+
+@register_preprocessor
+class TemporalSlicer(BasePreprocessor):
+    """Class for temporal slicing.
+
+    Parameters
+    ----------
+    start : int
+        Starting time point, in second.
+    stop : int
+        Ending time point, in second.
+    t_r : float, optional
+        Repetition time, in second (sampling period).
+        If None, it will use t_r from nifti header (default None).
+
+    """
+
+    _DEPENDENCIES: ClassVar[Dependencies] = {"nilearn"}
+
+    def __init__(
+        self,
+        start: int,
+        stop: int,
+        t_r: Optional[float] = None,
+    ) -> None:
+        """Initialize the class."""
+        self.start = start
+        self.stop = stop
+        self.t_r = t_r
+        super().__init__(on="BOLD", required_data_types=["BOLD"])
+
+    def get_valid_inputs(self) -> list[str]:
+        """Get valid data types for input.
+
+        Returns
+        -------
+        list of str
+            The list of data types that can be used as input for this
+            preprocessor.
+
+        """
+        return ["BOLD"]
+
+    def get_output_type(self, input_type: str) -> str:
+        """Get output type.
+
+        Parameters
+        ----------
+        input_type : str
+            The data type input to the preprocessor.
+
+        Returns
+        -------
+        str
+            The data type output by the preprocessor.
+
+        """
+        # Does not add any new keys
+        return input_type
+
+    def preprocess(
+        self,
+        input: dict[str, Any],
+        extra_input: Optional[dict[str, Any]] = None,
+    ) -> tuple[dict[str, Any], Optional[dict[str, dict[str, Any]]]]:
+        """Preprocess.
+
+        Parameters
+        ----------
+        input : dict
+            The input from the Junifer Data object.
+        extra_input : dict, optional
+            The other fields in the Junifer Data object.
+
+        Returns
+        -------
+        dict
+            The computed result as dictionary.
+        None
+            Extra "helper" data types as dictionary to add to the Junifer Data
+            object.
+
+        """
+        logger.debug("Temporal slicing")
+
+        # Get BOLD data
+        bold_img = input["data"]
+        # Set t_r
+        t_r = self.t_r
+        if t_r is None:
+            logger.info("No `t_r` specified, using t_r from NIfTI header")
+            t_r = bold_img.header.get_zooms()[3]  # type: ignore
+            logger.info(
+                f"Read t_r from NIfTI header: {t_r}",
+            )
+
+        # Create element-specific tempdir for storing generated data
+        element_tempdir = WorkDirManager().get_element_tempdir(
+            prefix="temporal_slicer"
+        )
+
+        # Slice image after converting slice range from seconds to indices
+        index = slice(int(self.start // t_r), int(self.stop // t_r))
+        sliced_img = nimg.index_img(bold_img, index)
+        # Fix t_r as nilearn messes it up
+        sliced_img.header["pixdim"][4] = t_r
+        # Save sliced data
+        sliced_img_path = element_tempdir / "sliced_data.nii.gz"
+        nib.save(sliced_img, sliced_img_path)
+
+        logger.debug("Updating `BOLD`")
+        input.update(
+            {
+                # Update path to sync with "data"
+                "path": sliced_img_path,
+                # Update data
+                "data": sliced_img,
+            }
+        )
+
+        return input, None

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -37,6 +37,11 @@ class TemporalSlicer(BasePreprocessor):
         Repetition time, in second (sampling period).
         If None, it will use t_r from nifti header (default None).
 
+    Raises
+    ------
+    ValueError
+        If ``start`` is negative.
+
     """
 
     _DEPENDENCIES: ClassVar[Dependencies] = {"nilearn"}
@@ -49,7 +54,10 @@ class TemporalSlicer(BasePreprocessor):
         t_r: Optional[float] = None,
     ) -> None:
         """Initialize the class."""
-        self.start = start
+        if start < 0:
+            raise_error("`start` cannot be negative")
+        else:
+            self.start = start
         self.stop = stop
         self.duration = duration
         self.t_r = t_r

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -3,7 +3,7 @@
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
-from typing import Any, ClassVar, Optional, Union
+from typing import Any, ClassVar, Optional
 
 import nibabel as nib
 import nilearn.image as nimg
@@ -32,7 +32,7 @@ class TemporalSlicer(BasePreprocessor):
         Python slicing except it represents time points.
     duration : float or None, optional
         Time duration to add to ``start``, in second. If None, ``stop`` is
-        respected, else error is raised.
+        respected, else error is raised (default None).
     t_r : float or None, optional
         Repetition time, in second (sampling period).
         If None, it will use t_r from nifti header (default None).
@@ -49,8 +49,8 @@ class TemporalSlicer(BasePreprocessor):
     def __init__(
         self,
         start: float,
-        stop: Union[float, None],
-        duration: Union[float, None] = None,
+        stop: Optional[float],
+        duration: Optional[float] = None,
         t_r: Optional[float] = None,
     ) -> None:
         """Initialize the class."""

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -173,8 +173,14 @@ class TemporalSlicer(BasePreprocessor):
                 stop = time_dim + 1 + self.stop
             else:
                 stop = self.stop
-        # Slice image after converting slice range from seconds to indices
+
+        # Convert slice range from seconds to indices
         index = slice(int(self.start // t_r), int(stop // t_r))
+
+        logger.info(
+            "Computed slice range for TemporalSlicer: "
+            f"[{index.start},{index.stop}]"
+        )
 
         # Slice image
         sliced_img = nimg.index_img(bold_img, index)

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -118,8 +118,13 @@ class TemporalSlicer(BasePreprocessor):
             prefix="temporal_slicer"
         )
 
+        # Calculate stop index if going from end
+        if self.stop < 0:
+            stop = bold_img.shape[3] + 1 + self.stop
+        else:
+            stop = self.stop
         # Slice image after converting slice range from seconds to indices
-        index = slice(int(self.start // t_r), int(self.stop // t_r))
+        index = slice(int(self.start // t_r), int(stop // t_r))
         sliced_img = nimg.index_img(bold_img, index)
         # Fix t_r as nilearn messes it up
         sliced_img.header["pixdim"][4] = t_r

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -118,7 +118,8 @@ class TemporalSlicer(BasePreprocessor):
         ------
         RuntimeError
             If no time slicing will be performed or
-            if ``stop`` is not None when ``duration`` is provided.
+            if ``stop`` is not None when ``duration`` is provided or
+            if calculated stop index is greater than allowed value.
 
         """
         logger.debug("Temporal slicing")
@@ -176,6 +177,14 @@ class TemporalSlicer(BasePreprocessor):
 
         # Convert slice range from seconds to indices
         index = slice(int(self.start // t_r), int(stop // t_r))
+
+        # Check if stop index is out of bounds
+        if index.stop > time_dim:
+            raise_error(
+                f"Calculated stop index: {index.stop} is greater than "
+                f"allowed value: {time_dim}",
+                klass=IndexError,
+            )
 
         logger.info(
             "Computed slice range for TemporalSlicer: "

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -224,14 +224,12 @@ class TemporalSlicer(BasePreprocessor):
             )
 
             logger.debug("Updating `BOLD.confounds`")
-            input.update(
+            input["confounds"].update(
                 {
-                    "confounds": {
-                        # Update path to sync with "data"
-                        "path": sliced_confounds_path,
-                        # Update data
-                        "data": sliced_confounds_df,
-                    }
+                    # Update path to sync with "data"
+                    "path": sliced_confounds_path,
+                    # Update data
+                    "data": sliced_confounds_df,
                 }
             )
 

--- a/junifer/preprocess/_temporal_slicer.py
+++ b/junifer/preprocess/_temporal_slicer.py
@@ -24,9 +24,9 @@ class TemporalSlicer(BasePreprocessor):
 
     Parameters
     ----------
-    start : int
+    start : float
         Starting time point, in second.
-    stop : int
+    stop : float
         Ending time point, in second.
     t_r : float, optional
         Repetition time, in second (sampling period).
@@ -38,8 +38,8 @@ class TemporalSlicer(BasePreprocessor):
 
     def __init__(
         self,
-        start: int,
-        stop: int,
+        start: float,
+        stop: float,
         t_r: Optional[float] = None,
     ) -> None:
         """Initialize the class."""

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -116,4 +116,7 @@ def test_TemporalSlicer(
                 t_r=t_r,  # in seconds
             ).fit_transform(element_data)
 
+            # Check image data dim
             assert output["BOLD"]["data"].shape[3] == expected_dim
+            # Check confounds dim
+            assert output["BOLD"]["confounds"]["data"].shape[0] == expected_dim

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -1,0 +1,51 @@
+"""Provide tests for TemporalSlicer."""
+
+# Authors: Synchon Mandal <s.mandal@fz-juelich.de>
+# License: AGPL
+
+import pytest
+
+from junifer.datareader import DefaultDataReader
+from junifer.preprocess import TemporalSlicer
+from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
+
+
+@pytest.mark.parametrize(
+    "start, stop, t_r, expected_dim",
+    (
+        [0, 168, 2.0, 84],  # t_r from doc is 2.0
+        [0, 168, None, 168],  # t_r from image is 1.0
+    ),
+)
+def test_TemporalSlicer(
+    start: int,
+    stop: int,
+    t_r: float,
+    expected_dim: int,
+) -> None:
+    """Test TemporalSlicer.
+
+    Parameters
+    ----------
+    start : int
+        The parametrized start.
+    stop : int
+        The parametrized stop.
+    t_r : float
+        The parametrized TR.
+    expected_dim : int
+        The parametrized expected time dimension size.
+
+    """
+
+    with PartlyCloudyTestingDataGrabber() as dg:
+        # Read data
+        element_data = DefaultDataReader().fit_transform(dg["sub-01"])
+        # Preprocess data
+        output = TemporalSlicer(
+            start=start,
+            stop=stop,  # in seconds
+            t_r=t_r,  # in seconds
+        ).fit_transform(element_data)
+
+        assert output["BOLD"]["data"].shape[3] == expected_dim

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -3,6 +3,8 @@
 # Authors: Synchon Mandal <s.mandal@fz-juelich.de>
 # License: AGPL
 
+from contextlib import AbstractContextManager, nullcontext
+
 import pytest
 
 from junifer.datareader import DefaultDataReader
@@ -11,16 +13,45 @@ from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
 
 
 @pytest.mark.parametrize(
-    "start, stop, t_r, expected_dim",
+    "start, stop, t_r, expected_dim, expect",
     (
-        [0, 168, 2.0, 84],  # t_r from doc is 2.0
-        [0, 84, 2.0, 42],  # first half
-        [0, -85, 2.0, 42],  # first half from end
-        [84, -1, 2.0, 42],  # second half
-        [0, 168, None, 168],  # t_r from image is 1.0
-        [0, 84, None, 84],  # first half
-        [0, -85, None, 84],  # first half from end
-        [84, -1, None, 84],  # second half
+        [
+            0,
+            168,
+            2.0,
+            84,
+            pytest.raises(RuntimeError, match="No temporal slicing"),
+        ],  # t_r from doc is 2.0
+        [0, 167, 2.0, 83, nullcontext()],  # t_r from doc is 2.0
+        [
+            0,
+            None,
+            2.0,
+            84,
+            pytest.raises(RuntimeError, match="No temporal slicing"),
+        ],  # total with no end
+        [2, None, 2.0, 83, nullcontext()],  # total with no end
+        [0, 84, 2.0, 42, nullcontext()],  # first half
+        [0, -85, 2.0, 42, nullcontext()],  # first half from end
+        [84, -1, 2.0, 42, nullcontext()],  # second half
+        [
+            0,
+            168,
+            None,
+            168,
+            pytest.raises(RuntimeError, match="No temporal slicing"),
+        ],  # t_r from image is 1.0
+        [0, 167, None, 167, nullcontext()],  # t_r from image is 1.0
+        [
+            0,
+            None,
+            None,
+            168,
+            pytest.raises(RuntimeError, match="No temporal slicing"),
+        ],  # total with no end
+        [0, 84, None, 84, nullcontext()],  # first half
+        [0, -85, None, 84, nullcontext()],  # first half from end
+        [84, -1, None, 84, nullcontext()],  # second half
     ),
 )
 def test_TemporalSlicer(
@@ -28,6 +59,7 @@ def test_TemporalSlicer(
     stop: int,
     t_r: float,
     expected_dim: int,
+    expect: AbstractContextManager,
 ) -> None:
     """Test TemporalSlicer.
 
@@ -41,6 +73,8 @@ def test_TemporalSlicer(
         The parametrized TR.
     expected_dim : int
         The parametrized expected time dimension size.
+    expect : typing.ContextManager
+        The parametrized ContextManager object.
 
     """
 
@@ -48,10 +82,11 @@ def test_TemporalSlicer(
         # Read data
         element_data = DefaultDataReader().fit_transform(dg["sub-01"])
         # Preprocess data
-        output = TemporalSlicer(
-            start=start,
-            stop=stop,  # in seconds
-            t_r=t_r,  # in seconds
-        ).fit_transform(element_data)
+        with expect:
+            output = TemporalSlicer(
+                start=start,
+                stop=stop,  # in seconds
+                t_r=t_r,  # in seconds
+            ).fit_transform(element_data)
 
-        assert output["BOLD"]["data"].shape[3] == expected_dim
+            assert output["BOLD"]["data"].shape[3] == expected_dim

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -4,7 +4,7 @@
 # License: AGPL
 
 from contextlib import AbstractContextManager, nullcontext
-from typing import Union
+from typing import Optional
 
 import pytest
 
@@ -95,9 +95,9 @@ from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
 )
 def test_TemporalSlicer(
     start: float,
-    stop: Union[float, None],
-    duration: Union[float, None],
-    t_r: Union[float, None],
+    stop: Optional[float],
+    duration: Optional[float],
+    t_r: Optional[float],
     expected_dim: int,
     expect: AbstractContextManager,
 ) -> None:

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -88,8 +88,8 @@ from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
 def test_TemporalSlicer(
     start: float,
     stop: Union[float, None],
-    duration: float,
-    t_r: float,
+    duration: Union[float, None],
+    t_r: Union[float, None],
     expected_dim: int,
     expect: AbstractContextManager,
 ) -> None:
@@ -99,11 +99,11 @@ def test_TemporalSlicer(
     ----------
     start : float
         The parametrized start.
-    stop : float
+    stop : float or None
         The parametrized stop.
-    duration : float
+    duration : float or None
         The parametrized duration.
-    t_r : float
+    t_r : float or None
         The parametrized TR.
     expected_dim : int
         The parametrized expected time dimension size.

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -14,7 +14,13 @@ from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
     "start, stop, t_r, expected_dim",
     (
         [0, 168, 2.0, 84],  # t_r from doc is 2.0
+        [0, 84, 2.0, 42],  # first half
+        [0, -85, 2.0, 42],  # first half from end
+        [84, -1, 2.0, 42],  # second half
         [0, 168, None, 168],  # t_r from image is 1.0
+        [0, 84, None, 84],  # first half
+        [0, -85, None, 84],  # first half from end
+        [84, -1, None, 84],  # second half
     ),
 )
 def test_TemporalSlicer(

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -75,6 +75,14 @@ from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
             pytest.raises(RuntimeError, match="`stop` should be None"),
         ],
         [10.0, None, 30.0, None, 30, nullcontext()],
+        [
+            -1.0,
+            None,
+            None,
+            None,
+            84,
+            pytest.raises(ValueError, match="`start` cannot be negative"),
+        ],
     ),
 )
 def test_TemporalSlicer(

--- a/junifer/preprocess/tests/test_temporal_slicer.py
+++ b/junifer/preprocess/tests/test_temporal_slicer.py
@@ -83,6 +83,14 @@ from junifer.testing.datagrabbers import PartlyCloudyTestingDataGrabber
             84,
             pytest.raises(ValueError, match="`start` cannot be negative"),
         ],
+        [
+            0.0,
+            500.0,
+            None,
+            2.0,
+            42,
+            pytest.raises(IndexError, match="Calculated stop index:"),
+        ],
     ),
 )
 def test_TemporalSlicer(


### PR DESCRIPTION
### Are you requiring a new dataset or marker?

- [x] I understand this is not a marker or dataset request

### Which feature do you want to include?

To have the option to define which segment of the time series to use for extracting connectomes (define start and end point). For example, cut a 20-minute sequence after 10 minutes and extract connectomes from only the second part. 

Use-Case: We have a 24 minute sequence with a task and a control task performed sequentially and want to analyze them separately. 

### How do you imagine this integrated in junifer?

Cut the time series before calculating the connectomes.

### Do you have a sample code that implements this outside of junifer?

```shell

```

### Anything else to say?

@kaurao 