### PR TITLE
[CI]: Disable FSL installation for junifer-ci Docker image

### DIFF
--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -60,13 +60,14 @@ ENV PATH="/opt/afni/bin:$PATH"
 # Patch gsl
 RUN ln -s /usr/lib/x86_64-linux-gnu/libgsl.so.27 /usr/lib/x86_64-linux-gnu/libgsl.so.23
 
-# Add FSL
-RUN curl https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py | \
-    python - -d /opt/fsl/ --skip_registration
-# Set env vars for FSL
-ENV FSLDIR=/opt/fsl \
-    FSLOUTPUTTYPE=NIFTI_GZ \
-    PATH="/opt/fsl/share/fsl/bin:$PATH"
+# disabled as standard github runner fails to install due to insufficient space on device
+# # Add FSL
+# RUN curl https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py | \
+#     python - -d /opt/fsl/ --skip_registration
+# # Set env vars for FSL
+# ENV FSLDIR=/opt/fsl \
+#     FSLOUTPUTTYPE=NIFTI_GZ \
+#     PATH="/opt/fsl/share/fsl/bin:$PATH"
 
 # Clean apt cache
 RUN apt-get autoremove --purge && apt-get clean

--- a/docs/changes/newsfragments/467.misc
+++ b/docs/changes/newsfragments/467.misc
@@ -1,0 +1,1 @@
+Disable FSL installation for `junifer-ci` Docker image build with `junifer-data` v4 by `Synchon Mandal`_


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR disabled FSL installation for junifer-ci build as standard GitHub Runner runs out of space.