### PR TITLE
[BUG]: `PatternDataGrabber` issues with replacements

### DIFF
--- a/docs/changes/newsfragments/492.bugfix
+++ b/docs/changes/newsfragments/492.bugfix
@@ -1,0 +1,1 @@
+Fix pattern indexing logic for :meth:`.PatternDataGrabber.get_elements` by `Synchon Mandal`_

--- a/junifer/datagrabber/pattern.py
+++ b/junifer/datagrabber/pattern.py
@@ -449,6 +449,19 @@ class PatternDataGrabber(BaseDataGrabber, PatternValidationMixin):
 
         return out
 
+    def _count_replacements_in_pattern(self, dtype: str) -> int:
+        """Count the replacements in pattern(s)."""
+        dtype_val = self.patterns[dtype]
+        # Convert non-list dtype vals
+        if not isinstance(dtype_val, list):
+            dtype_val = [dtype_val]
+        counts = []
+        for val in dtype_val:
+            counts.append(
+                np.sum([x in val.get("pattern") for x in self.replacements])
+            )
+        return np.max(counts).astype(int)
+
     def get_elements(self) -> Elements:
         """Implement fetching list of elements in the dataset.
 
@@ -466,14 +479,8 @@ class PatternDataGrabber(BaseDataGrabber, PatternValidationMixin):
 
         # Iterate by number of replacements. At least one pattern must have
         # all of them.
-        # NOTE: will ignore list dtype vals like Warp
         replacement_in_patterns = [
-            np.sum(
-                [
-                    x in self.patterns[t_type].get("pattern")
-                    for x in self.replacements
-                ]
-            )
+            self._count_replacements_in_pattern(t_type)
             for t_type in self.types
         ]
         order = np.argsort(replacement_in_patterns)

--- a/junifer/datagrabber/pattern.py
+++ b/junifer/datagrabber/pattern.py
@@ -466,8 +466,14 @@ class PatternDataGrabber(BaseDataGrabber, PatternValidationMixin):
 
         # Iterate by number of replacements. At least one pattern must have
         # all of them.
+        # NOTE: will ignore list dtype vals like Warp
         replacement_in_patterns = [
-            np.sum([x in self.patterns[t_type] for x in self.replacements])
+            np.sum(
+                [
+                    x in self.patterns[t_type].get("pattern")
+                    for x in self.replacements
+                ]
+            )
             for t_type in self.types
         ]
         order = np.argsort(replacement_in_patterns)


### PR DESCRIPTION
### Is there an existing issue for this?

- [x] I have searched the existing issues

### Current Behavior

Datagrabber for fmriprep output. Functional has 2 sessions, anatomical only 1. 

If I run the yaml using the cli, setting `--element "sub-101129844643,ses-1"`, I get an error that an element does not exist:
```
RuntimeError: The following element selectors are invalid:
{('sub-101129844643', 'ses-1')}
```

If I run the yaml without setting `--element`,

```
ValueError: The element keys must be ['subject', 'session'], element has ['subject'].
```

### Expected Behavior

Session is part of the BOLD pattern, but not the anat/warp. I expect that it works.

### Steps To Reproduce

1. with junifer latest, use this datagrabber:

```
"""Provide a datagrabber for EUAIMS data."""

# Authors: Federico Raimondo <f.raimondo@fz-juelich.de>
# License: AGPL

from pathlib import Path
from typing import Union

from junifer.api.decorators import register_datagrabber
from junifer.datagrabber import PatternDataGrabber


@register_datagrabber
class EUAIMSDatagrabber(PatternDataGrabber):
    """EUAIMS data.

    Parameters
    ----------
    datadir : str or Path, optional
        The directory where the datalad dataset will be cloned.

    space : str
        The space in which the data is stored. 
        Can be either "native" or "MNI152NLin2009cAsym".

    """

    def __init__(
        self,
        space: str,
        datadir: Union[str, Path],
    ):
        types = ["BOLD", "T1w", "Warp"]
        replacements = ["subject", "session"]
        if space == "native":
            func_sp_desc = "space-T1w"
            anat_sp_desc = ""
        elif space == "MNI152NLin2009cAsym":
            func_sp_desc = "space-MNI152NLin2009cAsym"
            anat_sp_desc = "space-MNI152NLin2009cAsym"
        else:
            raise ValueError(f"The space ({space}) is not valid.")

        patterns = {}
        patterns["BOLD"] = {
            "pattern": (
                "{subject}/{session}/func/{subject}_{session}"
                f"_task-rest_{func_sp_desc}_desc-preproc_bold.nii.gz",
            ),
            "space": "native",
            "mask": {
                "pattern": (
                    "{subject}/{session}/func/{subject}_{session}"
                    f"_task-rest_{func_sp_desc}_desc-brain_mask.nii.gz",
                ),
                "space": "native",
            },
            "confounds": {
                "pattern": (
                    "{subject}/{session}/func/{subject}_{session}"
                    "_task-rest_desc-confounds_timeseries.tsv",
                ),
                "format": "fmriprep",
            },
            "reference": {
                "pattern": (
                    "{subject}/{session}/func/{subject}_{session}"
                    f"_task-rest_{func_sp_desc}_boldref.nii.gz"
                ),
            },
        }
        patterns["T1w"] = {
            "pattern": (
                "{subject}/anat/{subject}"
                f"{anat_sp_desc}_desc-preproc_T1w.nii.gz"
            ),
            "space": "native",
        }
        patterns["Warp"] = [
            {
                "pattern": (
                    "{subject}/anat/{subject}_from-T1w_to-MNI152NLin2009cAsym"
                    "_mode-image_xfm.h5"
                ),
                "src": "native",
                "dst": "MNI152NLin2009cAsym",
                "warper": "ants",
            },
            {
                "pattern": (
                    "{subject}/anat/{subject}_from-MNI152NLin2009cAsym_to-T1w"
                    "_mode-image_xfm.h5"
                ),
                "src": "MNI152NLin2009cAsym",
                "dst": "native",
                "warper": "ants",
            },
        ]

        if space == "native":
            patterns["BOLD"]["prewarp_space"] = "MNI152NLin2009cAsym"
        else:
            patterns["BOLD"]["prewarp_space"] = "native"

        super().__init__(
            types=types,
            patterns=patterns,
            replacements=replacements,
            datadir=datadir,
        )

```

### Environment

```markdown
junifer:
  version: 0.0.7.dev326
python:
  version: 3.12.7
  implementation: CPython
dependencies:
  click: 8.1.7
  numpy: 1.26.4
  scipy: 1.14.1
  datalad: 1.1.4
  pandas: 2.2.3
  nibabel: 5.3.2
  nilearn: 0.10.4
  sqlalchemy: 2.0.36
  ruamel.yaml: 0.18.6
  templateflow: 24.2.2
  lazy_loader: '0.4'
  looseversion: None
  junifer_data: None
  structlog: 25.5.0
system:
  platform: Linux-6.12.12+bpo-amd64-x86_64-with-glibc2.36
environment:
  PATH: 
    /data/group/appliedml/tools/fsl_6.0.4-patched2/binaries:/data/group/appliedml/tools/ants_2.5.0/binaries:/data/group/appliedml/tools/afni_24.3.06/binaries:/home/fraimondo/miniforge3/envs/junifer_dev/bin:/home/fraimondo/.local/bin:/home/fraimondo/miniforge3/condabin:/usr/local/bin:/home/fraimondo/.vscode-server/data/User/globalStorage/github.copilot-chat/debugCommand:/home/fraimondo/.vscode-server/data/User/globalStorage/github.copilot-chat/copilotCli:/home/fraimondo/.vscode-server/cli/servers/Stable-07ff9d6178ede9a1bd12ad3399074d726ebe6e43/server/bin/remote-cli:/home/fraimondo/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/home/fraimondo/.vscode-remote-htcondor:/home/fraimondo/.vscode-server/extensions/ms-python.debugpy-2025.18.0-linux-x64/bundled/scripts/noConfigScripts
```

### Relevant log output 1

```shell
[junifer_dev] cpu10 ➜ 1_compute_features git:(main) ✗ junifer run euaims_native_icbm152_mask_fcness_reho.yaml --element "sub-101129844643,ses-1" --verbose debug
2026-03-26 09:00:39 [warning  ] Requested extension 'next' is not available [datalad.support.entrypoints]
2026-03-26 09:00:46 [info     ] ===== Lib Versions =====       [junifer]
2026-03-26 09:00:46 [info     ] click: 8.1.7                   [junifer]
2026-03-26 09:00:46 [info     ] numpy: 1.26.4                  [junifer]
2026-03-26 09:00:46 [info     ] scipy: 1.14.1                  [junifer]
2026-03-26 09:00:46 [info     ] datalad: 1.1.4                 [junifer]
2026-03-26 09:00:46 [info     ] pandas: 2.2.3                  [junifer]
2026-03-26 09:00:46 [info     ] nibabel: 5.3.2                 [junifer]
2026-03-26 09:00:46 [info     ] nilearn: 0.10.4                [junifer]
2026-03-26 09:00:46 [info     ] sqlalchemy: 2.0.36             [junifer]
2026-03-26 09:00:46 [info     ] ruamel.yaml: 0.18.6            [junifer]
2026-03-26 09:00:46 [info     ] templateflow: 24.2.2           [junifer]
2026-03-26 09:00:46 [info     ] junifer_data: None             [junifer]
2026-03-26 09:00:46 [info     ] junifer: 0.0.7.dev326          [junifer]
2026-03-26 09:00:46 [info     ] ========================       [junifer]
2026-03-26 09:00:46 [info     ] Parsing yaml file: /home/fraimondo/dev/projects/brain_size/1_compute_features/euaims_native_icbm152_mask_fcness_reho.yaml [junifer]
2026-03-26 09:00:46 [debug    ] Importing file: ../external/juni-private-farm/markers/fcness.py [junifer]
2026-03-26 09:00:46 [info     ] Registering FCness in marker   [junifer]
2026-03-26 09:00:46 [debug    ] Importing file: ../lib/brainsize/euaims_datagrabber.py [junifer]
2026-03-26 09:00:46 [info     ] Registering PatternDataGrabber in datagrabber [junifer]
2026-03-26 09:00:46 [info     ] Registering EUAIMSDatagrabber in datagrabber [junifer]
2026-03-26 09:00:46 [debug    ] Parsing elements: ('sub-101129844643,ses-1',) [junifer]
2026-03-26 09:00:46 [debug    ] Parsed elements: [('sub-101129844643', 'ses-1')] [junifer]
2026-03-26 09:00:46 [debug    ] Building datagrabber/EUAIMSDatagrabber [junifer]
2026-03-26 09:00:46 [debug    ]         Class: EUAIMSDatagrabber      [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'datadir': '/data/project/autism_fc/bids/derivatives/fmriprep', 'space': 'native'} [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `pattern` found for BOLD. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `space` found for BOLD. [junifer]
2026-03-26 09:00:46 [debug    ] Optional key: `mask` found for BOLD. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `pattern` found for BOLD.mask. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `space` found for BOLD.mask. [junifer]
2026-03-26 09:00:46 [debug    ] Optional key: `confounds` found for BOLD. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `pattern` found for BOLD.confounds. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `format` found for BOLD.confounds. [junifer]
2026-03-26 09:00:46 [debug    ] Optional key: `mappings` found for BOLD.confounds [junifer]
2026-03-26 09:00:46 [debug    ] Optional key: `reference` found for BOLD. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `pattern` found for BOLD.reference. [junifer]
2026-03-26 09:00:46 [debug    ] Optional key: `prewarp_space` found for BOLD. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `pattern` found for T1w. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `space` found for T1w. [junifer]
2026-03-26 09:00:46 [debug    ] Optional key: `mask` missing for T1w. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `pattern` found for Warp.0. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `src` found for Warp.0. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `dst` found for Warp.0. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `warper` found for Warp.0. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `pattern` found for Warp.1. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `src` found for Warp.1. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `dst` found for Warp.1. [junifer]
2026-03-26 09:00:46 [debug    ] Mandatory key: `warper` found for Warp.1. [junifer]
2026-03-26 09:00:46 [debug    ] Initializing BaseDataGrabber   [junifer]
2026-03-26 09:00:46 [debug    ]         _datadir = /data/project/autism_fc/bids/derivatives/fmriprep [junifer]
2026-03-26 09:00:46 [debug    ]         types = ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:00:46 [debug    ] Initializing PatternDataGrabber [junifer]
2026-03-26 09:00:46 [debug    ]         patterns = {'BOLD': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_space-T1w_desc-preproc_bold.nii.gz', 'space': 'native', 'mask': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_space-T1w_desc-brain_mask.nii.gz', 'space': 'native'}, 'confounds': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_desc-confounds_timeseries.tsv', 'format': 'fmriprep'}, 'reference': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_space-T1w_boldref.nii.gz'}, 'prewarp_space': 'MNI152NLin2009cAsym'}, 'T1w': {'pattern': '{subject}/anat/{subject}_desc-preproc_T1w.nii.gz', 'space': 'native'}, 'Warp': [{'pattern': '{subject}/anat/{subject}_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5', 'src': 'native', 'dst': 'MNI152NLin2009cAsym', 'warper': 'ants'}, {'pattern': '{subject}/anat/{subject}_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5', 'src': 'MNI152NLin2009cAsym', 'dst': 'native', 'warper': 'ants'}]} [junifer]
2026-03-26 09:00:46 [debug    ]         replacements = ['subject', 'session'] [junifer]
2026-03-26 09:00:46 [debug    ]         confounds_format = None       [junifer]
2026-03-26 09:00:46 [debug    ] Building marker/ReHoSpheres    [junifer]
2026-03-26 09:00:46 [info     ] Registering SphereAggregation in marker [junifer]
2026-03-26 09:00:46 [info     ] Registering ReHoSpheres in marker [junifer]
2026-03-26 09:00:46 [debug    ]         Class: ReHoSpheres            [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'name': 'ReHo-Power2011-5mm_mni', 'coords': 'Power2011', 'radius': 5, 'using': 'afni', 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:00:46 [debug    ] Building marker/ReHoSpheres    [junifer]
2026-03-26 09:00:46 [debug    ]         Class: ReHoSpheres            [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'name': 'ReHo-Power2011-10mm_mni', 'coords': 'Power2011', 'radius': 10, 'using': 'afni', 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:00:46 [debug    ] Building marker/FCness         [junifer]
2026-03-26 09:00:46 [debug    ]         Class: FCness                 [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'name': 'FCness-Power2011-5mm_mni', 'coords': 'Power2011', 'radius': 5, 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:00:46 [debug    ] Building marker/FCness         [junifer]
2026-03-26 09:00:46 [debug    ]         Class: FCness                 [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'name': 'FCness-Power2011-10mm_mni', 'coords': 'Power2011', 'radius': 10, 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:00:46 [debug    ] Building marker/SphereAggregation [junifer]
2026-03-26 09:00:46 [debug    ]         Class: SphereAggregation      [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'name': 'SphereSize-FCness-Power2011-5mm_mni', 'coords': 'Power', 'method': 'count', 'on': 'BOLD', 'allow_overlap': True, 'time_method': 'select', 'time_method_params': {'pick': [0]}, 'radius': 5, 'masks': ['inherit']} [junifer]
2026-03-26 09:00:46 [debug    ] Building marker/SphereAggregation [junifer]
2026-03-26 09:00:46 [debug    ]         Class: SphereAggregation      [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'name': 'SphereSize-FCness-Power2011-10mm_mni', 'coords': 'Power', 'method': 'count', 'on': 'BOLD', 'allow_overlap': True, 'time_method': 'select', 'time_method_params': {'pick': [0]}, 'radius': 10, 'masks': ['inherit']} [junifer]
2026-03-26 09:00:46 [debug    ] Building storage/HDF5FeatureStorage [junifer]
2026-03-26 09:00:46 [info     ] Registering HDF5FeatureStorage in storage [junifer]
2026-03-26 09:00:46 [debug    ]         Class: HDF5FeatureStorage     [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'uri': '/data/project/SPP2041/results/fraimondo/brain_size_project/storage/euaims_mni_icbm152_mask_fcness_reho/euaims_mni_icbm152_mask_fcness_reho.hdf5', 'single_output': False} [junifer]
2026-03-26 09:00:46 [debug    ] Building preprocessing/fMRIPrepConfoundRemover [junifer]
2026-03-26 09:00:46 [info     ] Registering fMRIPrepConfoundRemover in preprocessing [junifer]
2026-03-26 09:00:46 [debug    ]         Class: fMRIPrepConfoundRemover [junifer]
2026-03-26 09:00:46 [debug    ]         Init params: {'detrend': True, 'standardize': True, 'strategy': {'wm_csf': 'full', 'global_signal': 'full'}, 'low_pass': 0.08, 'high_pass': 0.01, 'masks': [{'compute_brain_mask': {'threshold': 0.2, 'mask_type': 'gm', 'template_space': 'MNI152NLin2009cAsym'}}]} [junifer]
2026-03-26 09:00:46 [info     ] Validating Marker Collection   [junifer]
2026-03-26 09:00:46 [info     ] DataGrabber output type: ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:00:46 [info     ] Validating Data Reader:        [junifer]
2026-03-26 09:00:46 [info     ] Data Reader output type: ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:00:46 [info     ] Validating Preprocessor: fMRIPrepConfoundRemover [junifer]
2026-03-26 09:00:46 [info     ] Preprocessor input type: ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:00:46 [info     ] Preprocessor output type: ['T1w', 'BOLD', 'Warp'] [junifer]
2026-03-26 09:00:46 [info     ] Validating Marker: ReHo-Power2011-5mm_mni [junifer]
2026-03-26 09:00:47 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:00:47 [info     ] Validating storage for ReHo-Power2011-5mm_mni [junifer]
2026-03-26 09:00:47 [info     ] Validating Marker: ReHo-Power2011-10mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:00:48 [info     ] Validating storage for ReHo-Power2011-10mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Validating Marker: FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:00:48 [info     ] Validating storage for FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Validating Marker: FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:00:48 [info     ] Validating storage for FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Validating Marker: SphereSize-FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Marker output type: ['timeseries'] [junifer]
2026-03-26 09:00:48 [info     ] Validating storage for SphereSize-FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Validating Marker: SphereSize-FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:00:48 [info     ] Marker output type: ['timeseries'] [junifer]
2026-03-26 09:00:48 [info     ] Validating storage for SphereSize-FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:00:49 [error    ] The following element selectors are invalid:
{('sub-101129844643', 'ses-1')} [junifer]
Traceback (most recent call last):
  File "/home/fraimondo/miniforge3/envs/junifer_dev/bin/junifer", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/dev/tbox/junifer/junifer/cli/cli.py", line 182, in run
    cli_func.run(
  File "/home/fraimondo/dev/tbox/junifer/junifer/api/functions.py", line 227, in run
    raise_error(
  File "/home/fraimondo/dev/tbox/junifer/junifer/utils/logging.py", line 267, in raise_error
    raise klass(msg)
RuntimeError: The following element selectors are invalid:
{('sub-101129844643', 'ses-1')}
```


### Relevant log output 2

```shell
[junifer_dev] cpu10 ➜ 1_compute_features git:(main) ✗ junifer run euaims_native_icbm152_mask_fcness_reho.yaml --verbose debug
2026-03-26 09:01:47 [warning  ] Requested extension 'next' is not available [datalad.support.entrypoints]
2026-03-26 09:01:54 [info     ] ===== Lib Versions =====       [junifer]
2026-03-26 09:01:54 [info     ] click: 8.1.7                   [junifer]
2026-03-26 09:01:54 [info     ] numpy: 1.26.4                  [junifer]
2026-03-26 09:01:54 [info     ] scipy: 1.14.1                  [junifer]
2026-03-26 09:01:54 [info     ] datalad: 1.1.4                 [junifer]
2026-03-26 09:01:54 [info     ] pandas: 2.2.3                  [junifer]
2026-03-26 09:01:54 [info     ] nibabel: 5.3.2                 [junifer]
2026-03-26 09:01:54 [info     ] nilearn: 0.10.4                [junifer]
2026-03-26 09:01:54 [info     ] sqlalchemy: 2.0.36             [junifer]
2026-03-26 09:01:54 [info     ] ruamel.yaml: 0.18.6            [junifer]
2026-03-26 09:01:54 [info     ] templateflow: 24.2.2           [junifer]
2026-03-26 09:01:54 [info     ] junifer_data: None             [junifer]
2026-03-26 09:01:54 [info     ] junifer: 0.0.7.dev326          [junifer]
2026-03-26 09:01:54 [info     ] ========================       [junifer]
2026-03-26 09:01:54 [info     ] Parsing yaml file: /home/fraimondo/dev/projects/brain_size/1_compute_features/euaims_native_icbm152_mask_fcness_reho.yaml [junifer]
2026-03-26 09:01:54 [debug    ] Importing file: ../external/juni-private-farm/markers/fcness.py [junifer]
2026-03-26 09:01:54 [info     ] Registering FCness in marker   [junifer]
2026-03-26 09:01:54 [debug    ] Importing file: ../lib/brainsize/euaims_datagrabber.py [junifer]
2026-03-26 09:01:54 [info     ] Registering PatternDataGrabber in datagrabber [junifer]
2026-03-26 09:01:54 [info     ] Registering EUAIMSDatagrabber in datagrabber [junifer]
2026-03-26 09:01:54 [debug    ] Parsing elements: ()           [junifer]
2026-03-26 09:01:54 [debug    ] Building datagrabber/EUAIMSDatagrabber [junifer]
2026-03-26 09:01:54 [debug    ]         Class: EUAIMSDatagrabber      [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'datadir': '/data/project/autism_fc/bids/derivatives/fmriprep', 'space': 'native'} [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `pattern` found for BOLD. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `space` found for BOLD. [junifer]
2026-03-26 09:01:54 [debug    ] Optional key: `mask` found for BOLD. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `pattern` found for BOLD.mask. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `space` found for BOLD.mask. [junifer]
2026-03-26 09:01:54 [debug    ] Optional key: `confounds` found for BOLD. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `pattern` found for BOLD.confounds. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `format` found for BOLD.confounds. [junifer]
2026-03-26 09:01:54 [debug    ] Optional key: `mappings` found for BOLD.confounds [junifer]
2026-03-26 09:01:54 [debug    ] Optional key: `reference` found for BOLD. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `pattern` found for BOLD.reference. [junifer]
2026-03-26 09:01:54 [debug    ] Optional key: `prewarp_space` found for BOLD. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `pattern` found for T1w. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `space` found for T1w. [junifer]
2026-03-26 09:01:54 [debug    ] Optional key: `mask` missing for T1w. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `pattern` found for Warp.0. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `src` found for Warp.0. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `dst` found for Warp.0. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `warper` found for Warp.0. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `pattern` found for Warp.1. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `src` found for Warp.1. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `dst` found for Warp.1. [junifer]
2026-03-26 09:01:54 [debug    ] Mandatory key: `warper` found for Warp.1. [junifer]
2026-03-26 09:01:54 [debug    ] Initializing BaseDataGrabber   [junifer]
2026-03-26 09:01:54 [debug    ]         _datadir = /data/project/autism_fc/bids/derivatives/fmriprep [junifer]
2026-03-26 09:01:54 [debug    ]         types = ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:01:54 [debug    ] Initializing PatternDataGrabber [junifer]
2026-03-26 09:01:54 [debug    ]         patterns = {'BOLD': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_space-T1w_desc-preproc_bold.nii.gz', 'space': 'native', 'mask': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_space-T1w_desc-brain_mask.nii.gz', 'space': 'native'}, 'confounds': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_desc-confounds_timeseries.tsv', 'format': 'fmriprep'}, 'reference': {'pattern': '{subject}/{session}/func/{subject}_{session}_task-rest_space-T1w_boldref.nii.gz'}, 'prewarp_space': 'MNI152NLin2009cAsym'}, 'T1w': {'pattern': '{subject}/anat/{subject}_desc-preproc_T1w.nii.gz', 'space': 'native'}, 'Warp': [{'pattern': '{subject}/anat/{subject}_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5', 'src': 'native', 'dst': 'MNI152NLin2009cAsym', 'warper': 'ants'}, {'pattern': '{subject}/anat/{subject}_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5', 'src': 'MNI152NLin2009cAsym', 'dst': 'native', 'warper': 'ants'}]} [junifer]
2026-03-26 09:01:54 [debug    ]         replacements = ['subject', 'session'] [junifer]
2026-03-26 09:01:54 [debug    ]         confounds_format = None       [junifer]
2026-03-26 09:01:54 [debug    ] Building marker/ReHoSpheres    [junifer]
2026-03-26 09:01:54 [info     ] Registering SphereAggregation in marker [junifer]
2026-03-26 09:01:54 [info     ] Registering ReHoSpheres in marker [junifer]
2026-03-26 09:01:54 [debug    ]         Class: ReHoSpheres            [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'name': 'ReHo-Power2011-5mm_mni', 'coords': 'Power2011', 'radius': 5, 'using': 'afni', 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:01:54 [debug    ] Building marker/ReHoSpheres    [junifer]
2026-03-26 09:01:54 [debug    ]         Class: ReHoSpheres            [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'name': 'ReHo-Power2011-10mm_mni', 'coords': 'Power2011', 'radius': 10, 'using': 'afni', 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:01:54 [debug    ] Building marker/FCness         [junifer]
2026-03-26 09:01:54 [debug    ]         Class: FCness                 [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'name': 'FCness-Power2011-5mm_mni', 'coords': 'Power2011', 'radius': 5, 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:01:54 [debug    ] Building marker/FCness         [junifer]
2026-03-26 09:01:54 [debug    ]         Class: FCness                 [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'name': 'FCness-Power2011-10mm_mni', 'coords': 'Power2011', 'radius': 10, 'allow_overlap': True, 'masks': ['inherit']} [junifer]
2026-03-26 09:01:54 [debug    ] Building marker/SphereAggregation [junifer]
2026-03-26 09:01:54 [debug    ]         Class: SphereAggregation      [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'name': 'SphereSize-FCness-Power2011-5mm_mni', 'coords': 'Power', 'method': 'count', 'on': 'BOLD', 'allow_overlap': True, 'time_method': 'select', 'time_method_params': {'pick': [0]}, 'radius': 5, 'masks': ['inherit']} [junifer]
2026-03-26 09:01:54 [debug    ] Building marker/SphereAggregation [junifer]
2026-03-26 09:01:54 [debug    ]         Class: SphereAggregation      [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'name': 'SphereSize-FCness-Power2011-10mm_mni', 'coords': 'Power', 'method': 'count', 'on': 'BOLD', 'allow_overlap': True, 'time_method': 'select', 'time_method_params': {'pick': [0]}, 'radius': 10, 'masks': ['inherit']} [junifer]
2026-03-26 09:01:54 [debug    ] Building storage/HDF5FeatureStorage [junifer]
2026-03-26 09:01:54 [info     ] Registering HDF5FeatureStorage in storage [junifer]
2026-03-26 09:01:54 [debug    ]         Class: HDF5FeatureStorage     [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'uri': '/data/project/SPP2041/results/fraimondo/brain_size_project/storage/euaims_mni_icbm152_mask_fcness_reho/euaims_mni_icbm152_mask_fcness_reho.hdf5', 'single_output': False} [junifer]
2026-03-26 09:01:54 [debug    ] Building preprocessing/fMRIPrepConfoundRemover [junifer]
2026-03-26 09:01:54 [info     ] Registering fMRIPrepConfoundRemover in preprocessing [junifer]
2026-03-26 09:01:54 [debug    ]         Class: fMRIPrepConfoundRemover [junifer]
2026-03-26 09:01:54 [debug    ]         Init params: {'detrend': True, 'standardize': True, 'strategy': {'wm_csf': 'full', 'global_signal': 'full'}, 'low_pass': 0.08, 'high_pass': 0.01, 'masks': [{'compute_brain_mask': {'threshold': 0.2, 'mask_type': 'gm', 'template_space': 'MNI152NLin2009cAsym'}}]} [junifer]
2026-03-26 09:01:54 [info     ] Validating Marker Collection   [junifer]
2026-03-26 09:01:54 [info     ] DataGrabber output type: ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:01:54 [info     ] Validating Data Reader:        [junifer]
2026-03-26 09:01:54 [info     ] Data Reader output type: ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:01:54 [info     ] Validating Preprocessor: fMRIPrepConfoundRemover [junifer]
2026-03-26 09:01:54 [info     ] Preprocessor input type: ['BOLD', 'T1w', 'Warp'] [junifer]
2026-03-26 09:01:54 [info     ] Preprocessor output type: ['T1w', 'BOLD', 'Warp'] [junifer]
2026-03-26 09:01:54 [info     ] Validating Marker: ReHo-Power2011-5mm_mni [junifer]
2026-03-26 09:01:55 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:01:55 [info     ] Validating storage for ReHo-Power2011-5mm_mni [junifer]
2026-03-26 09:01:55 [info     ] Validating Marker: ReHo-Power2011-10mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:01:56 [info     ] Validating storage for ReHo-Power2011-10mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Validating Marker: FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:01:56 [info     ] Validating storage for FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Validating Marker: FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Marker output type: ['vector'] [junifer]
2026-03-26 09:01:56 [info     ] Validating storage for FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Validating Marker: SphereSize-FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Marker output type: ['timeseries'] [junifer]
2026-03-26 09:01:56 [info     ] Validating storage for SphereSize-FCness-Power2011-5mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Validating Marker: SphereSize-FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:01:56 [info     ] Marker output type: ['timeseries'] [junifer]
2026-03-26 09:01:56 [info     ] Validating storage for SphereSize-FCness-Power2011-10mm_mni [junifer]
2026-03-26 09:01:57 [info     ] Getting element ('sub-899801407334',) [junifer]
2026-03-26 09:01:57 [debug    ] Named element: {'subject': 'sub-899801407334'} [junifer]
2026-03-26 09:01:57 [info     ] Resolving path from pattern for BOLD [junifer]
2026-03-26 09:01:57 [error    ] The element keys must be ['subject', 'session'], element has ['subject']. [junifer]
Traceback (most recent call last):
  File "/home/fraimondo/miniforge3/envs/junifer_dev/bin/junifer", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/miniforge3/envs/junifer_dev/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/dev/tbox/junifer/junifer/cli/cli.py", line 182, in run
    cli_func.run(
  File "/home/fraimondo/dev/tbox/junifer/junifer/api/functions.py", line 236, in run
    mc.fit(datagrabber_object[t_element])
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/fraimondo/dev/tbox/junifer/junifer/datagrabber/base.py", line 96, in __getitem__
    out = self.get_item(**named_element)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/dev/tbox/junifer/junifer/datagrabber/pattern.py", line 419, in get_item
    base_dtype_pattern_path = self._get_path_from_patterns(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/dev/tbox/junifer/junifer/datagrabber/pattern.py", line 324, in _get_path_from_patterns
    resolved_pattern = self._replace_patterns_glob(element, pattern)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fraimondo/dev/tbox/junifer/junifer/datagrabber/pattern.py", line 286, in _replace_patterns_glob
    raise_error(
  File "/home/fraimondo/dev/tbox/junifer/junifer/utils/logging.py", line 267, in raise_error
    raise klass(msg)
ValueError: The element keys must be ['subject', 'session'], element has ['subject'].
```

### Anything else?

_No response_