### PR TITLE
[CI]: Bump `junifer-data` to v3 for building Docker images

### DIFF
--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -45,7 +45,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Add junifer-data
-COPY --from=ghcr.io/juaml/junifer-data:v2 /opt/junifer-data /root/junifer_data/v2
+COPY --from=ghcr.io/juaml/junifer-data:v3 /opt/junifer-data /root/junifer_data/v3
 
 # Add ANTs
 COPY --from=antsx/ants:latest /opt/ants /opt/ants

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -14,7 +14,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Add junifer-data
-COPY --from=ghcr.io/juaml/junifer-data:v2 /opt/junifer-data /root/junifer_data/v2
+COPY --from=ghcr.io/juaml/junifer-data:v3 /opt/junifer-data /root/junifer_data/v3
 
 # Add ANTs
 COPY --from=antsx/ants:latest /opt/ants /opt/ants


### PR DESCRIPTION
* [x] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry for the latest changes

This PR bumps `junifer-data` to v3 for building Docker images.