### PR TITLE
[BUG]: Cannot register parcellation with non-continuous values

### DIFF
--- a/docs/changes/newsfragments/257.change
+++ b/docs/changes/newsfragments/257.change
@@ -1,0 +1,1 @@
+``ParcellationRegistry.get`` now returns labels as dictionary mapping from values to labels instead of a list of labels by `Synchon Mandal`_

--- a/docs/changes/newsfragments/257.enh
+++ b/docs/changes/newsfragments/257.enh
@@ -1,0 +1,1 @@
+Allow parcellation registration with non-continuous ranges as values by `Synchon Mandal`_

--- a/junifer/data/_dispatch.py
+++ b/junifer/data/_dispatch.py
@@ -143,8 +143,7 @@ def get_data(
     Returns
     -------
     tuple of numpy.ndarray, list of str; \
-    tuple of nibabel.nifti1.Nifti1Image, dict of int and str or,
-    list of str; \
+    tuple of nibabel.nifti1.Nifti1Image, dict or list of str; \
     nibabel.nifti1.Nifti1Image
 
     Raises

--- a/junifer/data/_dispatch.py
+++ b/junifer/data/_dispatch.py
@@ -120,7 +120,8 @@ def get_data(
     extra_input: Optional[dict[str, Any]] = None,
 ) -> Union[
     tuple[ArrayLike, list[str]],  # coordinates
-    tuple["Nifti1Image", list[str]],  # parcellation / maps
+    tuple["Nifti1Image", dict[int, str]],  # parcellation
+    tuple["Nifti1Image", list[str]],  # maps
     "Nifti1Image",  # mask
 ]:
     """Get tailored ``kind`` for ``target_data``.
@@ -142,7 +143,8 @@ def get_data(
     Returns
     -------
     tuple of numpy.ndarray, list of str; \
-    tuple of nibabel.nifti1.Nifti1Image, list of str; \
+    tuple of nibabel.nifti1.Nifti1Image, dict of int and str or,
+    list of str; \
     nibabel.nifti1.Nifti1Image
 
     Raises

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -1364,7 +1364,7 @@ def merge_parcellations(
         # Resample to reference (1st in the list) parcellation
         if parc.shape != ref_parc.shape:
             warn_with_log(
-                "The parcellations have different resolutions!"
+                "The parcellations have different resolutions. "
                 "Resampling all parcellations to the first one in the list."
             )
             parc = nimg.resample_to_img(

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -403,7 +403,7 @@ class ParcellationRegistry(BasePipelineDataRegistry):
         if not path_only:
             # Load image via nibabel
             parcellation_img = nib.load(parcellation_fname)
-            # Get unique values
+            # Get unique values (returns sorted result)
             parcel_values = np.unique(parcellation_img.get_fdata())
             # Check for dimension
             if len(parcel_values) - 1 != len(parcellation_labels):
@@ -411,8 +411,6 @@ class ParcellationRegistry(BasePipelineDataRegistry):
                     f"Parcellation {name} has {len(parcel_values) - 1} "
                     f"parcels but {len(parcellation_labels)} labels."
                 )
-            # Sort values
-            parcel_values.sort()
 
         return parcellation_img, parcellation_labels, parcellation_fname, space
 

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -413,12 +413,6 @@ class ParcellationRegistry(BasePipelineDataRegistry):
                 )
             # Sort values
             parcel_values.sort()
-            # Check if value range is invalid
-            if np.any(np.diff(parcel_values) != 1):
-                raise_error(
-                    f"Parcellation {name} must have all the values in the "
-                    f"range [0, {len(parcel_values)}]"
-                )
 
         return parcellation_img, parcellation_labels, parcellation_fname, space
 

--- a/junifer/data/parcellations/_parcellations.py
+++ b/junifer/data/parcellations/_parcellations.py
@@ -438,7 +438,7 @@ class ParcellationRegistry(BasePipelineDataRegistry):
         -------
         Nifti1Image
             The parcellation image.
-        dict of int and str
+        dict
             Parcellation value to label mappings.
 
         Raises

--- a/junifer/data/parcellations/tests/test_parcellations.py
+++ b/junifer/data/parcellations/tests/test_parcellations.py
@@ -1131,7 +1131,7 @@ def test_get_single() -> None:
             tailored_parcellation.get_fdata(),
             resampled_raw_parcellation.get_fdata(),
         )
-        assert tailored_labels == raw_labels
+        assert list(tailored_labels.values()) == raw_labels
 
 
 def test_get_multi_same_space() -> None:

--- a/junifer/data/parcellations/tests/test_parcellations.py
+++ b/junifer/data/parcellations/tests/test_parcellations.py
@@ -7,7 +7,6 @@
 
 from pathlib import Path
 
-import nibabel as nib
 import numpy as np
 import pytest
 from nilearn.image import new_img_like, resample_to_img
@@ -150,46 +149,6 @@ def test_parcellation_wrong_labels_values(tmp_path: Path) -> None:
         load_data(
             kind="parcellation",
             name="WrongLabels2",
-            target_space="MNI152NLin6Asym",
-        )
-
-    schaefer_data = schaefer.get_fdata().copy()
-    schaefer_data[schaefer_data == 50] = 0
-    new_schaefer_path = tmp_path / "new_schaefer.nii.gz"
-    new_schaefer_img = new_img_like(schaefer, schaefer_data)
-    nib.save(new_schaefer_img, new_schaefer_path)
-
-    register_data(
-        kind="parcellation",
-        name="WrongValues",
-        parcellation_path=new_schaefer_path,
-        parcels_labels=labels[:-1],
-        space="MNI152Lin",
-    )
-    with pytest.raises(ValueError, match=r"must have all the values in the"):
-        load_data(
-            kind="parcellation",
-            name="WrongValues",
-            target_space="MNI152NLin6Asym",
-        )
-
-    schaefer_data = schaefer.get_fdata().copy()
-    schaefer_data[schaefer_data == 50] = 200
-    new_schaefer_path = tmp_path / "new_schaefer2.nii.gz"
-    new_schaefer_img = new_img_like(schaefer, schaefer_data)
-    nib.save(new_schaefer_img, new_schaefer_path)
-
-    register_data(
-        kind="parcellation",
-        name="WrongValues2",
-        parcellation_path=new_schaefer_path,
-        parcels_labels=labels,
-        space="MNI152Lin",
-    )
-    with pytest.raises(ValueError, match=r"must have all the values in the"):
-        load_data(
-            kind="parcellation",
-            name="WrongValues2",
             target_space="MNI152NLin6Asym",
         )
 

--- a/junifer/markers/parcel_aggregation.py
+++ b/junifer/markers/parcel_aggregation.py
@@ -213,7 +213,7 @@ class ParcelAggregation(BaseMarker):
         logger.debug("Computing ROI means")
         out_values = []
         # Iterate over the parcels (existing)
-        for t_v in range(1, len(labels) + 1):
+        for t_v in labels.keys():
             t_values = agg_func(data[:, parcellation_values == t_v], axis=-1)
             out_values.append(t_values)
             # Update the labels just in case a parcel has no voxels
@@ -238,6 +238,6 @@ class ParcelAggregation(BaseMarker):
         return {
             "aggregation": {
                 "data": out_values,
-                "col_names": labels,
+                "col_names": list(labels.values()),
             },
         }

--- a/junifer/markers/tests/test_parcel_aggregation.py
+++ b/junifer/markers/tests/test_parcel_aggregation.py
@@ -408,8 +408,8 @@ def test_ParcelAggregation_3D_multiple_non_overlapping(tmp_path: Path) -> None:
         parcellation2_data = parcellation_data.copy()
         parcellation2_data[parcellation2_data <= 8] = 0
         parcellation2_data[parcellation2_data > 0] -= 8
-        labels1 = labels[:8]
-        labels2 = labels[8:]
+        labels1 = list(labels.values())[:8]
+        labels2 = list(labels.values())[8:]
 
         parcellation1_img = new_img_like(
             testing_parcellation, parcellation1_data
@@ -512,8 +512,9 @@ def test_ParcelAggregation_3D_multiple_overlapping(tmp_path: Path) -> None:
         # Make the second parcellation overlap with the first
         parcellation2_data[parcellation2_data <= 6] = 0
         parcellation2_data[parcellation2_data > 0] -= 6
-        labels1 = [f"low_{x}" for x in labels[:8]]  # Change the labels
-        labels2 = [f"high_{x}" for x in labels[6:]]  # Change the labels
+        # Change the labels
+        labels1 = [f"low_{x}" for x in list(labels.values())[:8]]
+        labels2 = [f"high_{x}" for x in list(labels.values())[6:]]
 
         parcellation1_img = new_img_like(
             testing_parcellation, parcellation1_data
@@ -621,8 +622,8 @@ def test_ParcelAggregation_3D_multiple_duplicated_labels(
         parcellation2_data = parcellation_data.copy()
         parcellation2_data[parcellation2_data <= 8] = 0
         parcellation2_data[parcellation2_data > 0] -= 8
-        labels1 = labels[:8]
-        labels2 = labels[7:-1]  # One label is duplicated
+        labels1 = list(labels.values())[:8]
+        labels2 = list(labels.values())[7:-1]  # One label is duplicated
 
         parcellation1_img = new_img_like(
             testing_parcellation, parcellation1_data


### PR DESCRIPTION
### Is there an existing issue for this?

- [X] I have searched the existing issues

### Current Behavior

I want to _register_ the Glasser parcellation: https://afni.nimh.nih.gov/pub/dist/atlases/MNI_HCP/MNI_Glasser_HCP_2021_v1.0a/

However, I get this error:

```
  File "/home/fraimondo/dev/tbox/junifer/junifer/data/parcellations.py", line 269, in load_parcellation
    raise_error(
  File "/home/fraimondo/dev/tbox/junifer/junifer/utils/logging.py", line 289, in raise_error
    raise klass(msg)
ValueError: Parcellation Glasser must have all the values in the range  [0, 361].

```

This is because so far, junifer expects that parcellation values are continuous. Some parcellations are not, like this one. The values are 1-180 for one hemisphere, and 1001-1180 for the other.

This was a restriction added when merging parcellations, as we have to "shift" the values to merge them, and this is done by adding the number of labels:

https://github.com/juaml/junifer/blob/3fd1877ddaa45c5d44d32a6f4d0ed43fff6fa6bf/junifer/data/parcellations.py#L1362-L1364



### Expected Behavior

Parcellations without continuous numbering should be able to be included in junifer (and merged)

### Steps To Reproduce

1. Get junifer latest
2. Register the Glasser parcellation
3. Try to compute any marker that uses a parcel (or even `load_parcellation`)

### Environment

```markdown
junifer:
  version: 0.0.3.dev101
python:
  version: 3.11.3
  implementation: CPython
dependencies:
  click: 8.1.3
  numpy: 1.23.5
  datalad: 0.18.2+59.gc5054cb91
  pandas: 1.5.3
  nibabel: 4.0.2
  nilearn: 0.10.0
  sqlalchemy: 1.4.48
  ruamel.yaml: 0.17.31
system:
  platform: Linux-6.1.0-12-amd64-x86_64-with-glibc2.36
environment:
  LC_CTYPE: en_US.UTF-8
  PATH: 
    /home/fraimondo/miniconda3/envs/junifer/bin:/home/fraimondo/miniconda3/condabin:/home/fraimondo/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games
```


### Relevant log output

_No response_

### Anything else?

_No response_