### PR TITLE
[BUG]: Fix `SpaceWarper` to handle native space data conversion in `"auto"` mode

### DIFF
--- a/docs/changes/newsfragments/482.bugfix
+++ b/docs/changes/newsfragments/482.bugfix
@@ -1,0 +1,1 @@
+Allow :class:`.SpaceWarper` to convert data from native to template space when ``using="auto"`` by `Fede Raimondo`_ and `Synchon Mandal`_

--- a/junifer/preprocess/warping/space_warper.py
+++ b/junifer/preprocess/warping/space_warper.py
@@ -173,8 +173,19 @@ class SpaceWarper(BasePreprocessor):
                 )
         else:
             input_space = input["space"]
-            # Transform from native space
-            if input_space == "native":
+            # Check pre-requirements for space manipulation
+            if self.using == "ants" and self.reference == input_space:
+                raise_error(
+                    (
+                        f"The target data is in {self.reference} space "
+                        "and thus warping will not be performed, hence you "
+                        "should remove the SpaceWarper from the preprocess "
+                        "step."
+                    ),
+                    klass=RuntimeError,
+                )
+            # Transform from native to MNI possible conditionally
+            if input_space == "native":  # pragma: no cover
                 # Check for reference as no T1w available
                 if input.get("reference") is None:
                     raise_error(

--- a/junifer/preprocess/warping/space_warper.py
+++ b/junifer/preprocess/warping/space_warper.py
@@ -129,13 +129,16 @@ class SpaceWarper(BasePreprocessor):
         ------
         ValueError
             If ``extra_input`` is None when transforming to native space
-            i.e., using ``"T1w"`` as reference.
+            i.e., using ``"T1w"`` as reference or converting from native to
+            template space or
+            if the ``reference`` key is missing from ``input`` when converting
+            from native to template space.
         RuntimeError
             If warper could not be found in ``extra_input`` when
             ``using="auto"`` or converting from native space or
             if the data is in the correct space and does not require
             warping or
-            if FSL is used when ``reference="T1w"``.
+            if FSL or "auto" is used when ``reference!="T1w"``.
 
         """
         logger.info(f"Warping to {self.reference} space using SpaceWarper")

--- a/junifer/preprocess/warping/space_warper.py
+++ b/junifer/preprocess/warping/space_warper.py
@@ -228,12 +228,12 @@ class SpaceWarper(BasePreprocessor):
                     )
             else:
                 # Transform from MNI to MNI template space not possible
-                if self.using == "fsl":
+                if self.using in ["fsl", "auto"]:
                     raise_error(
                         (
                             f"Warping from {input_space} space to "
                             f"{self.reference} space not possible with "
-                            "FSL, use ANTs instead."
+                            f"{self.using}, use ANTs instead."
                         ),
                         klass=RuntimeError,
                     )


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry for the latest changes

This PR fixes the logic for `SpaceWarper` native space data conversion when `using="auto"`.