### PR TITLE
[MAINT]: Bump `junifer-data` version to v5

### DIFF
--- a/junifer/data/parcellations/tests/test_parcellations.py
+++ b/junifer/data/parcellations/tests/test_parcellations.py
@@ -941,6 +941,27 @@ def test_retrieve_brainnetome_incorrect_threshold() -> None:
         )
 
 
+def test_aseg() -> None:
+    """Test FreeSurfer 7.4.1 aseg parcellation."""
+    parcellations = list_data(kind="parcellation")
+    assert "aseg-7_4_1" in parcellations
+
+    # Load parcellation
+    img, label, img_path, space = load_data(
+        kind="parcellation",
+        name="aseg-7_4_1",
+        target_space="fsaverage",
+    )
+    assert img is not None
+    assert img_path.name == "aseg.nii"
+    assert space == "fsaverage"
+    assert len(label) == 43
+    assert_array_equal(
+        img.header["pixdim"][1:4],
+        3 * [1],
+    )
+
+
 def test_merge_parcellations() -> None:
     """Test merging parcellations."""
     # load some parcellations for testing

--- a/junifer/data/utils.py
+++ b/junifer/data/utils.py
@@ -24,10 +24,10 @@ __all__ = [
 
 
 # junifer-data version constant
-JUNIFER_DATA_VERSION = "4"
+JUNIFER_DATA_VERSION = "5"
 
 # junifer-data hexsha constant
-JUNIFER_DATA_HEXSHA = "d178bddf383fede04742d7020312a574de47f0ab"
+JUNIFER_DATA_HEXSHA = "62a0e3d187259a3c3ba7be638ee39cfb40df0a61"
 
 JUNIFER_DATA_PARAMS = {
     "tag": JUNIFER_DATA_VERSION,


### PR DESCRIPTION
* [x] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry for the latest changes

This PR bumps `junifer-data` to v5 and adds FreeSurfer 7.4.1 aseg parcellation to `ParcellationRegistry`.