### PR TITLE
[CI]: Bump `junifer-data` to v4 for building Docker images

### DIFF
--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -45,7 +45,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Add junifer-data
-COPY --from=ghcr.io/juaml/junifer-data:v3 /opt/junifer-data /root/junifer_data/v3
+COPY --from=ghcr.io/juaml/junifer-data:v4 /opt/junifer-data /root/junifer_data/v4
 
 # Add ANTs
 COPY --from=antsx/ants:latest /opt/ants /opt/ants

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -14,7 +14,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Add junifer-data
-COPY --from=ghcr.io/juaml/junifer-data:v3 /opt/junifer-data /root/junifer_data/v3
+COPY --from=ghcr.io/juaml/junifer-data:v4 /opt/junifer-data /root/junifer_data/v4
 
 # Add ANTs
 COPY --from=antsx/ants:latest /opt/ants /opt/ants

--- a/docs/changes/newsfragments/465.misc
+++ b/docs/changes/newsfragments/465.misc
@@ -1,0 +1,1 @@
+Bump ``junifer-data`` to ``v4`` for Docker images by `Synchon Mandal`_


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR bumps `junifer-data` to v4 for building Docker images.